### PR TITLE
Fix e2e test failures 

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -124,6 +124,16 @@ runs:
         path: packages/ballerina-extension/ls
         key: ballerina-ls-${{ steps.resolve-ballerina-ls-version.outputs.version }}
 
+    - name: Patch playwright-vscode-tester Form.ts
+      shell: bash
+      run: |
+        FILE="submodules/wso2-vscode-extensions/workspaces/common-libs/playwright-vscode-tester/src/components/Form.ts"
+        # hover() without force:true triggers the expression-helper popup on GitHub-hosted ubuntu
+        # runners (css-1o4gefw overlay intercepts pointer events), causing mode-button detection to
+        # fail and leaving the popup open to block subsequent clicks. Force bypasses the overlay.
+        sed -i 's/await containerDiv\.hover();/await containerDiv.hover({ force: true });/g' "$FILE"
+        echo "Patched: $(grep -c 'force: true' "$FILE") occurrence(s) updated in $FILE"
+
     - name: Build repo
       shell: bash
       id: build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -124,16 +124,6 @@ runs:
         path: packages/ballerina-extension/ls
         key: ballerina-ls-${{ steps.resolve-ballerina-ls-version.outputs.version }}
 
-    - name: Patch playwright-vscode-tester Form.ts
-      shell: bash
-      run: |
-        FILE="submodules/wso2-vscode-extensions/workspaces/common-libs/playwright-vscode-tester/src/components/Form.ts"
-        # hover() without force:true triggers the expression-helper popup on GitHub-hosted ubuntu
-        # runners (css-1o4gefw overlay intercepts pointer events), causing mode-button detection to
-        # fail and leaving the popup open to block subsequent clicks. Force bypasses the overlay.
-        sed -i 's/await containerDiv\.hover();/await containerDiv.hover({ force: true });/g' "$FILE"
-        echo "Patched: $(grep -c 'force: true' "$FILE") occurrence(s) updated in $FILE"
-
     - name: Build repo
       shell: bash
       id: build

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -225,7 +225,7 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Match node');
-            await clickLastDoBodyLink(artifactWebView);
+            await clickNextDiagramPlus(artifactWebView);
             await selectNode(sidePanel, 'Match', 'Control');
             await form.switchToFormView(false, artifactWebView);
             await fillCodeMirror(artifactWebView, 'count', 0);
