### PR TITLE
Fix unable to open AI agent service when extra functions exist

### DIFF
--- a/packages/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
+++ b/packages/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
@@ -105,17 +105,14 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
     const { onFunctionSelect, onDeleteComponent, readonly } = useDiagramContext();
     const isMenuOpen = Boolean(menuAnchorEl);
 
-    const serviceFunctions = [];
-    if ((model.node as CDService).remoteFunctions?.length > 0) {
-        serviceFunctions.push(...(model.node as CDService).remoteFunctions);
-    }
-    if ((model.node as CDService).resourceFunctions?.length > 0) {
-        serviceFunctions.push(...(model.node as CDService).resourceFunctions);
-    }
+    // ai:Listener entry point is fixed to `post chat`.
+    const chatResource = (model.node as CDService).resourceFunctions?.find(
+        (r) => r.accessor === "post" && r.path === "chat"
+    );
 
     const handleOnClick = () => {
-        if (serviceFunctions.length > 0) {
-            onFunctionSelect(serviceFunctions[0]);
+        if (chatResource) {
+            onFunctionSelect(chatResource);
         }
     };
 
@@ -198,9 +195,9 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
             </Popover>
 
             <BottomPortWidget port={model.getPort("out")!} engine={engine} />
-            {serviceFunctions.length > 0 && (
+            {chatResource && (
                 <BottomPortWidget
-                    port={model.getPort(getEntryNodeFunctionPortName(serviceFunctions[0]))!}
+                    port={model.getPort(getEntryNodeFunctionPortName(chatResource))!}
                     engine={engine}
                 />
             )}


### PR DESCRIPTION
## Summary

Fixes https://github.com/wso2/product-integrator/issues/1525

> Mirror of wso2/vscode-extensions#2303

The AI Agent Service entry node in the component diagram picked the first function (remotes first, then resources). A stray `remote function chat` — e.g. one mistakenly generated by Copilot alongside the real `resource function post chat` — would be selected, sending navigation to a location no AI service artifact covers, so the editor failed to open.

Now the click target is found by an exact match on `accessor === "post" && path === "chat"`, which is the only valid `ai:Listener` entry point.