### PR TITLE
Fix MCP tool Configure error with @mcp:Tool description annotation

### DIFF
--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/McpFunctionBuilder.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/McpFunctionBuilder.java
@@ -65,7 +65,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
     private static final String TOOL_DESCRIPTION_PROPERTY = "toolDescription";
 
     // mcp:Tool annotation handling
-    private static final String TOOL_ANNOTATION_SIMPLE_NAME = "Tool";
+    private static final String TOOL_ANNOTATION_REF = MCP + ":Tool";
     private static final String TOOL_ANNOTATION_PROPERTY = "annotTool";
     private static final String DESCRIPTION_FIELD_NAME = "description";
 
@@ -330,18 +330,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
 
         // Set tool description in function properties
         if (toolDescription != null && !toolDescription.isEmpty()) {
-            Value toolDescValue =
-                    new Value.ValueBuilder()
-                            .metadata("Tool Description", "Description of what this MCP tool does")
-                            .setPlaceholder("Describe what this tool does...")
-                            .types(List.of(PropertyType.types(Value.FieldType.TEXT, "string")))
-                            .value(toolDescription)
-                            .enabled(true)
-                            .editable(true)
-                            .optional(true)
-                            .setAdvanced(false)
-                            .build();
-            function.getProperties().put(TOOL_DESCRIPTION_PROPERTY, toolDescValue);
+            function.getProperties().put(TOOL_DESCRIPTION_PROPERTY, buildToolDescriptionValue(toolDescription));
         }
 
         // Set parameter documentation