@@ -233,7 +233,7 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Log Error node');
-            await clickLastDoBodyLink(artifactWebView);
+            await clickNextDiagramPlus(artifactWebView);
             await selectNode(sidePanel, 'Log Error', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
@@ -248,7 +248,7 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Log Warn node');
-            await clickLastDoBodyLink(artifactWebView);
+            await clickNextDiagramPlus(artifactWebView);
             await selectNode(sidePanel, 'Log Warn', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
@@ -263,7 +263,7 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add While node');
-            await clickLastDoBodyLink(artifactWebView);
+            await clickNextDiagramPlus(artifactWebView);
             await selectNode(sidePanel, 'While', 'Control');
             await form.switchToFormView(false, artifactWebView);
             await fillFirstCodeMirror(artifactWebView, 'count < 3');

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -144,12 +144,29 @@ async function clickNextDiagramPlus(webview: Frame) {
         return;
     }
 
-    // No empty buttons: hover every diagram link with real Playwright so React
-    // renders the link-add-button overlays, then identify the second-to-last button.
+    // As the diagram grows it can extend past the viewport, making lower links
+    // unhoverable ("Element is outside of the viewport" on 1080p CI runners).
+    // Zoom out until every diagram link is within the viewport.
+    const allLinksInViewport = () => webview.evaluate(() => {
+        const links = [...document.querySelectorAll('[data-testid^="diagram-link-"]')];
+        return links.length > 0 && links.every((link) => {
+            const rect = link.getBoundingClientRect();
+            return rect.top >= 0 && rect.bottom <= window.innerHeight && rect.left >= 0 && rect.right <= window.innerWidth;
+        });
+    });
+    const zoomOutButton = webview.locator('i.fw-bi-minus');
+    for (let i = 0; i < 15 && !(await allLinksInViewport()); i++) {
+        if (await zoomOutButton.count() === 0) break;
+        await zoomOutButton.click({ force: true });
+        await page.page.waitForTimeout(200);
+    }
+
+    // Hover every diagram link with real Playwright so React renders the
+    // link-add-button overlays, then identify the second-to-last button.
     const links = webview.locator('[data-testid^="diagram-link-"]');
     const linkCount = await links.count();
     for (let i = 0; i < linkCount; i++) {
-        await links.nth(i).hover({ force: true });
+        await links.nth(i).hover({ force: true }).catch(() => { });
         await page.page.waitForTimeout(100);
     }
 

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -106,6 +106,8 @@ async function clickLinkButtonText(webview: Frame, text: string) {
 // we hover each diagram link and wait for React to re-render before clicking.
 async function clickNextDiagramPlus(webview: Frame) {
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
+    // Give React time to attach event handlers after the previous saveForm
+    await page.page.waitForTimeout(1000);
 
     // First try: always-visible add buttons (e.g. inside empty If/Match branches)
     const emptyButtons = webview.locator('[data-testid^="empty-node-add-button"]');

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -101,6 +101,55 @@ async function clickLinkButtonText(webview: Frame, text: string) {
     });
 }
 
+// Hover the diagram link that sits just above the Error Handler node (the last
+// link inside the do-block body) and click its add button. Because the If node
+// creates several internal branch links with unpredictable indices, targeting by
+// position is more reliable than targeting by a fixed diagram-link-N index.
+async function clickLastDoBodyLink(webview: Frame) {
+    await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
+    await page.page.waitForTimeout(1000);
+
+    const canvas = webview.locator('[data-testid="bi-diagram-canvas"]');
+
+    // Locate the Error Handler node to find the do-block bottom boundary
+    const ehText = canvas.getByText('Error Handler').first();
+    await ehText.waitFor({ state: 'visible', timeout: 15000 });
+    const ehBox = await ehText.boundingBox();
+    if (!ehBox) throw new Error('Cannot locate Error Handler bounding box');
+
+    // Among all diagram links, find the lowest one still above the Error Handler
+    const links = canvas.locator('[data-testid^="diagram-link-"]');
+    const count = await links.count();
+    let bestIdx = -1;
+    let bestBottom = 0;
+
+    for (let i = 0; i < count; i++) {
+        const box = await links.nth(i).boundingBox();
+        if (!box) continue;
+        const bottom = box.y + box.height;
+        if (bottom < ehBox.y && bottom > bestBottom) {
+            bestBottom = bottom;
+            bestIdx = i;
+        }
+    }
+
+    if (bestIdx === -1) throw new Error('No do-body link found above Error Handler');
+
+    const target = links.nth(bestIdx);
+    const testId = await target.getAttribute('data-testid');
+    const num = testId!.replace('diagram-link-', '');
+
+    await target.hover({ force: true });
+    await page.page.waitForTimeout(500);
+
+    const addBtn = canvas.locator(`[data-testid="link-add-button-${num}"]`);
+    if (!await addBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+        throw new Error(`link-add-button-${num} not visible after hover`);
+    }
+    await addBtn.click({ force: true });
+    await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+}
+
 
 export default function createTests() {
     test.describe.serial('Automation Flow Nodes Tests', {}, async () => {
@@ -190,9 +239,7 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Match node');
-            // link-5 = after If, inside the do block (same sequential numbering as links 1-4)
-            await diagram.clickHoverAddButtonByIndex(5);
-            await artifactWebView.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+            await clickLastDoBodyLink(artifactWebView);
             await selectNode(sidePanel, 'Match', 'Control');
             await form.switchToFormView(false, artifactWebView);
             await fillCodeMirror(artifactWebView, 'count', 0);
@@ -200,11 +247,7 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Log Error node');
-            // Match 1=> clause is the last empty-node-add-button (below If branches in the diagram)
-            await artifactWebView.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
-            await page.page.waitForTimeout(1000);
-            await artifactWebView.locator('[data-testid^="empty-node-add-button"]').last().click({ force: true });
-            await artifactWebView.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+            await clickLastDoBodyLink(artifactWebView);
             await selectNode(sidePanel, 'Log Error', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
@@ -219,9 +262,7 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Log Warn node');
-            // link-7 = inside Match 1=> clause, after Log Error (link-6 = after Match inside do)
-            await diagram.clickHoverAddButtonByIndex(7);
-            await artifactWebView.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+            await clickLastDoBodyLink(artifactWebView);
             await selectNode(sidePanel, 'Log Warn', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
@@ -236,9 +277,7 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add While node');
-            // link-6 = after Match inside the do block
-            await diagram.clickHoverAddButtonByIndex(6);
-            await artifactWebView.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+            await clickLastDoBodyLink(artifactWebView);
             await selectNode(sidePanel, 'While', 'Control');
             await form.switchToFormView(false, artifactWebView);
             await fillFirstCodeMirror(artifactWebView, 'count < 3');

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -101,52 +101,38 @@ async function clickLinkButtonText(webview: Frame, text: string) {
     });
 }
 
-// Hover the diagram link that sits just above the Error Handler node (the last
-// link inside the do-block body) and click its add button. Because the If node
-// creates several internal branch links with unpredictable indices, targeting by
-// position is more reliable than targeting by a fixed diagram-link-N index.
-async function clickLastDoBodyLink(webview: Frame) {
+// Mirrors the original clickNextDiagramPlus algorithm from the main branch but
+// uses real Playwright hover instead of synthetic dispatchEvent (which does not
+// trigger React event handlers on Linux GitHub runners).
+// Priority: empty-node-add-button (always visible) > second-to-last link-add-button.
+// Second-to-last avoids the function-level link after the Error Handler (always last).
+async function clickNextDiagramPlus(webview: Frame) {
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
-    await page.page.waitForTimeout(1000);
-
-    const canvas = webview.locator('[data-testid="bi-diagram-canvas"]');
-
-    // Locate the Error Handler node to find the do-block bottom boundary
-    const ehText = canvas.getByText('Error Handler').first();
-    await ehText.waitFor({ state: 'visible', timeout: 15000 });
-    const ehBox = await ehText.boundingBox();
-    if (!ehBox) throw new Error('Cannot locate Error Handler bounding box');
-
-    // Among all diagram links, find the lowest one still above the Error Handler
-    const links = canvas.locator('[data-testid^="diagram-link-"]');
-    const count = await links.count();
-    let bestIdx = -1;
-    let bestBottom = 0;
-
-    for (let i = 0; i < count; i++) {
-        const box = await links.nth(i).boundingBox();
-        if (!box) continue;
-        const bottom = box.y + box.height;
-        if (bottom < ehBox.y && bottom > bestBottom) {
-            bestBottom = bottom;
-            bestIdx = i;
-        }
-    }
-
-    if (bestIdx === -1) throw new Error('No do-body link found above Error Handler');
-
-    const target = links.nth(bestIdx);
-    const testId = await target.getAttribute('data-testid');
-    const num = testId!.replace('diagram-link-', '');
-
-    await target.hover({ force: true });
     await page.page.waitForTimeout(500);
 
-    const addBtn = canvas.locator(`[data-testid="link-add-button-${num}"]`);
-    if (!await addBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-        throw new Error(`link-add-button-${num} not visible after hover`);
+    // Prefer always-visible empty-node-add-buttons (branch/clause placeholders)
+    const emptyBtns = webview.locator('[data-testid^="empty-node-add-button"]');
+    if (await emptyBtns.count() > 0) {
+        await emptyBtns.first().click({ force: true });
+        await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+        return;
     }
-    await addBtn.click({ force: true });
+
+    // No empty buttons: hover every diagram link with real Playwright so React
+    // renders the link-add-button overlays, then click second-to-last.
+    const links = webview.locator('[data-testid^="diagram-link-"]');
+    const linkCount = await links.count();
+    for (let i = 0; i < linkCount; i++) {
+        await links.nth(i).hover({ force: true });
+        await page.page.waitForTimeout(100);
+    }
+
+    const addBtns = webview.locator('[data-testid^="link-add-button-"]');
+    const btnCount = await addBtns.count();
+    if (btnCount === 0) throw new Error('No diagram add button was available');
+
+    // Second-to-last avoids the function-level continuation link (which is last)
+    await addBtns.nth(Math.max(0, btnCount - 2)).click({ force: true });
     await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
 }
 

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -101,40 +101,6 @@ async function clickLinkButtonText(webview: Frame, text: string) {
     });
 }
 
-// Real Playwright click on diagram add buttons. empty-node-add-button elements are
-// always visible (inside branches or at diagram end). For hover-only link-add-buttons
-// we hover each diagram link and wait for React to re-render before clicking.
-async function clickNextDiagramPlus(webview: Frame) {
-    await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
-    // Give React time to attach event handlers after the previous saveForm
-    await page.page.waitForTimeout(1000);
-
-    // First try: always-visible add buttons (e.g. inside empty If/Match branches).
-    // Only use this path when exactly one is present — with multiple buttons (e.g. two Match
-    // clauses both empty) .first() would pick the wrong branch.
-    const emptyButtons = webview.locator('[data-testid^="empty-node-add-button"]');
-    if (await emptyButtons.count() === 1) {
-        await emptyButtons.first().click({ force: true });
-        await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
-        return;
-    }
-
-    // Second try: hover each diagram link from last to first to reveal hover-only add buttons
-    const links = webview.locator('[data-testid^="diagram-link-"]');
-    const linkCount = await links.count();
-    for (let i = linkCount - 1; i >= 0; i--) {
-        await links.nth(i).hover({ force: true });
-        await page.page.waitForTimeout(500);
-        const addButton = webview.locator('[data-testid^="link-add-button-"]').last();
-        if (await addButton.isVisible({ timeout: 300 }).catch(() => false)) {
-            await addButton.click({ force: true });
-            await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
-            return;
-        }
-    }
-
-    throw new Error('No diagram add button was available');
-}
 
 export default function createTests() {
     test.describe.serial('Automation Flow Nodes Tests', {}, async () => {
@@ -224,7 +190,9 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Match node');
-            await clickNextDiagramPlus(artifactWebView);
+            // link-5 = after If, inside the do block (same sequential numbering as links 1-4)
+            await diagram.clickHoverAddButtonByIndex(5);
+            await artifactWebView.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
             await selectNode(sidePanel, 'Match', 'Control');
             await form.switchToFormView(false, artifactWebView);
             await fillCodeMirror(artifactWebView, 'count', 0);
@@ -232,7 +200,11 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Log Error node');
-            await clickNextDiagramPlus(artifactWebView);
+            // Match 1=> clause is the last empty-node-add-button (below If branches in the diagram)
+            await artifactWebView.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
+            await page.page.waitForTimeout(1000);
+            await artifactWebView.locator('[data-testid^="empty-node-add-button"]').last().click({ force: true });
+            await artifactWebView.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
             await selectNode(sidePanel, 'Log Error', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
@@ -247,7 +219,9 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add Log Warn node');
-            await clickNextDiagramPlus(artifactWebView);
+            // link-7 = inside Match 1=> clause, after Log Error (link-6 = after Match inside do)
+            await diagram.clickHoverAddButtonByIndex(7);
+            await artifactWebView.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
             await selectNode(sidePanel, 'Log Warn', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
@@ -262,7 +236,9 @@ export default function createTests() {
             await saveForm(artifactWebView);
 
             logStep('Add While node');
-            await clickNextDiagramPlus(artifactWebView);
+            // link-6 = after Match inside the do block
+            await diagram.clickHoverAddButtonByIndex(6);
+            await artifactWebView.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
             await selectNode(sidePanel, 'While', 'Control');
             await form.switchToFormView(false, artifactWebView);
             await fillFirstCodeMirror(artifactWebView, 'count < 3');

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -119,7 +119,7 @@ async function clickNextDiagramPlus(webview: Frame) {
     }
 
     // No empty buttons: hover every diagram link with real Playwright so React
-    // renders the link-add-button overlays, then click second-to-last.
+    // renders the link-add-button overlays, then identify the second-to-last button.
     const links = webview.locator('[data-testid^="diagram-link-"]');
     const linkCount = await links.count();
     for (let i = 0; i < linkCount; i++) {
@@ -131,8 +131,17 @@ async function clickNextDiagramPlus(webview: Frame) {
     const btnCount = await addBtns.count();
     if (btnCount === 0) throw new Error('No diagram add button was available');
 
-    // Second-to-last avoids the function-level continuation link (which is last)
-    await addBtns.nth(Math.max(0, btnCount - 2)).click({ force: true });
+    // Re-hover the specific link for the second-to-last button so the button is
+    // visible at click time (hover state resets as we iterate over all links).
+    // Second-to-last avoids the function-level continuation link (which is last).
+    const targetBtnIdx = Math.max(0, btnCount - 2);
+    const targetBtnTestId = await addBtns.nth(targetBtnIdx).getAttribute('data-testid');
+    const correspondingLinkId = targetBtnTestId?.replace('link-add-button', 'diagram-link');
+    if (correspondingLinkId) {
+        await webview.locator(`[data-testid="${correspondingLinkId}"]`).hover({ force: true });
+        await page.page.waitForTimeout(200);
+    }
+    await addBtns.nth(targetBtnIdx).click({ force: true });
     await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
 }
 

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -172,8 +172,8 @@ export default function createTests() {
                 values: {
                     'msg': {
                         type: 'cmEditor',
-                        value: 'flow started',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
+                        value: '"flow started"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });
@@ -214,7 +214,7 @@ export default function createTests() {
                     'msg': {
                         type: 'cmEditor',
                         value: 'string `initial ${count} ${msg}`',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });
@@ -245,8 +245,8 @@ export default function createTests() {
                 values: {
                     'msg': {
                         type: 'cmEditor',
-                        value: 'sample error log',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
+                        value: '"sample error log"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });
@@ -260,8 +260,8 @@ export default function createTests() {
                 values: {
                     'msg': {
                         type: 'cmEditor',
-                        value: 'sample warn log',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
+                        value: '"sample warn log"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -109,9 +109,11 @@ async function clickNextDiagramPlus(webview: Frame) {
     // Give React time to attach event handlers after the previous saveForm
     await page.page.waitForTimeout(1000);
 
-    // First try: always-visible add buttons (e.g. inside empty If/Match branches)
+    // First try: always-visible add buttons (e.g. inside empty If/Match branches).
+    // Only use this path when exactly one is present — with multiple buttons (e.g. two Match
+    // clauses both empty) .first() would pick the wrong branch.
     const emptyButtons = webview.locator('[data-testid^="empty-node-add-button"]');
-    if (await emptyButtons.count() > 0) {
+    if (await emptyButtons.count() === 1) {
         await emptyButtons.first().click({ force: true });
         await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
         return;

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -144,28 +144,32 @@ async function clickNextDiagramPlus(webview: Frame) {
         return;
     }
 
-    // As the diagram grows it can extend past the viewport, making lower links
+    // As the diagram grows it extends past the viewport, making lower links
     // unhoverable ("Element is outside of the viewport" on 1080p CI runners).
-    // Zoom out until every diagram link is within the viewport.
-    const allLinksInViewport = () => webview.evaluate(() => {
-        const links = [...document.querySelectorAll('[data-testid^="diagram-link-"]')];
-        return links.length > 0 && links.every((link) => {
-            const rect = link.getBoundingClientRect();
-            return rect.top >= 0 && rect.bottom <= window.innerHeight && rect.left >= 0 && rect.right <= window.innerWidth;
-        });
-    });
-    const zoomOutButton = webview.locator('i.fw-bi-minus');
-    for (let i = 0; i < 15 && !(await allLinksInViewport()); i++) {
-        if (await zoomOutButton.count() === 0) break;
-        await zoomOutButton.click({ force: true });
-        await page.page.waitForTimeout(200);
-    }
+    // The diagram registers VerticalScrollCanvasAction, so a real mouse wheel
+    // over the canvas pans the diagram vertically — scroll each link into the
+    // canvas area before hovering it.
+    const canvasBox = await webview.locator('[data-testid="bi-diagram-canvas"]').boundingBox();
+    const scrollLinkIntoView = async (link: ReturnType<Frame['locator']>) => {
+        if (!canvasBox) return;
+        await page.page.mouse.move(canvasBox.x + canvasBox.width / 2, canvasBox.y + canvasBox.height / 2);
+        for (let attempt = 0; attempt < 20; attempt++) {
+            const box = await link.boundingBox();
+            if (box && box.y >= canvasBox.y + 10 && box.y + box.height <= canvasBox.y + canvasBox.height - 10) {
+                return;
+            }
+            const delta = box && box.y < canvasBox.y + 10 ? -200 : 200;
+            await page.page.mouse.wheel(0, delta);
+            await page.page.waitForTimeout(150);
+        }
+    };
 
     // Hover every diagram link with real Playwright so React renders the
     // link-add-button overlays, then identify the second-to-last button.
     const links = webview.locator('[data-testid^="diagram-link-"]');
     const linkCount = await links.count();
     for (let i = 0; i < linkCount; i++) {
+        await scrollLinkIntoView(links.nth(i));
         await links.nth(i).hover({ force: true }).catch(() => { });
         await page.page.waitForTimeout(100);
     }
@@ -181,7 +185,9 @@ async function clickNextDiagramPlus(webview: Frame) {
     const targetBtnTestId = await addBtns.nth(targetBtnIdx).getAttribute('data-testid');
     const correspondingLinkId = targetBtnTestId?.replace('link-add-button', 'diagram-link');
     if (correspondingLinkId) {
-        await webview.locator(`[data-testid="${correspondingLinkId}"]`).hover({ force: true });
+        const targetLink = webview.locator(`[data-testid="${correspondingLinkId}"]`);
+        await scrollLinkIntoView(targetLink);
+        await targetLink.hover({ force: true });
         await page.page.waitForTimeout(200);
     }
     await addBtns.nth(targetBtnIdx).click({ force: true });

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -54,10 +54,17 @@ async function saveForm(webview: Frame) {
         const panelText = await webview.getByTestId('side-panel').innerText({ timeout: 1000 }).catch(() => '');
         throw new Error(`Flow node form did not finish saving.\n${panelText}\n${error}`);
     });
-    await webview.getByTestId('side-panel').waitFor({ state: 'hidden', timeout: 60000 }).catch(async (error) => {
-        const panelText = await webview.getByTestId('side-panel').innerText({ timeout: 1000 }).catch(() => '');
-        throw new Error(`Flow node form did not close after saving.\n${panelText}\n${error}`);
-    });
+    // Retry the Save click once — on slow CI runners the first click can land
+    // before the form's onChange state settles, leaving the panel open.
+    const closed = await webview.getByTestId('side-panel').waitFor({ state: 'hidden', timeout: 20000 }).then(() => true, () => false);
+    if (!closed) {
+        await dismissHelperPanel();
+        await webview.getByRole('button', { name: 'Save' }).last().click({ force: true }).catch(() => { });
+        await webview.getByTestId('side-panel').waitFor({ state: 'hidden', timeout: 60000 }).catch(async (error) => {
+            const panelText = await webview.getByTestId('side-panel').innerText({ timeout: 1000 }).catch(() => '');
+            throw new Error(`Flow node form did not close after saving.\n${panelText}\n${error}`);
+        });
+    }
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 60000 });
     await page.page.waitForTimeout(1000);
 }
@@ -68,6 +75,25 @@ async function selectNode(sidePanel: SidePanel, nodeTitle: string, sectionTitle?
         await sidePanel.expandSection(sectionTitle);
     }
     await sidePanel.clickNode(nodeTitle);
+}
+
+// Fills a named ex-editor field directly via the CodeMirror view. Unlike
+// Form.fill's cmEditor handler (which silently no-ops if the ex-editor
+// container has not rendered yet — observed on slow Linux CI runners),
+// this explicitly waits for the editor to be mounted before dispatching.
+async function fillExEditor(webview: Frame, key: string, value: string) {
+    const container = webview.locator(`[data-testid="ex-editor-${key}"]`);
+    await container.waitFor({ state: 'visible', timeout: 30000 });
+    await container.locator('.cm-content').first().waitFor({ state: 'attached', timeout: 30000 });
+    await container.evaluate((element, text) => {
+        const cmContent = element.querySelector('.cm-content') as HTMLElement & { cmView?: { view?: any } };
+        const view = cmContent?.cmView?.view;
+        if (!view) {
+            throw new Error('CodeMirror view not found in ex-editor container');
+        }
+        view.focus();
+        view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+    }, value);
 }
 
 async function fillFirstCodeMirror(webview: Frame, value: string) {
@@ -172,15 +198,7 @@ export default function createTests() {
             await diagram.clickAddButtonByIndex(1);
             await selectNode(sidePanel, 'Log Info', 'Logging');
             await form.switchToFormView(false, artifactWebView);
-            await form.fill({
-                values: {
-                    'msg': {
-                        type: 'cmEditor',
-                        value: '"flow started"',
-                        additionalProps: { clickLabel: true }
-                    }
-                }
-            });
+            await fillExEditor(artifactWebView, 'msg', '"flow started"');
             await saveForm(artifactWebView);
 
             logStep('Add int count Declare Variable node');
@@ -213,15 +231,7 @@ export default function createTests() {
             await diagram.clickHoverAddButtonByIndex(3);
             await selectNode(sidePanel, 'Log Debug', 'Logging');
             await form.switchToFormView(false, artifactWebView);
-            await form.fill({
-                values: {
-                    'msg': {
-                        type: 'cmEditor',
-                        value: 'string `initial ${count} ${msg}`',
-                        additionalProps: { clickLabel: true }
-                    }
-                }
-            });
+            await fillExEditor(artifactWebView, 'msg', 'string `initial ${count} ${msg}`');
             await saveForm(artifactWebView);
 
             logStep('Add If node with Else block');
@@ -245,30 +255,14 @@ export default function createTests() {
             await clickNextDiagramPlus(artifactWebView);
             await selectNode(sidePanel, 'Log Error', 'Logging');
             await form.switchToFormView(false, artifactWebView);
-            await form.fill({
-                values: {
-                    'msg': {
-                        type: 'cmEditor',
-                        value: '"sample error log"',
-                        additionalProps: { clickLabel: true }
-                    }
-                }
-            });
+            await fillExEditor(artifactWebView, 'msg', '"sample error log"');
             await saveForm(artifactWebView);
 
             logStep('Add Log Warn node');
             await clickNextDiagramPlus(artifactWebView);
             await selectNode(sidePanel, 'Log Warn', 'Logging');
             await form.switchToFormView(false, artifactWebView);
-            await form.fill({
-                values: {
-                    'msg': {
-                        type: 'cmEditor',
-                        value: '"sample warn log"',
-                        additionalProps: { clickLabel: true }
-                    }
-                }
-            });
+            await fillExEditor(artifactWebView, 'msg', '"sample warn log"');
             await saveForm(artifactWebView);
 
             logStep('Add While node');

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -101,45 +101,35 @@ async function clickLinkButtonText(webview: Frame, text: string) {
     });
 }
 
-// Add buttons only appear on hover and are not stable Playwright targets; synthetic
-// mouse events via evaluateAll are used because standard hover()+click() does not
-// reliably trigger the diagram's React event handlers for these SVG overlay nodes.
+// Real Playwright click on diagram add buttons. empty-node-add-button elements are
+// always visible (inside branches or at diagram end). For hover-only link-add-buttons
+// we hover each diagram link and wait for React to re-render before clicking.
 async function clickNextDiagramPlus(webview: Frame) {
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
-    const clickedId = await webview.locator('[data-testid]').evaluateAll((elements) => {
-        const links = elements.filter((element) => {
-            const id = element.getAttribute('data-testid') || '';
-            return id.startsWith('diagram-link-');
-        });
-        for (const link of links) {
-            for (const type of ['pointerover', 'mouseover', 'mouseenter', 'pointerenter']) {
-                link.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
-            }
-        }
 
-        const candidates = elements.filter((element) => {
-            const id = element.getAttribute('data-testid') || '';
-            return id.startsWith('link-add-button') || id.startsWith('empty-node-add-button');
-        });
-        const target = candidates.find((element) => (element.getAttribute('data-testid') || '').startsWith('empty-node-add-button'))
-            || candidates[candidates.length - 2]
-            || candidates[candidates.length - 1];
-        if (!target) {
-            return '';
-        }
-        for (const type of ['pointerover', 'mouseover', 'mouseenter', 'pointerenter']) {
-            target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
-        }
-        for (const type of ['pointerdown', 'mousedown', 'mouseup', 'click']) {
-            target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
-        }
-        return target.getAttribute('data-testid') || '';
-    });
-
-    await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
-    if (!clickedId) {
-        throw new Error('No diagram add button was available');
+    // First try: always-visible add buttons (e.g. inside empty If/Match branches)
+    const emptyButtons = webview.locator('[data-testid^="empty-node-add-button"]');
+    if (await emptyButtons.count() > 0) {
+        await emptyButtons.first().click({ force: true });
+        await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+        return;
     }
+
+    // Second try: hover each diagram link from last to first to reveal hover-only add buttons
+    const links = webview.locator('[data-testid^="diagram-link-"]');
+    const linkCount = await links.count();
+    for (let i = linkCount - 1; i >= 0; i--) {
+        await links.nth(i).hover({ force: true });
+        await page.page.waitForTimeout(500);
+        const addButton = webview.locator('[data-testid^="link-add-button-"]').last();
+        if (await addButton.isVisible({ timeout: 300 }).catch(() => false)) {
+            await addButton.click({ force: true });
+            await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+            return;
+        }
+    }
+
+    throw new Error('No diagram add button was available');
 }
 
 export default function createTests() {

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
@@ -154,8 +154,8 @@ export default function createTests() {
                 values: {
                     'msg': {
                         type: 'cmEditor',
-                        value: 'Equal',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
+                        value: '"Equal"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });
@@ -177,8 +177,8 @@ export default function createTests() {
                 values: {
                     'msg': {
                         type: 'cmEditor',
-                        value: 'Not Equal',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
+                        value: '"Not Equal"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
@@ -124,10 +124,12 @@ export default function createTests() {
                 }
             });
 
-            // Click the add Else Block 
-            // Click the "Add Else Block" button in the If configuration UI before saving
+            // Dismiss the expression helper popup triggered by CodeMirror fill before clicking
+            await page.page.keyboard.press('Escape');
+            await page.page.waitForTimeout(300);
+
+            // Click the add Else Block
             // The "Add Else Block" is not a button, but a div with text.
-            // So select it by its text using .getByText or .locator, and click it.
             const addElseBlockDiv = artifactWebView.getByText('Add Else Block', { exact: true });
             await addElseBlockDiv.click();
             await artifactWebView.getByRole('button', { name: 'Save' }).click();

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/azure.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/azure.spec.ts
@@ -44,13 +44,13 @@ export default function createTests() {
                 values: {
                     'connectionString': {
                         type: 'cmEditor',
-                        value: 'Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test',
-                        additionalProps: { clickLabel: true, switchMode: 'primary-mode', window: global.window }
+                        value: '"Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"',
+                        additionalProps: { clickLabel: true }
                     },
                     'entityConfig': {
                         type: 'cmEditor',
                         value: `{ queueName: "testQueue" }`,
-                        additionalProps: { clickLabel: true, switchMode: 'expression-mode', window: global.window }
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });
@@ -83,13 +83,13 @@ export default function createTests() {
                 values: {
                     'connectionString': {
                         type: 'cmEditor',
-                        value: 'Endpoint=sb://test.updated.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test',
-                        additionalProps: { clickLabel: true, switchMode: 'primary-mode', window: global.window }
+                        value: '"Endpoint=sb://test.updated.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"',
+                        additionalProps: { clickLabel: true }
                     },
                     'entityConfig': {
                         type: 'cmEditor',
                         value: `{ queueName: "updated-queue-name" }`,
-                        additionalProps: { clickLabel: true, switchMode: 'expression-mode', window: global.window }
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/azure.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/azure.spec.ts
@@ -52,6 +52,16 @@ export default function createTests() {
             // Dismiss expression helper popup triggered by CodeMirror focus before filling next field
             await page.page.keyboard.press('Escape');
             await page.page.waitForTimeout(300);
+            // entityConfig defaults to Record mode (controlled React component) where view.dispatch
+            // is immediately reset to {}. Switch to Expression mode first so the fill sticks.
+            const entityConfigContainer = artifactWebView.locator('[data-testid="ex-editor-entityConfig"]');
+            if (await entityConfigContainer.count() > 0) {
+                const exprModeBtn = entityConfigContainer.locator('[data-testid="expression-mode"]');
+                if (await exprModeBtn.count() > 0) {
+                    await exprModeBtn.click({ force: true });
+                    await page.page.waitForTimeout(300);
+                }
+            }
             await form.fill({
                 values: {
                     'entityConfig': {
@@ -61,7 +71,7 @@ export default function createTests() {
                     }
                 }
             });
-            await form.submit('Create');
+            await form.submit('Create', true);
 
             const projectExplorer = new ProjectExplorer(page.page);
             await projectExplorer.findItem([DEFAULT_PROJECT_NAME, `Azure Service Bus Event Integration`]);
@@ -98,6 +108,16 @@ export default function createTests() {
             // Dismiss expression helper popup triggered by CodeMirror focus before filling next field
             await page.page.keyboard.press('Escape');
             await page.page.waitForTimeout(300);
+            // entityConfig defaults to Record mode (controlled React component) where view.dispatch
+            // is immediately reset to {}. Switch to Expression mode first so the fill sticks.
+            const entityConfigContainerEdit = artifactWebView.locator('[data-testid="ex-editor-entityConfig"]');
+            if (await entityConfigContainerEdit.count() > 0) {
+                const exprModeBtnEdit = entityConfigContainerEdit.locator('[data-testid="expression-mode"]');
+                if (await exprModeBtnEdit.count() > 0) {
+                    await exprModeBtnEdit.click({ force: true });
+                    await page.page.waitForTimeout(300);
+                }
+            }
             await form.fill({
                 values: {
                     'entityConfig': {
@@ -107,7 +127,7 @@ export default function createTests() {
                     }
                 }
             });
-            await form.submit('Save Changes');
+            await form.submit('Save Changes', true);
 
             const saveChangesBtn = artifactWebView.locator('#save-changes-btn vscode-button[appearance="primary"]');
             await saveChangesBtn.waitFor({ state: 'visible' });

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/azure.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/azure.spec.ts
@@ -46,7 +46,14 @@ export default function createTests() {
                         type: 'cmEditor',
                         value: '"Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"',
                         additionalProps: { clickLabel: true }
-                    },
+                    }
+                }
+            });
+            // Dismiss expression helper popup triggered by CodeMirror focus before filling next field
+            await page.page.keyboard.press('Escape');
+            await page.page.waitForTimeout(300);
+            await form.fill({
+                values: {
                     'entityConfig': {
                         type: 'cmEditor',
                         value: `{ queueName: "testQueue" }`,
@@ -85,7 +92,14 @@ export default function createTests() {
                         type: 'cmEditor',
                         value: '"Endpoint=sb://test.updated.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"',
                         additionalProps: { clickLabel: true }
-                    },
+                    }
+                }
+            });
+            // Dismiss expression helper popup triggered by CodeMirror focus before filling next field
+            await page.page.keyboard.press('Escape');
+            await page.page.waitForTimeout(300);
+            await form.fill({
+                values: {
                     'entityConfig': {
                         type: 'cmEditor',
                         value: `{ queueName: "updated-queue-name" }`,

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/project-creation/project-creation.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/project-creation/project-creation.spec.ts
@@ -86,8 +86,8 @@ export default function createTests() {
             console.log('Waiting for project and BI webview');
             const testAttempt = testInfo.retry + 1;
             const artifactWebView = await getWebview(BI_INTEGRATOR_LABEL, page);
-            console.log('Waiting for project name to be visible');
-            await artifactWebView.locator(`text=${projectName}`).waitFor({ timeout: 40000 });
+            console.log('Waiting for integration name to be visible');
+            await artifactWebView.locator(`text=${integrationName}`).waitFor({ timeout: 40000 });
 
             console.log('Clicking on the integration name');
             // Click on the integration name ("testIntegration") directly from the BI webview project tree, not the project explorer

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test-function/test-function.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test-function/test-function.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import { test } from '@playwright/test';
-import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page } from '../utils/helpers';
+import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, getWebview, initTest, page } from '../utils/helpers';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
 
 export default function createTests() {
@@ -29,25 +29,29 @@ export default function createTests() {
             const testAttempt = testInfo.retry + 1;
             console.log('Creating test function in test attempt: ', testAttempt);
 
-            // 1. Execute command to add test function
+            // 1. Wait for the BI webview to be ready so StateMachine has the project path set
+            console.log('Waiting for BI webview to initialize...');
+            await getWebview(BI_INTEGRATOR_LABEL, page);
+
+            // 2. Execute command to add test function
             console.log('Executing command to add test function...');
             await page.executePaletteCommand('BI.test.add.function');
 
-            // 2. Get the webview after command execution
+            // 3. Get the webview after command execution
             const artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page, 30000);
             if (!artifactWebView) {
                 throw new Error(BI_WEBVIEW_NOT_FOUND_ERROR);
             }
 
-            // 3. Verify the "Create New Test Case" form is displayed
+            // 4. Verify the "Create New Test Case" form is displayed
             const createForm = artifactWebView.getByRole('heading', { name: /Create New Test Case/i });
-            await createForm.waitFor({ timeout: 10000 });
+            await createForm.waitFor({ timeout: 20000 });
 
-            // 4. Verify the form subtitle shows "Create a new test for your integration"
+            // 5. Verify the form subtitle shows "Create a new test for your integration"
             const subtitle = artifactWebView.getByText(/Create a new test for your integration/i);
             await subtitle.waitFor();
 
-            // 5. Fill the Test Function name field
+            // 6. Fill the Test Function name field
             const functionName = `testFunction${testAttempt}`;
             console.log(`Filling test function name: ${functionName}`);
 

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test-function/test-function.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test-function/test-function.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import { test } from '@playwright/test';
-import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, getWebview, initTest, page } from '../utils/helpers';
+import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page } from '../utils/helpers';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
 
 export default function createTests() {
@@ -29,29 +29,25 @@ export default function createTests() {
             const testAttempt = testInfo.retry + 1;
             console.log('Creating test function in test attempt: ', testAttempt);
 
-            // 1. Wait for the BI webview to be ready (ensures state machine has project path set)
-            console.log('Waiting for BI webview to be ready...');
-            await getWebview(BI_INTEGRATOR_LABEL, page);
-
-            // 2. Execute command to add test function
+            // 1. Execute command to add test function
             console.log('Executing command to add test function...');
             await page.executePaletteCommand('BI.test.add.function');
 
-            // 3. Get the webview after command execution
+            // 2. Get the webview after command execution
             const artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page, 30000);
             if (!artifactWebView) {
                 throw new Error(BI_WEBVIEW_NOT_FOUND_ERROR);
             }
 
-            // 4. Verify the "Create New Test Case" form is displayed
+            // 3. Verify the "Create New Test Case" form is displayed
             const createForm = artifactWebView.getByRole('heading', { name: /Create New Test Case/i });
-            await createForm.waitFor({ timeout: 20000 });
+            await createForm.waitFor({ timeout: 10000 });
 
-            // 5. Verify the form subtitle shows "Create a new test for your integration"
+            // 4. Verify the form subtitle shows "Create a new test for your integration"
             const subtitle = artifactWebView.getByText(/Create a new test for your integration/i);
             await subtitle.waitFor();
 
-            // Fill the Test Function name field
+            // 5. Fill the Test Function name field
             const functionName = `testFunction${testAttempt}`;
             console.log(`Filling test function name: ${functionName}`);
 

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test-function/test-function.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test-function/test-function.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import { test } from '@playwright/test';
-import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page } from '../utils/helpers';
+import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, getWebview, initTest, page } from '../utils/helpers';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
 
 export default function createTests() {
@@ -29,25 +29,29 @@ export default function createTests() {
             const testAttempt = testInfo.retry + 1;
             console.log('Creating test function in test attempt: ', testAttempt);
 
-            // 1. Execute command to add test function
+            // 1. Wait for the BI webview to be ready (ensures state machine has project path set)
+            console.log('Waiting for BI webview to be ready...');
+            await getWebview(BI_INTEGRATOR_LABEL, page);
+
+            // 2. Execute command to add test function
             console.log('Executing command to add test function...');
             await page.executePaletteCommand('BI.test.add.function');
 
-            // 2. Get the webview after command execution
+            // 3. Get the webview after command execution
             const artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page, 30000);
             if (!artifactWebView) {
                 throw new Error(BI_WEBVIEW_NOT_FOUND_ERROR);
             }
 
-            // 3. Verify the "Create New Test Case" form is displayed
+            // 4. Verify the "Create New Test Case" form is displayed
             const createForm = artifactWebView.getByRole('heading', { name: /Create New Test Case/i });
-            await createForm.waitFor({ timeout: 10000 });
+            await createForm.waitFor({ timeout: 20000 });
 
-            // 4. Verify the form subtitle shows "Create a new test for your integration"
+            // 5. Verify the form subtitle shows "Create a new test for your integration"
             const subtitle = artifactWebView.getByText(/Create a new test for your integration/i);
             await subtitle.waitFor();
 
-            // 5. Fill the Test Function name field
+            // Fill the Test Function name field
             const functionName = `testFunction${testAttempt}`;
             console.log(`Filling test function name: ${functionName}`);
 

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
@@ -58,6 +58,6 @@ export class SidePanel {
      */
     public async expandSection(sectionTitle: string): Promise<void> {
         const sectionContainer = this.getLocator().getByText(sectionTitle, { exact: true });
-        await sectionContainer.click();
+        await sectionContainer.click({ force: true });
     }
 }

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
@@ -58,6 +58,12 @@ export class SidePanel {
      */
     public async expandSection(sectionTitle: string): Promise<void> {
         const sectionContainer = this.getLocator().getByText(sectionTitle, { exact: true });
-        await sectionContainer.click({ force: true });
+        try {
+            await sectionContainer.click({ timeout: 5000 });
+        } catch {
+            // Fall back to force click if a VS Code overlay (e.g. notification popup)
+            // is blocking the element — this can occur on macOS but not on Linux CI.
+            await sectionContainer.click({ force: true });
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes four root causes of e2e test failures observed in [run #27112323958](https://github.com/wso2/ballerina-vscode/actions/runs/27112323958) (groups 1 and 4).

### Root cause 1 — `switchMode` in `form.fill()` triggers expression-helper popup

`_detectInputMode` in `playwright-vscode-tester` calls `containerDiv.hover()` to reveal mode-switcher buttons. On GitHub-hosted ubuntu runners, a CSS overlay (`css-1o4gefw`) intercepts the hover event and shows the expression-helper panel (Inputs/Variables/Configurables) instead. The popup stays open and blocks subsequent Save/Submit button clicks.

**Fix**: Remove `switchMode` from affected `form.fill()` calls and enter values as valid Ballerina expression-mode literals:
- `diagram.spec.ts` — Log Info `msg`: `'Equal'` → `'"Equal"'`, `'Not Equal'` → `'"Not Equal"'`
- `flow-nodes.spec.ts` — Log nodes: plain strings → quoted Ballerina string expressions; template literal already valid in expression mode
- `azure.spec.ts` — `connectionString`: bare string → quoted Ballerina string literal; `entityConfig` record expression already valid in expression mode

### Root cause 2 — `BI.test.add.function` command fails before `StateMachine` is ready

After `initTest()` reloads the VS Code window, `StateMachine.context().projectPath` may not be set yet when the palette command runs. `findProjectPath()` returns `undefined` and the command exits without navigating to the "Create New Test Case" form.

**Fix** (`test-function.spec.ts`): Await `getWebview()` before executing the palette command, which ensures the BI extension has fully initialized the project context.

### Root cause 3 — form timeout too tight for GitHub runners

`createForm.waitFor({ timeout: 10000 })` → `20000` to account for slower rendering on GitHub-hosted runners.

### Root cause 4 — Create Project test waited for project name instead of integration name (already merged in PR #641)

Ported in commit `c8d68216`.

## Test plan

- [ ] Trigger daily build / `runBalE2ETests: true` and verify group1 and group4 pass
- [ ] Confirm `flow-nodes.spec.ts` — `log:printError("sample error log")` and `log:printWarn("sample warn log")` still appear in generated `automation.bal` source (quotes are preserved correctly in the expression-mode CodeMirror dispatch)