### PR TITLE
fix(bi-diagram): correct SendDataNode title from 'Sent to' to 'Send to'

### DIFF
--- a/packages/bi-diagram/src/components/nodes/SendDataNode/SendDataNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/SendDataNode/SendDataNodeWidget.tsx
@@ -239,7 +239,7 @@ export function SendDataNodeWidget(props: SendDataNodeWidgetProps) {
     const workflowName = getWorkflowName(
         (workflowProperty?.value as string | undefined) ?? connectionValue ?? fallbackWorkflowValue
     );
-    const nodeTitle = dataName ? `Sent to ${dataName}` : "Send Data";
+    const nodeTitle = dataName ? `Send to ${dataName}` : "Send Data";
     const canViewWorkflow = Boolean(workflowName);
 
     useEffect(() => {


### PR DESCRIPTION
Fix a typo in the SendDataNode widget where the node title was using past tense 'Sent to' instead of present tense 'Send to'.