### PR TITLE
Remove unused BALLERINA_AUTH_* and BALLERINA_DEV_COPILOT_* env vars from workflows

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -35,18 +35,6 @@ inputs:
     description: Ballerina distribution version
     required: false
     default: '2201.13.2'
-  BALLERINA_AUTH_ORG:
-    required: false
-  BALLERINA_AUTH_CLIENT_ID:
-    required: false
-  BALLERINA_DEV_COPILOT_ROOT_URL:
-    required: false
-  BALLERINA_DEV_COPILOT_AUTH_ORG:
-    required: false
-  BALLERINA_DEV_COPILOT_AUTH_CLIENT_ID:
-    required: false
-  BALLERINA_DEV_COPILOT_AUTH_REDIRECT_URL:
-    required: false
   COPILOT_ROOT_URL:
     required: false
   COPILOT_DEV_ROOT_URL:
@@ -153,12 +141,6 @@ runs:
         # Credentials for the LS gradle build (maven.pkg.github.com/ballerina-platform/*)
         packageUser: ${{ github.actor }}
         packagePAT: ${{ github.token }}
-        BALLERINA_AUTH_ORG: ${{ inputs.BALLERINA_AUTH_ORG }}
-        BALLERINA_AUTH_CLIENT_ID: ${{ inputs.BALLERINA_AUTH_CLIENT_ID }}
-        BALLERINA_DEV_COPILOT_ROOT_URL: ${{ inputs.BALLERINA_DEV_COPILOT_ROOT_URL }}
-        BALLERINA_DEV_COPILOT_AUTH_ORG: ${{ inputs.BALLERINA_DEV_COPILOT_AUTH_ORG }}
-        BALLERINA_DEV_COPILOT_AUTH_CLIENT_ID: ${{ inputs.BALLERINA_DEV_COPILOT_AUTH_CLIENT_ID }}
-        BALLERINA_DEV_COPILOT_AUTH_REDIRECT_URL: ${{ inputs.BALLERINA_DEV_COPILOT_AUTH_REDIRECT_URL }}
         COPILOT_ROOT_URL: ${{ inputs.COPILOT_ROOT_URL }}
         COPILOT_DEV_ROOT_URL: ${{ inputs.COPILOT_DEV_ROOT_URL }}
         APPINSIGHTS_INSTRUMENTATION_KEY: ${{ inputs.APPINSIGHTS_INSTRUMENTATION_KEY }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,7 +39,7 @@ Each has `defaults.run.working-directory: packages/ballerina-language-server` in
 - `BI_TEAM_CHAT_API` — daily build success + release announcements (pre-release and final)
 - `EDITOR_TEAM_CHAT_API` — threaded release progress, build/sync failures
 - `CLOUD_EDITOR_BUILDER_REPO` / `CLOUD_EDITOR_BUILDER_REPO_TOKEN` — optional cross-repo dispatch on stable release (publish-vsix)
-- `BALLERINA_AUTH_*` / `BALLERINA_DEV_COPLIOT_*` / `COPILOT_*` / `APPINSIGHTS_INSTRUMENTATION_KEY` — passed through to the build composite action
+- `COPILOT_ROOT_URL` / `COPILOT_DEV_ROOT_URL` / `APPINSIGHTS_INSTRUMENTATION_KEY` — passed through to the build composite action
 
 Configure these in the new repo's settings before triggering anything.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,16 +103,6 @@ jobs:
           enableLSCache: ${{ !inputs.isReleaseBuild }}
           ballerina: ${{ inputs.ballerina }}
           version: ${{ inputs.version }}
-          BALLERINA_AUTH_ORG: ${{ secrets.BALLERINA_AUTH_ORG }}
-          BALLERINA_AUTH_CLIENT_ID: ${{ secrets.BALLERINA_AUTH_CLIENT_ID }}
-          # NOTE: input keys (left) use the corrected COPILOT spelling;
-          # secret names (right) keep the COPLIOT typo to match what's
-          # configured on the org. Rename the org secrets and update the
-          # right side when convenient.
-          BALLERINA_DEV_COPILOT_ROOT_URL: ${{ secrets.BALLERINA_DEV_COPLIOT_ROOT_URL }}
-          BALLERINA_DEV_COPILOT_AUTH_ORG: ${{ secrets.BALLERINA_DEV_COPLIOT_AUTH_ORG }}
-          BALLERINA_DEV_COPILOT_AUTH_CLIENT_ID: ${{ secrets.BALLERINA_DEV_COPLIOT_AUTH_CLIENT_ID }}
-          BALLERINA_DEV_COPILOT_AUTH_REDIRECT_URL: ${{ secrets.BALLERINA_DEV_COPLIOT_AUTH_REDIRECT_URL }}
           COPILOT_ROOT_URL: ${{ secrets.COPILOT_ROOT_URL }}
           COPILOT_DEV_ROOT_URL: ${{ secrets.COPILOT_DEV_ROOT_URL }}
           APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}


### PR DESCRIPTION
## Summary

Six environment variables were being forwarded through the entire workflow chain (`build.yml` → `build/action.yml` → build step `env:`) but had no usages in any source file or build script. Removed them entirely.

Deleted variables:
- `BALLERINA_AUTH_ORG`
- `BALLERINA_AUTH_CLIENT_ID`
- `BALLERINA_DEV_COPILOT_ROOT_URL`
- `BALLERINA_DEV_COPILOT_AUTH_ORG`
- `BALLERINA_DEV_COPILOT_AUTH_CLIENT_ID`
- `BALLERINA_DEV_COPILOT_AUTH_REDIRECT_URL`

Variables confirmed as genuinely used and left untouched: `COPILOT_ROOT_URL`, `COPILOT_DEV_ROOT_URL`, `APPINSIGHTS_INSTRUMENTATION_KEY`, `isPreRelease`, `BALLERINA_LS_SOURCE`, `BALLERINA_LS_TAG`, `packageUser`, `packagePAT`.

## Changes

- `.github/actions/build/action.yml` — removed 6 input declarations and 6 `env:` entries from the build step
- `.github/workflows/build.yml` — removed 6 `${{ secrets.* }}` pass-throughs (including the stale comment about the `COPLIOT` typo)
- `.github/workflows/README.md` — updated secrets list to only mention variables that are actually used

## Test plan

- [ ] Trigger `pull-request.yml` or `daily-build.yml` — build should complete without referencing the removed vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)