@@ -452,15 +441,14 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
 
     /**
      * Hoists a string-literal {@code description} from the {@code @mcp:Tool} annotation into the
-     * {@code toolDescription} property and strips it from the annotation, preserving any other fields. Also seeds
-     * {@code annotTool.types} so the frontend form does not crash on the property the parent left without types.
+     * {@code toolDescription} property and strips it from the annotation, preserving any other fields.
      */
     private static void processToolAnnotation(Function function, MetadataNode metadata) {
         Value annotProperty = function.getProperties().get(TOOL_ANNOTATION_PROPERTY);
         if (annotProperty == null) {
             return;
         }
-        // Seed types: the form factory mounts every property and throws on null/empty types. Stays hidden via enabled=false.
+        // The parent leaves annotation-attachment properties without a types list; populate it so it is well-formed.
         if (annotProperty.getTypes() == null || annotProperty.getTypes().isEmpty()) {
             annotProperty.setTypes(new ArrayList<>(List.of(PropertyType.types(Value.FieldType.TEXT, "string"))));
         }
@@ -509,14 +497,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
 
     private static AnnotationNode findToolAnnotation(MetadataNode metadata) {
         for (AnnotationNode annotation : metadata.annotations()) {
-            String ref = annotation.annotReference().toString().trim();
-            int colonIdx = ref.indexOf(':');
-            if (colonIdx < 0) {
-                continue;
-            }
-            String module = ref.substring(0, colonIdx).trim();
-            String simple = ref.substring(colonIdx + 1).trim();
-            if (MCP.equals(module) && TOOL_ANNOTATION_SIMPLE_NAME.equals(simple)) {
+            if (TOOL_ANNOTATION_REF.equals(annotation.annotReference().toString().trim())) {
                 return annotation;
             }
         }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/McpFunctionBuilder.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/McpFunctionBuilder.java
@@ -537,8 +537,8 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
     }
 
     /**
-     * Returns the unescaped contents of a double-quoted string literal expression, or {@code null} if {@code expr}
-     * is not such a literal. Used to decide whether the description can be safely hoisted into the doc-comment form.
+     * Returns the contents of a double-quoted string literal expression, or {@code null} if {@code expr} is not
+     * such a literal. Used to decide whether the description can be safely hoisted into the doc-comment form.
      */
     private static String extractStringLiteral(ExpressionNode expr) {
         if (!(expr instanceof BasicLiteralNode literal)) {
@@ -548,31 +548,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
         if (text.length() < 2 || !text.startsWith("\"") || !text.endsWith("\"")) {
             return null;
         }
-        return unescapeBalString(text.substring(1, text.length() - 1));
-    }
-
-    private static String unescapeBalString(String s) {
-        StringBuilder out = new StringBuilder(s.length());
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            if (c == '\\' && i + 1 < s.length()) {
-                char next = s.charAt(++i);
-                switch (next) {
-                    case 'n' -> out.append('\n');
-                    case 't' -> out.append('\t');
-                    case 'r' -> out.append('\r');
-                    case '\\' -> out.append('\\');
-                    case '"' -> out.append('"');
-                    default -> {
-                        out.append('\\');
-                        out.append(next);
-                    }
-                }
-            } else {
-                out.append(c);
-            }
-        }
-        return out.toString();
+        return text.substring(1, text.length() - 1);
     }
 
     private static Value buildToolDescriptionValue(String description) {

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/McpFunctionBuilder.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/McpFunctionBuilder.java
@@ -400,11 +400,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
         return result;
     }
 
-    /**
-     * Returns the doc-comment {@link TextEdit} emitted by {@code addFunctionDocTextEdits}, identified by its
-     * leading {@code #}. Returns empty when the original source had no doc string AND no parameter docs were
-     * generated, in which case the parent emits no doc edit at all.
-     */
+    // The doc-comment edit (leading '#' or empty); absent when the source had no doc string and no param docs.
     private static Optional<TextEdit> findDocCommentEdit(Map<String, List<TextEdit>> textEdits) {
         return textEdits.values().stream()
                 .flatMap(List::stream)
@@ -419,10 +415,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
                 .findFirst();
     }
 
-    /**
-     * Inserts a fresh doc-comment block above the function's metadata, matching the anchor used by
-     * {@code addFunctionDocTextEdits} when metadata exists but no doc string is present.
-     */
+    // Inserts a fresh doc-comment block at the metadata anchor when the source had no doc string.
     private static void insertNewDocEdit(Map<String, List<TextEdit>> result, UpdateModelContext context,
                                          String toolDescription, String returnType) {
         Optional<MetadataNode> metadata = context.functionNode().metadata();
@@ -441,8 +434,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
     @Override
     public Function getModelFromSource(ModelFromSourceContext context) {
         Function function = super.getModelFromSource(context);
-        // MCP tools are remote functions; without this, FunctionBuilderRouter.updateFunction would treat them
-        // as OBJECT_METHOD and dispatch to DefaultFunctionBuilder, bypassing MCP-specific save handling.
+        // Mark as REMOTE so updateFunction routes saves here instead of DefaultFunctionBuilder.
         function.setKind(KIND_REMOTE);
 
         FunctionDefinitionNode functionNode = (FunctionDefinitionNode) context.node();
@@ -459,20 +451,16 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
     }
 
     /**
-     * Handles the {@code @mcp:Tool} annotation when present. If its {@code description} field is a string literal,
-     * its value is hoisted into the {@code toolDescription} property (so the form renders it as a doc-style field)
-     * and stripped from the annotation source held on {@code annotTool}; any other fields (e.g. {@code schema}) are
-     * preserved verbatim. The {@code annotTool} entry's {@code types} list is always patched to a non-null value
-     * so the frontend form does not crash on a malformed property.
+     * Hoists a string-literal {@code description} from the {@code @mcp:Tool} annotation into the
+     * {@code toolDescription} property and strips it from the annotation, preserving any other fields. Also seeds
+     * {@code annotTool.types} so the frontend form does not crash on the property the parent left without types.
      */
     private static void processToolAnnotation(Function function, MetadataNode metadata) {
         Value annotProperty = function.getProperties().get(TOOL_ANNOTATION_PROPERTY);
         if (annotProperty == null) {
             return;
         }
-        // Parent's updateAnnotationAttachmentProperty doesn't set types. The frontend form factory mounts every
-        // property regardless of enabled flag and throws when types is null/empty, so seed a placeholder type. The
-        // editor itself stays hidden because we leave the parent's enabled=false default in place.
+        // Seed types: the form factory mounts every property and throws on null/empty types. Stays hidden via enabled=false.
         if (annotProperty.getTypes() == null || annotProperty.getTypes().isEmpty()) {
             annotProperty.setTypes(new ArrayList<>(List.of(PropertyType.types(Value.FieldType.TEXT, "string"))));
         }
@@ -484,8 +472,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
 
         MappingConstructorExpressionNode mapping = toolAnnotation.annotValue().get();
         SpecificFieldNode descriptionField = null;
-        // Source-code snippets so spread fields (...x), computed-name fields, etc. are preserved verbatim
-        // alongside ordinary SpecificFieldNode entries.
+        // Keep source snippets so non-description fields (schema, spread fields) round-trip verbatim.
         List<String> keptFieldSources = new ArrayList<>();
         for (MappingFieldNode field : mapping.fields()) {
             if (field instanceof SpecificFieldNode specific
@@ -536,10 +523,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
         return null;
     }
 
-    /**
-     * Returns the contents of a double-quoted string literal expression, or {@code null} if {@code expr} is not
-     * such a literal. Used to decide whether the description can be safely hoisted into the doc-comment form.
-     */
+    // Contents of a double-quoted string literal, or null if expr is not one.
     private static String extractStringLiteral(ExpressionNode expr) {
         if (!(expr instanceof BasicLiteralNode literal)) {
             return null;
@@ -564,12 +548,7 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
                 .build();
     }
 
-    /**
-     * Reconstructs a mapping-constructor source string from pre-captured field source snippets. Snippets come
-     * straight from {@link MappingFieldNode#toSourceCode()} so nested values like a {@code map<json>} schema, as
-     * well as spread fields, are preserved byte-for-byte. The result is the annotation value that
-     * {@code addFunctionAnnotationTextEdits} will splice back into source.
-     */
+    // Rebuilds the annotation mapping body from the kept field source snippets.
     private static String buildAnnotationValue(List<String> keptFieldSources) {
         StringBuilder sb = new StringBuilder(" {");
         boolean first = true;

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/McpFunctionBuilder.java
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/builder/function/McpFunctionBuilder.java
@@ -20,8 +20,14 @@ package io.ballerina.servicemodelgenerator.extension.builder.function;
 
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
+import io.ballerina.compiler.syntax.tree.AnnotationNode;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingFieldNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.servicemodelgenerator.extension.model.Function;
 import io.ballerina.servicemodelgenerator.extension.model.Parameter;
 import io.ballerina.servicemodelgenerator.extension.model.PropertyType;
@@ -37,6 +43,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +51,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.ballerina.servicemodelgenerator.extension.util.Constants.KIND_REMOTE;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.MCP;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.NEW_LINE;
 import static io.ballerina.servicemodelgenerator.extension.util.Constants.REMOTE;
@@ -56,11 +64,17 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
     private static final String MCP_FUNCTION_MODEL_LOCATION = "functions/mcp_tool.json";
     private static final String TOOL_DESCRIPTION_PROPERTY = "toolDescription";
 
+    // mcp:Tool annotation handling
+    private static final String TOOL_ANNOTATION_SIMPLE_NAME = "Tool";
+    private static final String TOOL_ANNOTATION_PROPERTY = "annotTool";
+    private static final String DESCRIPTION_FIELD_NAME = "description";
+
     // Documentation format constants
     private static final String DOC_COMMENT_PREFIX = "# ";
     private static final String DOC_COMMENT_SEPARATOR = "    #";
     private static final String DOC_RETURN_PREFIX = "    # + return - ";
     private static final String PARAM_DOC_PATTERN_STR = "# + ";
+    private static final String DOC_INDENT = "    ";
 
     // Regex pattern for parameter documentation
     private static final Pattern PARAM_PATTERN = Pattern.compile("^\\s*#\\s*\\+\\s+(\\w+)\\s*-\\s*(.*)$");
@@ -280,18 +294,6 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
     }
 
     /**
-     * Finds the first TextEdit in the result map.
-     *
-     * @param textEdits Map of text edits
-     * @return Optional containing the first TextEdit
-     */
-    private static Optional<TextEdit> findFirstEdit(Map<String, List<TextEdit>> textEdits) {
-        return textEdits.values().stream()
-                .flatMap(List::stream)
-                .findFirst();
-    }
-
-    /**
      * Parses the markdown documentation string and populates the function model.
      *
      * @param function      The function model to populate
@@ -380,40 +382,69 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
         String toolDescription = extractToolDescription(context.function());
         String returnType = getReturnTypeDescription(context.function());
 
-        Optional<TextEdit> firstEdit = findFirstEdit(result);
-        if (firstEdit.isEmpty()) {
-            return result;
-        }
-
-        TextEdit edit = firstEdit.get();
-        String originalText = edit.getNewText();
-
-        if (originalText == null) {
-            return result;
-        }
-
-        String stripped = originalText.stripLeading();
-
-        if (stripped.startsWith("#")) {
-            // Has documentation - keep it and add tool desc + return type
-            updateDocumentationEdit(edit, originalText, toolDescription, returnType);
-        } else if (stripped.isEmpty()) {
-            // Empty string - add only tool desc and return type
-            String newDoc = buildCompleteDocumentation(toolDescription, "", returnType);
-            edit.setNewText(newDoc);
-        } else {
-            // Non-documentation content - skip update
-            // This could be other code content that shouldn't have documentation prepended
+        Optional<TextEdit> docEdit = findDocCommentEdit(result);
+        if (docEdit.isPresent()) {
+            TextEdit edit = docEdit.get();
+            String originalText = edit.getNewText();
+            String stripped = originalText == null ? "" : originalText.stripLeading();
+            if (stripped.startsWith("#")) {
+                updateDocumentationEdit(edit, originalText, toolDescription, returnType);
+            } else if (stripped.isEmpty()) {
+                edit.setNewText(buildCompleteDocumentation(toolDescription, "", returnType));
+            }
+        } else if (toolDescription != null && !toolDescription.trim().isEmpty()) {
+            // Annotation-form source had no doc comment; insert one at the metadata anchor.
+            insertNewDocEdit(result, context, toolDescription, returnType);
         }
 
         return result;
     }
 
+    /**
+     * Returns the doc-comment {@link TextEdit} emitted by {@code addFunctionDocTextEdits}, identified by its
+     * leading {@code #}. Returns empty when the original source had no doc string AND no parameter docs were
+     * generated, in which case the parent emits no doc edit at all.
+     */
+    private static Optional<TextEdit> findDocCommentEdit(Map<String, List<TextEdit>> textEdits) {
+        return textEdits.values().stream()
+                .flatMap(List::stream)
+                .filter(edit -> {
+                    String text = edit.getNewText();
+                    if (text == null) {
+                        return false;
+                    }
+                    String stripped = text.stripLeading();
+                    return stripped.startsWith("#") || stripped.isEmpty();
+                })
+                .findFirst();
+    }
+
+    /**
+     * Inserts a fresh doc-comment block above the function's metadata, matching the anchor used by
+     * {@code addFunctionDocTextEdits} when metadata exists but no doc string is present.
+     */
+    private static void insertNewDocEdit(Map<String, List<TextEdit>> result, UpdateModelContext context,
+                                         String toolDescription, String returnType) {
+        Optional<MetadataNode> metadata = context.functionNode().metadata();
+        if (metadata.isEmpty()) {
+            return;
+        }
+        String filePath = result.keySet().stream().findFirst().orElse(null);
+        if (filePath == null) {
+            return;
+        }
+        String docBlock = DOC_INDENT + buildCompleteDocumentation(toolDescription, "", returnType);
+        TextEdit insertEdit = new TextEdit(Utils.toRange(metadata.get().lineRange().startLine()), docBlock);
+        result.get(filePath).addFirst(insertEdit);
+    }
+
     @Override
     public Function getModelFromSource(ModelFromSourceContext context) {
         Function function = super.getModelFromSource(context);
+        // MCP tools are remote functions; without this, FunctionBuilderRouter.updateFunction would treat them
+        // as OBJECT_METHOD and dispatch to DefaultFunctionBuilder, bypassing MCP-specific save handling.
+        function.setKind(KIND_REMOTE);
 
-        // Extract and parse documentation from the function node
         FunctionDefinitionNode functionNode = (FunctionDefinitionNode) context.node();
         if (functionNode.metadata().isPresent()) {
             MetadataNode metadata = functionNode.metadata().get();
@@ -421,9 +452,160 @@ public class McpFunctionBuilder extends AbstractFunctionBuilder {
                 String documentation = metadata.documentationString().get().toString();
                 parseDocumentation(function, documentation);
             }
+            processToolAnnotation(function, metadata);
         }
 
         return function;
+    }
+
+    /**
+     * Handles the {@code @mcp:Tool} annotation when present. If its {@code description} field is a string literal,
+     * its value is hoisted into the {@code toolDescription} property (so the form renders it as a doc-style field)
+     * and stripped from the annotation source held on {@code annotTool}; any other fields (e.g. {@code schema}) are
+     * preserved verbatim. The {@code annotTool} entry's {@code types} list is always patched to a non-null value
+     * so the frontend form does not crash on a malformed property.
+     */
+    private static void processToolAnnotation(Function function, MetadataNode metadata) {
+        Value annotProperty = function.getProperties().get(TOOL_ANNOTATION_PROPERTY);
+        if (annotProperty == null) {
+            return;
+        }
+        // Parent's updateAnnotationAttachmentProperty doesn't set types. The frontend form factory mounts every
+        // property regardless of enabled flag and throws when types is null/empty, so seed a placeholder type. The
+        // editor itself stays hidden because we leave the parent's enabled=false default in place.
+        if (annotProperty.getTypes() == null || annotProperty.getTypes().isEmpty()) {
+            annotProperty.setTypes(new ArrayList<>(List.of(PropertyType.types(Value.FieldType.TEXT, "string"))));
+        }
+
+        AnnotationNode toolAnnotation = findToolAnnotation(metadata);
+        if (toolAnnotation == null || toolAnnotation.annotValue().isEmpty()) {
+            return;
+        }
+
+        MappingConstructorExpressionNode mapping = toolAnnotation.annotValue().get();
+        SpecificFieldNode descriptionField = null;
+        // Source-code snippets so spread fields (...x), computed-name fields, etc. are preserved verbatim
+        // alongside ordinary SpecificFieldNode entries.
+        List<String> keptFieldSources = new ArrayList<>();
+        for (MappingFieldNode field : mapping.fields()) {
+            if (field instanceof SpecificFieldNode specific
+                    && DESCRIPTION_FIELD_NAME.equals(specific.fieldName().toString().trim())) {
+                descriptionField = specific;
+            } else {
+                keptFieldSources.add(field.toSourceCode().trim());
+            }
+        }
+
+        if (descriptionField == null) {
+            return;
+        }
+
+        String literal = extractStringLiteral(descriptionField.valueExpr().orElse(null));
+        if (literal == null) {
+            // Non-literal description (template / variable / expression). Leave the annotation untouched.
+            return;
+        }
+
+        // Only hoist if parseDocumentation didn't already set it from a doc comment.
+        if (!function.getProperties().containsKey(TOOL_DESCRIPTION_PROPERTY)) {
+            function.getProperties().put(TOOL_DESCRIPTION_PROPERTY, buildToolDescriptionValue(literal));
+        }
+
+        if (keptFieldSources.isEmpty()) {
+            // Annotation only contained the description we just hoisted; suppress emission on save.
+            annotProperty.setEnabled(false);
+            annotProperty.setEditable(true);
+        } else {
+            annotProperty.setValue(buildAnnotationValue(keptFieldSources));
+        }
+    }
+
+    private static AnnotationNode findToolAnnotation(MetadataNode metadata) {
+        for (AnnotationNode annotation : metadata.annotations()) {
+            String ref = annotation.annotReference().toString().trim();
+            int colonIdx = ref.indexOf(':');
+            if (colonIdx < 0) {
+                continue;
+            }
+            String module = ref.substring(0, colonIdx).trim();
+            String simple = ref.substring(colonIdx + 1).trim();
+            if (MCP.equals(module) && TOOL_ANNOTATION_SIMPLE_NAME.equals(simple)) {
+                return annotation;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the unescaped contents of a double-quoted string literal expression, or {@code null} if {@code expr}
+     * is not such a literal. Used to decide whether the description can be safely hoisted into the doc-comment form.
+     */
+    private static String extractStringLiteral(ExpressionNode expr) {
+        if (!(expr instanceof BasicLiteralNode literal)) {
+            return null;
+        }
+        String text = literal.literalToken().text();
+        if (text.length() < 2 || !text.startsWith("\"") || !text.endsWith("\"")) {
+            return null;
+        }
+        return unescapeBalString(text.substring(1, text.length() - 1));
+    }
+
+    private static String unescapeBalString(String s) {
+        StringBuilder out = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\\' && i + 1 < s.length()) {
+                char next = s.charAt(++i);
+                switch (next) {
+                    case 'n' -> out.append('\n');
+                    case 't' -> out.append('\t');
+                    case 'r' -> out.append('\r');
+                    case '\\' -> out.append('\\');
+                    case '"' -> out.append('"');
+                    default -> {
+                        out.append('\\');
+                        out.append(next);
+                    }
+                }
+            } else {
+                out.append(c);
+            }
+        }
+        return out.toString();
+    }
+
+    private static Value buildToolDescriptionValue(String description) {
+        return new Value.ValueBuilder()
+                .metadata("Tool Description", "Description of what this MCP tool does")
+                .setPlaceholder("Describe what this tool does...")
+                .types(List.of(PropertyType.types(Value.FieldType.TEXT, "string")))
+                .value(description)
+                .enabled(true)
+                .editable(true)
+                .optional(true)
+                .setAdvanced(false)
+                .build();
+    }
+
+    /**
+     * Reconstructs a mapping-constructor source string from pre-captured field source snippets. Snippets come
+     * straight from {@link MappingFieldNode#toSourceCode()} so nested values like a {@code map<json>} schema, as
+     * well as spread fields, are preserved byte-for-byte. The result is the annotation value that
+     * {@code addFunctionAnnotationTextEdits} will splice back into source.
+     */
+    private static String buildAnnotationValue(List<String> keptFieldSources) {
+        StringBuilder sb = new StringBuilder(" {");
+        boolean first = true;
+        for (String fieldSource : keptFieldSources) {
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append(NEW_LINE).append(DOC_INDENT).append(fieldSource);
+            first = false;
+        }
+        sb.append(NEW_LINE).append("}");
+        return sb.toString();
     }
 
     @Override

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/get_mcp_tool_annotation_only.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/get_mcp_tool_annotation_only.json
@@ -1,0 +1,295 @@
+{
+  "filePath": "mcp_tool/main.bal",
+  "description": "MCP tool described via @mcp:Tool annotation (no doc comment, no schema)",
+  "codedata": {
+    "lineRange": {
+      "fileName": "main.bal",
+      "startLine": {
+        "line": 12,
+        "offset": 4
+      },
+      "endLine": {
+        "line": 17,
+        "offset": 5
+      }
+    }
+  },
+  "response": {
+    "metadata": {
+      "label": "",
+      "description": ""
+    },
+    "kind": "REMOTE",
+    "accessor": {
+      "metadata": {
+        "label": "Accessor",
+        "description": "The accessor of the function"
+      },
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "name": {
+      "metadata": {
+        "label": "Function Name",
+        "description": "The name of the function"
+      },
+      "value": "deleteBook",
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "parameters": [
+      {
+        "metadata": {
+          "label": "bookId",
+          "description": "bookId"
+        },
+        "kind": "REQUIRED",
+        "type": {
+          "metadata": {
+            "label": "Parameter Type",
+            "description": "The type of the parameter"
+          },
+          "value": "int",
+          "types": [
+            {
+              "fieldType": "TYPE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "name": {
+          "metadata": {
+            "label": "Parameter Name",
+            "description": "The name of the parameter"
+          },
+          "value": "bookId",
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "defaultValue": {
+          "metadata": {
+            "label": "Default Value",
+            "description": "The default value of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "EXPRESSION",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "documentation": {
+          "metadata": {
+            "label": "Description",
+            "description": "The description of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "hidden": false,
+        "isGraphqlId": false
+      }
+    ],
+    "schema": {
+      "parameter": {
+        "type": {
+          "metadata": {
+            "label": "Parameter Type",
+            "description": "The type of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "TYPE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "name": {
+          "metadata": {
+            "label": "Parameter Name",
+            "description": "The name of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "defaultValue": {
+          "metadata": {
+            "label": "Default Value",
+            "description": "The default value of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "EXPRESSION",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "documentation": {
+          "metadata": {
+            "label": "Description",
+            "description": "The description of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "hidden": false,
+        "isGraphqlId": false
+      }
+    },
+    "returnType": {
+      "hasError": false,
+      "isGraphqlId": false,
+      "metadata": {
+        "label": "Return Type",
+        "description": "The return type of the function"
+      },
+      "value": "string|error",
+      "types": [
+        {
+          "fieldType": "TYPE",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": true,
+      "advanced": false
+    },
+    "enabled": true,
+    "optional": true,
+    "editable": true,
+    "canAddParameters": true,
+    "codedata": {
+      "lineRange": {
+        "fileName": "main.bal",
+        "startLine": {
+          "line": 12,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 17,
+          "offset": 5
+        }
+      },
+      "orgName": "ballerina",
+      "packageName": "mcp",
+      "moduleName": "mcp"
+    },
+    "properties": {
+      "toolDescription": {
+        "metadata": {
+          "label": "Tool Description",
+          "description": "Description of what this MCP tool does"
+        },
+        "placeholder": "Describe what this tool does...",
+        "value": "Delete a book from the bookstore by its ID",
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": true
+          }
+        ],
+        "enabled": true,
+        "editable": true,
+        "optional": true,
+        "advanced": false
+      },
+      "annotTool": {
+        "metadata": {
+          "label": "Tool",
+          "description": "Tool"
+        },
+        "codedata": {
+          "type": "ANNOTATION_ATTACHMENT",
+          "originalName": "Tool",
+          "moduleName": "mcp"
+        },
+        "value": "{\n        description: \"Delete a book from the bookstore by its ID\"\n    }",
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": false
+          }
+        ],
+        "enabled": false,
+        "editable": true,
+        "optional": false,
+        "advanced": false
+      }
+    }
+  }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/get_mcp_tool_annotation_with_schema.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/get_mcp_tool_annotation_with_schema.json
@@ -1,0 +1,295 @@
+{
+  "filePath": "mcp_tool/main.bal",
+  "description": "MCP tool described via @mcp:Tool annotation with description and schema fields",
+  "codedata": {
+    "lineRange": {
+      "fileName": "main.bal",
+      "startLine": {
+        "line": 19,
+        "offset": 4
+      },
+      "endLine": {
+        "line": 30,
+        "offset": 5
+      }
+    }
+  },
+  "response": {
+    "metadata": {
+      "label": "",
+      "description": ""
+    },
+    "kind": "REMOTE",
+    "accessor": {
+      "metadata": {
+        "label": "Accessor",
+        "description": "The accessor of the function"
+      },
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "name": {
+      "metadata": {
+        "label": "Function Name",
+        "description": "The name of the function"
+      },
+      "value": "listBooks",
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "parameters": [
+      {
+        "metadata": {
+          "label": "author",
+          "description": "author"
+        },
+        "kind": "REQUIRED",
+        "type": {
+          "metadata": {
+            "label": "Parameter Type",
+            "description": "The type of the parameter"
+          },
+          "value": "string",
+          "types": [
+            {
+              "fieldType": "TYPE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "name": {
+          "metadata": {
+            "label": "Parameter Name",
+            "description": "The name of the parameter"
+          },
+          "value": "author",
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "defaultValue": {
+          "metadata": {
+            "label": "Default Value",
+            "description": "The default value of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "EXPRESSION",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "documentation": {
+          "metadata": {
+            "label": "Description",
+            "description": "The description of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "hidden": false,
+        "isGraphqlId": false
+      }
+    ],
+    "schema": {
+      "parameter": {
+        "type": {
+          "metadata": {
+            "label": "Parameter Type",
+            "description": "The type of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "TYPE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "name": {
+          "metadata": {
+            "label": "Parameter Name",
+            "description": "The name of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "defaultValue": {
+          "metadata": {
+            "label": "Default Value",
+            "description": "The default value of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "EXPRESSION",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "documentation": {
+          "metadata": {
+            "label": "Description",
+            "description": "The description of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "hidden": false,
+        "isGraphqlId": false
+      }
+    },
+    "returnType": {
+      "hasError": false,
+      "isGraphqlId": false,
+      "metadata": {
+        "label": "Return Type",
+        "description": "The return type of the function"
+      },
+      "value": "string",
+      "types": [
+        {
+          "fieldType": "TYPE",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": true,
+      "advanced": false
+    },
+    "enabled": true,
+    "optional": true,
+    "editable": true,
+    "canAddParameters": true,
+    "codedata": {
+      "lineRange": {
+        "fileName": "main.bal",
+        "startLine": {
+          "line": 19,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 30,
+          "offset": 5
+        }
+      },
+      "orgName": "ballerina",
+      "packageName": "mcp",
+      "moduleName": "mcp"
+    },
+    "properties": {
+      "toolDescription": {
+        "metadata": {
+          "label": "Tool Description",
+          "description": "Description of what this MCP tool does"
+        },
+        "placeholder": "Describe what this tool does...",
+        "value": "List books filtered by author",
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": true
+          }
+        ],
+        "enabled": true,
+        "editable": true,
+        "optional": true,
+        "advanced": false
+      },
+      "annotTool": {
+        "metadata": {
+          "label": "Tool",
+          "description": "Tool"
+        },
+        "codedata": {
+          "type": "ANNOTATION_ATTACHMENT",
+          "originalName": "Tool",
+          "moduleName": "mcp"
+        },
+        "value": " {\n    schema: {\n            \"type\": \"object\",\n            \"properties\": {\n                \"author\": {\"type\": \"string\"}\n            }\n        }\n}",
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": false
+          }
+        ],
+        "enabled": false,
+        "editable": false,
+        "optional": false,
+        "advanced": false
+      }
+    }
+  }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/get_mcp_tool_doc_comment.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/config/get_mcp_tool_doc_comment.json
@@ -1,0 +1,273 @@
+{
+  "filePath": "mcp_tool/main.bal",
+  "description": "MCP tool described via doc comment (legacy / editor-generated form)",
+  "codedata": {
+    "lineRange": {
+      "fileName": "main.bal",
+      "startLine": {
+        "line": 32,
+        "offset": 4
+      },
+      "endLine": {
+        "line": 38,
+        "offset": 5
+      }
+    }
+  },
+  "response": {
+    "metadata": {
+      "label": "",
+      "description": ""
+    },
+    "kind": "REMOTE",
+    "accessor": {
+      "metadata": {
+        "label": "Accessor",
+        "description": "The accessor of the function"
+      },
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "name": {
+      "metadata": {
+        "label": "Function Name",
+        "description": "The name of the function"
+      },
+      "value": "getBook",
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "parameters": [
+      {
+        "metadata": {
+          "label": "bookId",
+          "description": "bookId"
+        },
+        "kind": "REQUIRED",
+        "type": {
+          "metadata": {
+            "label": "Parameter Type",
+            "description": "The type of the parameter"
+          },
+          "value": "int",
+          "types": [
+            {
+              "fieldType": "TYPE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "name": {
+          "metadata": {
+            "label": "Parameter Name",
+            "description": "The name of the parameter"
+          },
+          "value": "bookId",
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "defaultValue": {
+          "metadata": {
+            "label": "Default Value",
+            "description": "The default value of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "EXPRESSION",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "documentation": {
+          "metadata": {
+            "label": "Description",
+            "description": "The description of the parameter"
+          },
+          "value": "Book identifier",
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "hidden": false,
+        "isGraphqlId": false
+      }
+    ],
+    "schema": {
+      "parameter": {
+        "type": {
+          "metadata": {
+            "label": "Parameter Type",
+            "description": "The type of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "TYPE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "name": {
+          "metadata": {
+            "label": "Parameter Name",
+            "description": "The name of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "defaultValue": {
+          "metadata": {
+            "label": "Default Value",
+            "description": "The default value of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "EXPRESSION",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "documentation": {
+          "metadata": {
+            "label": "Description",
+            "description": "The description of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "hidden": false,
+        "isGraphqlId": false
+      }
+    },
+    "returnType": {
+      "hasError": false,
+      "isGraphqlId": false,
+      "metadata": {
+        "label": "Return Type",
+        "description": "The return type of the function"
+      },
+      "value": "string",
+      "types": [
+        {
+          "fieldType": "TYPE",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": true,
+      "advanced": false
+    },
+    "enabled": true,
+    "optional": true,
+    "editable": true,
+    "canAddParameters": true,
+    "codedata": {
+      "lineRange": {
+        "fileName": "main.bal",
+        "startLine": {
+          "line": 32,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 38,
+          "offset": 5
+        }
+      },
+      "orgName": "ballerina",
+      "packageName": "mcp",
+      "moduleName": "mcp"
+    },
+    "properties": {
+      "toolDescription": {
+        "metadata": {
+          "label": "Tool Description",
+          "description": "Description of what this MCP tool does"
+        },
+        "placeholder": "Describe what this tool does...",
+        "value": "\"Get a book\"",
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": true
+          }
+        ],
+        "enabled": true,
+        "editable": true,
+        "optional": true,
+        "advanced": false
+      }
+    }
+  }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/source/mcp_tool/Ballerina.toml
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/source/mcp_tool/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "ballerina"
+name = "service_designer"
+version = "0.1.0"

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/source/mcp_tool/main.bal
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_fm_from_source/source/mcp_tool/main.bal
@@ -1,0 +1,40 @@
+import ballerina/mcp;
+
+listener mcp:Listener mcpListener = check new (9090);
+
+@mcp:ServiceConfig {
+    info: {
+        name: "bookstore",
+        version: "1.0.0"
+    }
+}
+service mcp:Service /mcp on mcpListener {
+
+    @mcp:Tool {
+        description: "Delete a book from the bookstore by its ID"
+    }
+    remote function deleteBook(int bookId) returns string|error {
+        return "ok";
+    }
+
+    @mcp:Tool {
+        description: "List books filtered by author",
+        schema: {
+            "type": "object",
+            "properties": {
+                "author": {"type": "string"}
+            }
+        }
+    }
+    remote function listBooks(string author) returns string {
+        return "ok";
+    }
+
+    # "Get a book"
+    #
+    # + bookId - Book identifier
+    # + return - The book
+    remote function getBook(int bookId) returns string {
+        return "ok";
+    }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_function/config/update_mcp_tool_annotation_only.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_function/config/update_mcp_tool_annotation_only.json
@@ -1,0 +1,240 @@
+{
+  "filePath": "update_mcp_tool.bal",
+  "description": "Update MCP tool whose source had an annotation-only description (description hoisted to doc comment, annotation removed)",
+  "function": {
+    "metadata": {
+      "label": "",
+      "description": ""
+    },
+    "kind": "REMOTE",
+    "accessor": {
+      "metadata": {
+        "label": "Accessor",
+        "description": "The accessor of the function"
+      },
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "name": {
+      "metadata": {
+        "label": "Function Name",
+        "description": "The name of the function"
+      },
+      "value": "deleteBook",
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "documentation": {
+      "types": [
+        {
+          "fieldType": "TEXT",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": true,
+      "advanced": false
+    },
+    "parameters": [
+      {
+        "metadata": {
+          "label": "bookId",
+          "description": "bookId"
+        },
+        "kind": "REQUIRED",
+        "type": {
+          "metadata": {
+            "label": "Parameter Type",
+            "description": "The type of the parameter"
+          },
+          "value": "int",
+          "types": [
+            {
+              "fieldType": "TYPE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "name": {
+          "metadata": {
+            "label": "Parameter Name",
+            "description": "The name of the parameter"
+          },
+          "value": "bookId",
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "defaultValue": {
+          "metadata": {
+            "label": "Default Value",
+            "description": "The default value of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "EXPRESSION",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "documentation": {
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "hidden": false,
+        "isGraphqlId": false
+      }
+    ],
+    "returnType": {
+      "hasError": false,
+      "isGraphqlId": false,
+      "metadata": {
+        "label": "Return Type",
+        "description": "The return type of the function"
+      },
+      "value": "string|error",
+      "types": [
+        {
+          "fieldType": "TYPE",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": true,
+      "advanced": false
+    },
+    "enabled": true,
+    "optional": true,
+    "editable": true,
+    "canAddParameters": true,
+    "codedata": {
+      "lineRange": {
+        "fileName": "main.bal",
+        "startLine": {
+          "line": 12,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 17,
+          "offset": 5
+        }
+      },
+      "orgName": "ballerina",
+      "packageName": "mcp",
+      "moduleName": "mcp"
+    },
+    "properties": {
+      "toolDescription": {
+        "metadata": {
+          "label": "Tool Description",
+          "description": "Description of what this MCP tool does"
+        },
+        "placeholder": "Describe what this tool does...",
+        "value": "Delete a book from the bookstore by its ID",
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": true
+          }
+        ],
+        "enabled": true,
+        "editable": true,
+        "optional": true,
+        "advanced": false
+      },
+      "annotTool": {
+        "metadata": {
+          "label": "Tool",
+          "description": "Tool"
+        },
+        "codedata": {
+          "type": "ANNOTATION_ATTACHMENT",
+          "originalName": "Tool",
+          "moduleName": "mcp"
+        },
+        "value": "{\n        description: \"Delete a book from the bookstore by its ID\"\n    }",
+        "types": [],
+        "enabled": false,
+        "editable": true,
+        "optional": false,
+        "advanced": false
+      }
+    }
+  },
+  "output": {
+    "update_mcp_tool.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 12,
+            "character": 4
+          },
+          "end": {
+            "line": 14,
+            "character": 5
+          }
+        },
+        "newText": "# Delete a book from the bookstore by its ID\n    #\n        # + return - string|error\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 15,
+            "character": 30
+          },
+          "end": {
+            "line": 15,
+            "character": 63
+          }
+        },
+        "newText": "(int bookId) returns string|error "
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_function/config/update_mcp_tool_annotation_with_schema.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_function/config/update_mcp_tool_annotation_with_schema.json
@@ -1,0 +1,253 @@
+{
+  "filePath": "update_mcp_tool.bal",
+  "description": "Update MCP tool whose source had description and schema in the annotation (description hoisted to doc comment, schema preserved in annotation)",
+  "function": {
+    "metadata": {
+      "label": "",
+      "description": ""
+    },
+    "kind": "REMOTE",
+    "accessor": {
+      "metadata": {
+        "label": "Accessor",
+        "description": "The accessor of the function"
+      },
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "name": {
+      "metadata": {
+        "label": "Function Name",
+        "description": "The name of the function"
+      },
+      "value": "listBooks",
+      "types": [
+        {
+          "fieldType": "IDENTIFIER",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false
+    },
+    "documentation": {
+      "types": [
+        {
+          "fieldType": "TEXT",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": true,
+      "advanced": false
+    },
+    "parameters": [
+      {
+        "metadata": {
+          "label": "author",
+          "description": "author"
+        },
+        "kind": "REQUIRED",
+        "type": {
+          "metadata": {
+            "label": "Parameter Type",
+            "description": "The type of the parameter"
+          },
+          "value": "string",
+          "types": [
+            {
+              "fieldType": "TYPE",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "name": {
+          "metadata": {
+            "label": "Parameter Name",
+            "description": "The name of the parameter"
+          },
+          "value": "author",
+          "types": [
+            {
+              "fieldType": "IDENTIFIER",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false
+        },
+        "defaultValue": {
+          "metadata": {
+            "label": "Default Value",
+            "description": "The default value of the parameter"
+          },
+          "types": [
+            {
+              "fieldType": "EXPRESSION",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "documentation": {
+          "types": [
+            {
+              "fieldType": "TEXT",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": true,
+          "advanced": false
+        },
+        "enabled": true,
+        "editable": true,
+        "optional": false,
+        "advanced": false,
+        "hidden": false,
+        "isGraphqlId": false
+      }
+    ],
+    "returnType": {
+      "hasError": false,
+      "isGraphqlId": false,
+      "metadata": {
+        "label": "Return Type",
+        "description": "The return type of the function"
+      },
+      "value": "string",
+      "types": [
+        {
+          "fieldType": "TYPE",
+          "selected": true
+        }
+      ],
+      "enabled": true,
+      "editable": true,
+      "optional": true,
+      "advanced": false
+    },
+    "enabled": true,
+    "optional": true,
+    "editable": true,
+    "canAddParameters": true,
+    "codedata": {
+      "lineRange": {
+        "fileName": "main.bal",
+        "startLine": {
+          "line": 19,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 30,
+          "offset": 5
+        }
+      },
+      "orgName": "ballerina",
+      "packageName": "mcp",
+      "moduleName": "mcp"
+    },
+    "properties": {
+      "toolDescription": {
+        "metadata": {
+          "label": "Tool Description",
+          "description": "Description of what this MCP tool does"
+        },
+        "placeholder": "Describe what this tool does...",
+        "value": "List books filtered by author",
+        "types": [
+          {
+            "fieldType": "TEXT",
+            "ballerinaType": "string",
+            "selected": true
+          }
+        ],
+        "enabled": true,
+        "editable": true,
+        "optional": true,
+        "advanced": false
+      },
+      "annotTool": {
+        "metadata": {
+          "label": "Tool",
+          "description": "Tool"
+        },
+        "codedata": {
+          "type": "ANNOTATION_ATTACHMENT",
+          "originalName": "Tool",
+          "moduleName": "mcp"
+        },
+        "value": " {\n    schema: {\n            \"type\": \"object\",\n            \"properties\": {\n                \"author\": {\"type\": \"string\"}\n            }\n        }\n}",
+        "types": [],
+        "enabled": false,
+        "editable": false,
+        "optional": false,
+        "advanced": false
+      }
+    }
+  },
+  "output": {
+    "update_mcp_tool.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 19,
+            "character": 4
+          },
+          "end": {
+            "line": 19,
+            "character": 4
+          }
+        },
+        "newText": "    # List books filtered by author\n    #\n        # + return - string\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 19,
+            "character": 4
+          },
+          "end": {
+            "line": 27,
+            "character": 5
+          }
+        },
+        "newText": "@mcp:Tool {\n    schema: {\n            \"type\": \"object\",\n            \"properties\": {\n                \"author\": {\"type\": \"string\"}\n            }\n        }\n}"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 28,
+            "character": 29
+          },
+          "end": {
+            "line": 28,
+            "character": 59
+          }
+        },
+        "newText": "(string author) returns string "
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_function/source/update_mcp_tool.bal
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/update_function/source/update_mcp_tool.bal
@@ -1,0 +1,32 @@
+import ballerina/mcp;
+
+listener mcp:Listener mcpListener = check new (9090);
+
+@mcp:ServiceConfig {
+    info: {
+        name: "bookstore",
+        version: "1.0.0"
+    }
+}
+service mcp:Service /mcp on mcpListener {
+
+    @mcp:Tool {
+        description: "Delete a book from the bookstore by its ID"
+    }
+    remote function deleteBook(int bookId) returns string|error {
+        return "ok";
+    }
+
+    @mcp:Tool {
+        description: "List books filtered by author",
+        schema: {
+            "type": "object",
+            "properties": {
+                "author": {"type": "string"}
+            }
+        }
+    }
+    remote function listBooks(string author) returns string {
+        return "ok";
+    }
+}


### PR DESCRIPTION
Fixes wso2/product-integrator#1527.

> Mirror of ballerina-platform/ballerina-language-server#938

Clicking **Configure** on an MCP tool generated with `@mcp:Tool { description: "..." }` crashed the visualizer (`Field types are not defined`). The parent annotation handler created an `annotTool` property with null `types`, and `parseDocumentation` only reads doc comments, so `toolDescription` was never populated.

`McpFunctionBuilder` now hoists a string-literal `description` from the annotation into `toolDescription` on read, while rewriting `annotTool.value` to preserve any other fields (`schema` kept byte-for-byte). It also seeds `annotTool.types`, sets the function `kind` to `REMOTE` so `updateFunction` dispatches to the MCP builder, inserts a fresh doc-comment block on save when the source had none, and scopes the `@mcp:Tool` match to the `mcp` module qualifier.

Fixtures added for annotation-only, annotation + schema, and doc-comment forms (read + update).