### PR TITLE
Normalize tool-call inputs to prevent `tool_use.input` string bug

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -21,7 +21,7 @@ import { Command, GenerateAgentCodeRequest, ProjectSource, ExecutionContext, Sem
 import { StateMachine } from '../../../stateMachine';
 import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, addCacheControlToMessages, ANTHROPIC_SONNET_4 } from '../utils/ai-client';
-import { populateHistoryForAgent, getErrorMessage } from '../utils/ai-utils';
+import { populateHistoryForAgent, normalizeToolCallInputs, getErrorMessage } from '../utils/ai-utils';
 import { sendAgentDidOpenForFreshProjects } from '../utils/project/ls-schema-notifications';
 import { getSystemPrompt, getUserPrompt } from './prompts';
 import { GenerationType } from '../utils/libs/libraries';
@@ -363,6 +363,7 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                     if (cleanedCompactionSummary) {
                         stripAnalysisFromCompactionBlocks(stepMessages);
                     }
+                    normalizeToolCallInputs(stepMessages);
                     return { messages: addCacheControlToMessages({ messages: stepMessages, model }) };
                 },
 

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -76,6 +76,52 @@ export function populateHistoryForAgent(chatHistory: any[]): ModelMessage[] {
             });
         }
     }
+    normalizeToolCallInputs(messages);
+    return messages;
+}
+
+/**
+ * Ensures every `tool-call` content block in assistant messages has `input` as a
+ * plain object instead of a JSON string. The Anthropic API rejects requests where
+ * `tool_use.input` is not an object; this can happen when the SDK accumulates a
+ * streaming tool call whose JSON delta fails schema validation and the raw string
+ * leaks through `doParseToolCall`'s error path.
+ *
+ * Mutates the messages array in place and returns it for chaining.
+ */
+export function normalizeToolCallInputs(messages: any[]): any[] {
+    let fixed = 0;
+    for (const message of messages) {
+        if (message?.role !== 'assistant' || !Array.isArray(message.content)) {
+            continue;
+        }
+        for (const block of message.content) {
+            if (block?.type !== 'tool-call') {
+                continue;
+            }
+            const input = block.input;
+            if (input !== null && typeof input === 'object') {
+                continue;
+            }
+            if (typeof input === 'string') {
+                try {
+                    const parsed = JSON.parse(input);
+                    if (parsed !== null && typeof parsed === 'object') {
+                        block.input = parsed;
+                        fixed++;
+                        continue;
+                    }
+                } catch {
+                    // fall through to empty-object fallback
+                }
+            }
+            block.input = {};
+            fixed++;
+        }
+    }
+    if (fixed > 0) {
+        console.warn(`[normalizeToolCallInputs] Fixed ${fixed} tool-call block(s) with non-object input — likely a streaming JSON parse failure in the AI SDK.`);
+    }
     return messages;
 }
 


### PR DESCRIPTION
$subject.

Added `normalizeToolCallInputs()` in `ai-utils.ts`, a defensive guard that walks every assistant message before it is sent to the API, finds any `tool-call` block where `input` is a string (or null/undefined), tries `JSON.parse()` to recover the object, and falls back to `{}` if that also fails. Called in two places:

- `prepareStep` in `AgentExecutor.ts`: covers SDK-accumulated messages during in-step streaming (the main failure path).
-  `populateHistoryForAgent` in `ai-utils.ts`: covers cross-stage AI Chat history loaded from `chatStateStorage`.

Fixes https://github.com/wso2/product-integrator/issues/1741