### PR TITLE
Improve LS test stability and fix dependency version drift

### DIFF
--- a/.github/actions/ls-test/action.yml
+++ b/.github/actions/ls-test/action.yml
@@ -40,7 +40,6 @@ runs:
         key: ${{ runner.os }}-ballerina-${{ inputs.cache-branch }}-${{ hashFiles('**/gradle.properties') }}
         restore-keys: |
           ${{ runner.os }}-ballerina-${{ inputs.cache-branch }}-
-          ${{ runner.os }}-ballerina-
 
     - name: Test with Gradle
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,6 +355,6 @@ jobs:
       - name: Run LS tests
         uses: ./.github/actions/ls-test
         with:
-          cache-branch: ${{ github.ref_name }}
+          cache-branch: ${{ github.base_ref || github.ref_name }}
           package-user: ${{ github.actor }}
           package-pat: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/java/io/ballerina/designmodelgenerator/extension/PublishArtifactsSubscriberTest.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/java/io/ballerina/designmodelgenerator/extension/PublishArtifactsSubscriberTest.java
@@ -408,7 +408,7 @@ public class PublishArtifactsSubscriberTest extends AbstractLSTest {
         String packageName = artifactsParams.packageName();
         String moduleName = artifactsParams.moduleName();
 
-        if (!publishedArtifacts.equals(expectedArtifacts) ||
+        if (!isJsonPermutation(gson.toJsonTree(publishedArtifacts), gson.toJsonTree(expectedArtifacts)) ||
                 !Objects.equals(packageName, testConfig.packageName()) ||
                 !Objects.equals(moduleName, testConfig.moduleName())) {
             TestConfig updatedConfig = new TestConfig(testConfig.source(), testConfig.description(),

--- a/packages/ballerina-language-server/build.gradle
+++ b/packages/ballerina-language-server/build.gradle
@@ -87,6 +87,7 @@ subprojects {
         ballerinaStdLibs "io.ballerina.stdlib:auth-ballerina:${stdlibAuthVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:oauth2-ballerina:${stdlibOAuth2Version}"
         ballerinaStdLibs "io.ballerina.lib:data.jsondata-ballerina:${stdlibJsonDataVersion}"
+        ballerinaStdLibs "io.ballerina.lib:data.xmldata-ballerina:${stdlibXmlDataVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:http-ballerina:${stdlibHttpVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:graphql-ballerina:${stdlibGraphqlVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:sql-ballerina:${stdLibSqlVersion}"

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_1.json
@@ -1000,7 +1000,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1104,7 +1104,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1141,7 +1141,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1234,7 +1234,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1271,7 +1271,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1308,7 +1308,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1386,49 +1386,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1465,7 +1465,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1502,7 +1502,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1539,7 +1539,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1576,7 +1576,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1613,7 +1613,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1678,7 +1678,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1743,7 +1743,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1859,7 +1859,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1963,7 +1963,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2000,7 +2000,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2093,7 +2093,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2130,7 +2130,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2167,7 +2167,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2245,49 +2245,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2324,7 +2324,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2361,7 +2361,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2398,7 +2398,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2435,7 +2435,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2472,7 +2472,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2537,7 +2537,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2602,7 +2602,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2965,7 +2965,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3005,7 +3005,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3101,7 +3101,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3141,7 +3141,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3225,7 +3225,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3265,7 +3265,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3305,7 +3305,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3345,7 +3345,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3385,7 +3385,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_2.json
@@ -1010,7 +1010,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1114,7 +1114,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1151,7 +1151,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1244,7 +1244,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1281,7 +1281,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1318,7 +1318,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1396,49 +1396,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1475,7 +1475,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1512,7 +1512,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1549,7 +1549,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1586,7 +1586,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1623,7 +1623,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1688,7 +1688,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1753,7 +1753,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1869,7 +1869,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1973,7 +1973,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2010,7 +2010,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2103,7 +2103,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2140,7 +2140,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2177,7 +2177,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2255,49 +2255,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2334,7 +2334,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2371,7 +2371,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2408,7 +2408,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2445,7 +2445,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2482,7 +2482,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2547,7 +2547,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2612,7 +2612,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2975,7 +2975,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3015,7 +3015,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3111,7 +3111,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3151,7 +3151,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3235,7 +3235,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3275,7 +3275,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3315,7 +3315,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3355,7 +3355,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3395,7 +3395,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_3.json
@@ -1000,7 +1000,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1104,7 +1104,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1141,7 +1141,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1234,7 +1234,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1271,7 +1271,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1308,7 +1308,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1386,49 +1386,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1465,7 +1465,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1502,7 +1502,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1539,7 +1539,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1576,7 +1576,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1613,7 +1613,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1678,7 +1678,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1743,7 +1743,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1859,7 +1859,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1963,7 +1963,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2000,7 +2000,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2093,7 +2093,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2130,7 +2130,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2167,7 +2167,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2245,49 +2245,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2324,7 +2324,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2361,7 +2361,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2398,7 +2398,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2435,7 +2435,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2472,7 +2472,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2537,7 +2537,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2602,7 +2602,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2974,7 +2974,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3014,7 +3014,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3110,7 +3110,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3150,7 +3150,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3234,7 +3234,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3274,7 +3274,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3314,7 +3314,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3354,7 +3354,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3394,7 +3394,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_4.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/agent_call_flow_node_4.json
@@ -1259,7 +1259,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1299,7 +1299,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1395,7 +1395,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1435,7 +1435,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1519,7 +1519,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1559,7 +1559,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1599,7 +1599,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1639,7 +1639,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1679,7 +1679,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/available_agents.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/agents_manager/config/available_agents.json
@@ -53,7 +53,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -62,7 +62,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -72,7 +72,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -81,7 +81,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -91,7 +91,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -100,7 +100,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -110,7 +110,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -119,7 +119,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -129,7 +129,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -138,7 +138,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -148,7 +148,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -157,7 +157,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -167,7 +167,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -176,7 +176,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -186,7 +186,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -195,7 +195,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -205,7 +205,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -214,7 +214,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -224,7 +224,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -233,7 +233,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -243,7 +243,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -252,7 +252,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -262,7 +262,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -271,7 +271,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -281,7 +281,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -290,7 +290,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -300,7 +300,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -309,7 +309,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -319,7 +319,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -328,7 +328,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -338,7 +338,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -347,7 +347,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -357,7 +357,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -366,7 +366,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -376,7 +376,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -385,7 +385,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -395,7 +395,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -404,7 +404,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClient",
                 "resourcePath": ""
               },
@@ -424,7 +424,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -433,7 +433,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -443,7 +443,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -452,7 +452,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -462,7 +462,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -471,7 +471,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -481,7 +481,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -490,7 +490,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -500,7 +500,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -509,7 +509,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -519,7 +519,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -528,7 +528,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -538,7 +538,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -547,7 +547,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -557,7 +557,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -566,7 +566,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -576,7 +576,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -585,7 +585,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -595,7 +595,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -604,7 +604,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -614,7 +614,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -623,7 +623,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -633,7 +633,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -642,7 +642,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -652,7 +652,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -661,7 +661,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -671,7 +671,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -680,7 +680,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -690,7 +690,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -699,7 +699,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -709,7 +709,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -718,7 +718,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -728,7 +728,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -737,7 +737,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -747,7 +747,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -756,7 +756,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },
@@ -766,7 +766,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -775,7 +775,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "httpClientResult",
                 "resourcePath": ""
               },

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/caller.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/caller.json
@@ -24,7 +24,7 @@
               "metadata": {
                 "label": "respond",
                 "description": "Sends the outbound response to the caller.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -33,7 +33,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "respond",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -43,7 +43,7 @@
               "metadata": {
                 "label": "promise",
                 "description": "Pushes a promise to the caller.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -52,7 +52,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "promise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -62,7 +62,7 @@
               "metadata": {
                 "label": "pushPromisedResponse",
                 "description": "Sends a promised push response to the caller.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -71,7 +71,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "pushPromisedResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -81,7 +81,7 @@
               "metadata": {
                 "label": "'continue",
                 "description": "Sends a `100-continue` response to the caller.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -90,7 +90,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "'continue",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -100,7 +100,7 @@
               "metadata": {
                 "label": "redirect",
                 "description": "Sends a redirect response to the user with the specified redirection status code.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -109,7 +109,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "redirect",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },
@@ -119,7 +119,7 @@
               "metadata": {
                 "label": "getRemoteHostName",
                 "description": "Gets the hostname from the remote address. This method may trigger a DNS reverse lookup if the address was created\nwith a literal IP address.\n```ballerina\nstring? remoteHost = caller.getRemoteHostName();\n```\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -128,7 +128,7 @@
                 "packageName": "http",
                 "object": "Caller",
                 "symbol": "getRemoteHostName",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "caller",
                 "resourcePath": ""
               },

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/connector1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/connector1.json
@@ -24,7 +24,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -33,7 +33,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -43,7 +43,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -52,7 +52,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -62,7 +62,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -71,7 +71,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -81,7 +81,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -90,7 +90,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -100,7 +100,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -109,7 +109,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -119,7 +119,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -128,7 +128,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -138,7 +138,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -147,7 +147,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -157,7 +157,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -166,7 +166,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -176,7 +176,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -185,7 +185,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -195,7 +195,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -204,7 +204,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -214,7 +214,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -223,7 +223,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -233,7 +233,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -242,7 +242,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -252,7 +252,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -261,7 +261,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -271,7 +271,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -280,7 +280,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -290,7 +290,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -299,7 +299,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -309,7 +309,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -318,7 +318,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -328,7 +328,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -337,7 +337,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -347,7 +347,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -356,7 +356,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -366,7 +366,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -375,7 +375,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/connector2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/connector2.json
@@ -24,7 +24,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -33,7 +33,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -43,7 +43,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -52,7 +52,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -62,7 +62,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -71,7 +71,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -81,7 +81,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -90,7 +90,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -100,7 +100,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -109,7 +109,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -119,7 +119,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -128,7 +128,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -138,7 +138,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -147,7 +147,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -157,7 +157,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -166,7 +166,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -176,7 +176,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -185,7 +185,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -195,7 +195,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -204,7 +204,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -214,7 +214,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -223,7 +223,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -233,7 +233,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -242,7 +242,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -252,7 +252,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -261,7 +261,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -271,7 +271,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -280,7 +280,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -290,7 +290,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -299,7 +299,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -309,7 +309,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -318,7 +318,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -328,7 +328,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -337,7 +337,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -347,7 +347,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -356,7 +356,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },
@@ -366,7 +366,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -375,7 +375,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": ""
               },

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/tool_compatibility.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/config/tool_compatibility.json
@@ -24,7 +24,7 @@
               "metadata": {
                 "label": "get",
                 "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -33,7 +33,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "get",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -46,7 +46,7 @@
               "metadata": {
                 "label": "post",
                 "description": "Create a new resource or submit data to a resource for processing.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -55,7 +55,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "post",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -68,7 +68,7 @@
               "metadata": {
                 "label": "put",
                 "description": "Create a new resource or replace a representation of a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -77,7 +77,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "put",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -90,7 +90,7 @@
               "metadata": {
                 "label": "delete",
                 "description": "Remove a specified resource from an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -99,7 +99,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "delete",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -112,7 +112,7 @@
               "metadata": {
                 "label": "patch",
                 "description": "Partially update an existing resource in an HTTP endpoint.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -121,7 +121,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "patch",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -134,7 +134,7 @@
               "metadata": {
                 "label": "head",
                 "description": "Get the metadata of a resource in the form of headers without the body. Often used for testing the resource existence or finding recent modifications.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -143,7 +143,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "head",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -156,7 +156,7 @@
               "metadata": {
                 "label": "options",
                 "description": "Get the communication options for a specified resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -165,7 +165,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "options",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -178,7 +178,7 @@
               "metadata": {
                 "label": "execute",
                 "description": "Send a request using any HTTP method. Can be used to invoke the endpoint with a custom or less common HTTP method.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -187,7 +187,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "execute",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -200,7 +200,7 @@
               "metadata": {
                 "label": "forward",
                 "description": "Forward an incoming request to another endpoint using the same HTTP method. Can be used in proxy or gateway scenarios.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -209,7 +209,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "forward",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -222,7 +222,7 @@
               "metadata": {
                 "label": "submit",
                 "description": "Send an asynchronous HTTP request that does not wait for the response immediately. Can be used for non-blocking operations.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -231,7 +231,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "submit",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -244,7 +244,7 @@
               "metadata": {
                 "label": "getResponse",
                 "description": "Get the response from a previously submitted asynchronous request. Can be used after calling `submit()` action to retrieve the actual response.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -253,7 +253,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -266,7 +266,7 @@
               "metadata": {
                 "label": "hasPromise",
                 "description": "Check if the server has sent a push promise for additional resources. Should be used with HTTP/2 server push functionality.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -275,7 +275,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "hasPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -288,7 +288,7 @@
               "metadata": {
                 "label": "getNextPromise",
                 "description": "Get the next server push promise that contains information about additional resources the server wants to send.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -297,7 +297,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getNextPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -310,7 +310,7 @@
               "metadata": {
                 "label": "getPromisedResponse",
                 "description": "Get the actual response data from a server push promise. Can be used to receive resources that the server proactively sends.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -319,7 +319,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getPromisedResponse",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -332,7 +332,7 @@
               "metadata": {
                 "label": "rejectPromise",
                 "description": "Reject a server push promise to decline receiving the additional resource.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "REMOTE_ACTION_CALL",
@@ -341,7 +341,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "rejectPromise",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -354,7 +354,7 @@
               "metadata": {
                 "label": "getCookieStore",
                 "description": "Get the cookie storage associated with this HTTP client. Can be used to access stored cookies for session management.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -363,7 +363,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCookieStore",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -376,7 +376,7 @@
               "metadata": {
                 "label": "circuitBreakerForceClose",
                 "description": "Force the circuit breaker to allow all requests through, ignoring current error rates. Can be used to manually\nrestore service after fixing issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -385,7 +385,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceClose",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -398,7 +398,7 @@
               "metadata": {
                 "label": "circuitBreakerForceOpen",
                 "description": "Force the circuit breaker to block all requests until the reset time expires. Can be used to manually stop\nrequests during maintenance or known issues.",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -407,7 +407,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "circuitBreakerForceOpen",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {
@@ -420,7 +420,7 @@
               "metadata": {
                 "label": "getCircuitBreakerCurrentState",
                 "description": "Check the current state of the circuit breaker. Can be used to monitor the health status of your HTTP connections.\n",
-                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
               },
               "codedata": {
                 "node": "METHOD_CALL",
@@ -429,7 +429,7 @@
                 "packageName": "http",
                 "object": "Client",
                 "symbol": "getCircuitBreakerCurrentState",
-                "version": "2.16.3",
+                "version": "2.16.4",
                 "parentSymbol": "moduleClient",
                 "resourcePath": "",
                 "data": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj13.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj13.json
@@ -40,7 +40,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.3_  \n  \nSends the outbound response to the caller.\n  \n**Params**  \n- `http:ResponseMessage|http:StatusCodeResponse|error` message: The outbound response or status code response or error or any allowed payload(Defaultable)  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to respond or else `()`  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.4_  \n  \nSends the outbound response to the caller.\n  \n**Params**  \n- `http:ResponseMessage|http:StatusCodeResponse|error` message: The outbound response or status code response or error or any allowed payload(Defaultable)  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to respond or else `()`  \n  \n"
         }
       },
       "sortText": "AD",
@@ -59,7 +59,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.3_  \n  \nPushes a promise to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` in case of failures  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.4_  \n  \nPushes a promise to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` in case of failures  \n  \n"
         }
       },
       "sortText": "AE",
@@ -78,7 +78,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.3_  \n  \nSends a promised push response to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n- `http:Response` response: The outbound response  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` in case of failures while responding with the promised response  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.4_  \n  \nSends a promised push response to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n- `http:Response` response: The outbound response  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` in case of failures while responding with the promised response  \n  \n"
         }
       },
       "sortText": "AF",
@@ -97,7 +97,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.3_  \n  \nSends a `100-continue` response to the caller.\n  \n  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to send the `100-continue` response or else `()`  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.4_  \n  \nSends a `100-continue` response to the caller.\n  \n  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to send the `100-continue` response or else `()`  \n  \n"
         }
       },
       "sortText": "AG",
@@ -112,7 +112,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http:2.16.3_  \n  \nSends a redirect response to the user with the specified redirection status code.\n  \n**Params**  \n- `http:Response` response: Response to be sent to the caller  \n- `http:RedirectCode` code: The redirect status code to be sent  \n- `string[]` locations: An array of URLs to which the caller can redirect to  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to send the redirect response or else `()`  \n  \n"
+          "value": "**Package:** _ballerina/http:2.16.4_  \n  \nSends a redirect response to the user with the specified redirection status code.\n  \n**Params**  \n- `http:Response` response: Response to be sent to the caller  \n- `http:RedirectCode` code: The redirect status code to be sent  \n- `string[]` locations: An array of URLs to which the caller can redirect to  \n  \n**Return** `http:ListenerError?`   \n- An `http:ListenerError` if failed to send the redirect response or else `()`  \n  \n"
         }
       },
       "sortText": "AH",

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables_v2_get/config/config2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables_v2_get/config/config2.json
@@ -1173,7 +1173,7 @@
                   "typeMembers": [
                     {
                       "type": "ListenerConfiguration",
-                      "packageInfo": "ballerina:http:2.16.3",
+                      "packageInfo": "ballerina:http:2.16.4",
                       "packageName": "http",
                       "kind": "RECORD_TYPE",
                       "selected": false
@@ -1421,7 +1421,7 @@
                   "typeMembers": [
                     {
                       "type": "TraceLogAdvancedConfiguration",
-                      "packageInfo": "ballerina:http:2.16.3",
+                      "packageInfo": "ballerina:http:2.16.4",
                       "packageName": "http",
                       "kind": "RECORD_TYPE",
                       "selected": false
@@ -1545,7 +1545,7 @@
                   "typeMembers": [
                     {
                       "type": "AccessLogConfiguration",
-                      "packageInfo": "ballerina:http:2.16.3",
+                      "packageInfo": "ballerina:http:2.16.4",
                       "packageName": "http",
                       "kind": "RECORD_TYPE",
                       "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/function_call2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/function_call2.json
@@ -52,7 +52,7 @@
       "code": {
         "left": "BCE2066"
       },
-      "message": "incompatible types: expected 'ballerina/time:2.8.0:Civil', found 'int'"
+      "message": "incompatible types: expected 'ballerina/time:2.8.1:Civil', found 'int'"
     }
   ]
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/agent_with_backticks_in_system_prompt.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/agent_with_backticks_in_system_prompt.json
@@ -1309,7 +1309,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1349,7 +1349,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1445,7 +1445,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1485,7 +1485,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1569,7 +1569,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1609,7 +1609,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1649,7 +1649,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1689,7 +1689,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1729,7 +1729,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/chat_agent.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/chat_agent.json
@@ -1309,7 +1309,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1349,7 +1349,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1445,7 +1445,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1485,7 +1485,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1569,7 +1569,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1609,7 +1609,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1649,7 +1649,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1689,7 +1689,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1729,7 +1729,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/class_field_init_from_param.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/class_field_init_from_param.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -151,7 +151,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -188,7 +188,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -281,7 +281,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -318,7 +318,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -355,7 +355,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -433,49 +433,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -512,7 +512,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -549,7 +549,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -586,7 +586,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -623,7 +623,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -660,7 +660,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -725,7 +725,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -790,7 +790,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -55,7 +55,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -339,7 +339,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -402,7 +402,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -518,7 +518,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -527,7 +527,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -970,7 +970,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1033,7 +1033,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
@@ -856,7 +856,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -865,7 +865,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.16.3",
+                          "version": "2.16.4",
                           "lineRange": {
                             "fileName": "main.bal",
                             "startLine": {
@@ -2222,7 +2222,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -2326,7 +2326,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2363,7 +2363,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2456,7 +2456,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2493,7 +2493,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2530,7 +2530,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2608,49 +2608,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2687,7 +2687,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2724,7 +2724,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2761,7 +2761,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2798,7 +2798,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2835,7 +2835,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2900,7 +2900,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2965,7 +2965,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter2.json
@@ -95,7 +95,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -199,7 +199,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -236,7 +236,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -329,7 +329,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -366,7 +366,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -403,7 +403,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -481,49 +481,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -560,7 +560,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -597,7 +597,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -634,7 +634,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -671,7 +671,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -708,7 +708,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -773,7 +773,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -838,7 +838,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
@@ -1014,7 +1014,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1118,7 +1118,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1155,7 +1155,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1248,7 +1248,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1285,7 +1285,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1322,7 +1322,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1400,49 +1400,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1479,7 +1479,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1516,7 +1516,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1553,7 +1553,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1590,7 +1590,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1627,7 +1627,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1692,7 +1692,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1757,7 +1757,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
@@ -181,7 +181,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -190,7 +190,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -571,7 +571,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -675,7 +675,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -712,7 +712,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -805,7 +805,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -842,7 +842,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -879,7 +879,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -957,49 +957,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1036,7 +1036,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1073,7 +1073,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1110,7 +1110,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1147,7 +1147,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1184,7 +1184,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1249,7 +1249,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1314,7 +1314,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
@@ -181,7 +181,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -190,7 +190,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -607,7 +607,7 @@
                         "metadata": {
                           "label": "post",
                           "description": "Create a new resource or submit data to a resource for processing.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -616,7 +616,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "post",
-                          "version": "2.16.3",
+                          "version": "2.16.4",
                           "lineRange": {
                             "fileName": "error_handler.bal",
                             "startLine": {
@@ -1071,7 +1071,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1175,7 +1175,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1212,7 +1212,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1305,7 +1305,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1342,7 +1342,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1379,7 +1379,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1457,49 +1457,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1536,7 +1536,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1573,7 +1573,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1610,7 +1610,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1647,7 +1647,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1684,7 +1684,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1749,7 +1749,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1814,7 +1814,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
@@ -90,7 +90,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -99,7 +99,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -501,7 +501,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -605,7 +605,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -642,7 +642,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -735,7 +735,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -772,7 +772,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -809,7 +809,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -887,49 +887,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -966,7 +966,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1003,7 +1003,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1040,7 +1040,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1114,7 +1114,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1179,7 +1179,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1244,7 +1244,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -399,7 +399,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -503,7 +503,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -540,7 +540,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -633,7 +633,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -670,7 +670,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -707,7 +707,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -785,49 +785,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -864,7 +864,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -901,7 +901,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -938,7 +938,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -975,7 +975,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1012,7 +1012,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1142,7 +1142,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -399,7 +399,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -503,7 +503,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -540,7 +540,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -633,7 +633,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -670,7 +670,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -707,7 +707,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -785,49 +785,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -864,7 +864,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -901,7 +901,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -938,7 +938,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -975,7 +975,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1012,7 +1012,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1142,7 +1142,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
@@ -467,7 +467,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -476,7 +476,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
@@ -1119,7 +1119,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1223,7 +1223,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1260,7 +1260,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1353,7 +1353,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1390,7 +1390,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1427,7 +1427,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1505,49 +1505,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1584,7 +1584,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1621,7 +1621,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1658,7 +1658,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1695,7 +1695,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1732,7 +1732,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1797,7 +1797,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1862,7 +1862,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
@@ -1293,7 +1293,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1397,7 +1397,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1434,7 +1434,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1527,7 +1527,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1564,7 +1564,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1601,7 +1601,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1679,49 +1679,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1758,7 +1758,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1795,7 +1795,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1832,7 +1832,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1869,7 +1869,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1906,7 +1906,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1971,7 +1971,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2036,7 +2036,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
@@ -418,7 +418,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -522,7 +522,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -559,7 +559,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -652,7 +652,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -689,7 +689,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -726,7 +726,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -804,49 +804,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -883,7 +883,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -920,7 +920,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -957,7 +957,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -994,7 +994,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1031,7 +1031,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1096,7 +1096,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1161,7 +1161,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
@@ -401,7 +401,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -505,7 +505,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -542,7 +542,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -635,7 +635,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -672,7 +672,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -709,7 +709,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -787,49 +787,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -866,7 +866,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -903,7 +903,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -940,7 +940,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -977,7 +977,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1014,7 +1014,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1079,7 +1079,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1144,7 +1144,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
@@ -525,7 +525,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -629,7 +629,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -666,7 +666,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -759,7 +759,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -796,7 +796,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -833,7 +833,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -911,49 +911,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -990,7 +990,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1027,7 +1027,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1064,7 +1064,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1101,7 +1101,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1138,7 +1138,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1203,7 +1203,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1268,7 +1268,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -689,7 +689,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -793,7 +793,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -830,7 +830,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -923,7 +923,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -960,7 +960,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -997,7 +997,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1075,49 +1075,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1154,7 +1154,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1191,7 +1191,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1228,7 +1228,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1265,7 +1265,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1302,7 +1302,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1367,7 +1367,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1432,7 +1432,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
@@ -579,7 +579,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -683,7 +683,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -720,7 +720,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -813,7 +813,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -850,7 +850,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -887,7 +887,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -965,49 +965,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1044,7 +1044,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1081,7 +1081,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1118,7 +1118,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1155,7 +1155,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1192,7 +1192,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1257,7 +1257,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1322,7 +1322,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
@@ -315,7 +315,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -419,7 +419,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -456,7 +456,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -549,7 +549,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -586,7 +586,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -623,7 +623,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -701,49 +701,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -780,7 +780,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -817,7 +817,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -854,7 +854,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -891,7 +891,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -928,7 +928,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -993,7 +993,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1058,7 +1058,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
@@ -293,7 +293,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -397,7 +397,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -434,7 +434,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -527,7 +527,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -564,7 +564,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -601,7 +601,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -679,49 +679,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -758,7 +758,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -795,7 +795,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -832,7 +832,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -869,7 +869,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -906,7 +906,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -971,7 +971,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1036,7 +1036,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
@@ -449,7 +449,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -553,7 +553,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -590,7 +590,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -683,7 +683,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -720,7 +720,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -757,7 +757,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -835,49 +835,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -914,7 +914,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -951,7 +951,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -988,7 +988,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1025,7 +1025,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1062,7 +1062,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1127,7 +1127,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1192,7 +1192,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
@@ -535,7 +535,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -639,7 +639,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -676,7 +676,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -769,7 +769,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -806,7 +806,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -843,7 +843,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -921,49 +921,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1000,7 +1000,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1037,7 +1037,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1074,7 +1074,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1111,7 +1111,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1148,7 +1148,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1213,7 +1213,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1278,7 +1278,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
@@ -363,7 +363,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -467,7 +467,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -504,7 +504,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -597,7 +597,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -634,7 +634,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -671,7 +671,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -749,49 +749,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -828,7 +828,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -865,7 +865,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -902,7 +902,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -939,7 +939,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -976,7 +976,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1041,7 +1041,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1106,7 +1106,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
@@ -418,7 +418,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -522,7 +522,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -559,7 +559,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -652,7 +652,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -689,7 +689,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -726,7 +726,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -804,49 +804,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -883,7 +883,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -920,7 +920,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -957,7 +957,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -994,7 +994,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1031,7 +1031,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1096,7 +1096,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1161,7 +1161,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call_time.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call_time.json
@@ -45,8 +45,8 @@
         "id": "34897",
         "metadata": {
           "label": "loadSystemZone",
-          "description": "Load the default time zone of the system.\n```ballerina\ntime:Zone|time:Error zone = time:loadSystemZone();\n```",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_time_2.8.0.png"
+          "description": "Loads the default time zone of the system.\n```ballerina\ntime:Zone|time:Error zone = time:loadSystemZone();\n```",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_time_2.8.1.png"
         },
         "codedata": {
           "node": "FUNCTION_CALL",
@@ -54,7 +54,7 @@
           "module": "time",
           "packageName": "time",
           "symbol": "loadSystemZone",
-          "version": "2.8.0",
+          "version": "2.8.1",
           "lineRange": {
             "fileName": "method_call_time.bal",
             "startLine": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
@@ -92,7 +92,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -196,7 +196,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -233,7 +233,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -326,7 +326,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -363,7 +363,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -400,7 +400,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -478,49 +478,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -557,7 +557,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -594,7 +594,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -631,7 +631,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -668,7 +668,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -705,7 +705,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -770,7 +770,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -835,7 +835,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
@@ -157,7 +157,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -166,7 +166,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.16.3",
+                          "version": "2.16.4",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -420,7 +420,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -429,7 +429,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.16.3",
+                          "version": "2.16.4",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -748,7 +748,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -852,7 +852,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -889,7 +889,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -982,7 +982,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1056,7 +1056,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1134,49 +1134,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1213,7 +1213,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1250,7 +1250,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1287,7 +1287,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1324,7 +1324,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1361,7 +1361,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1426,7 +1426,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1491,7 +1491,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
@@ -91,7 +91,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -195,7 +195,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -232,7 +232,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -325,7 +325,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -362,7 +362,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -399,7 +399,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -477,49 +477,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -556,7 +556,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -593,7 +593,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -630,7 +630,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -667,7 +667,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -704,7 +704,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -769,7 +769,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -834,7 +834,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
@@ -92,7 +92,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -196,7 +196,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -233,7 +233,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -326,7 +326,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -363,7 +363,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -400,7 +400,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -478,49 +478,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -557,7 +557,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -594,7 +594,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -631,7 +631,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -668,7 +668,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -705,7 +705,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -770,7 +770,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -835,7 +835,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
@@ -92,7 +92,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -196,7 +196,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -233,7 +233,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -326,7 +326,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -363,7 +363,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -400,7 +400,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -478,49 +478,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -557,7 +557,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -594,7 +594,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -631,7 +631,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -668,7 +668,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -705,7 +705,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -770,7 +770,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -835,7 +835,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node6.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node6.json
@@ -404,7 +404,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -508,7 +508,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -545,7 +545,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -638,7 +638,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -675,7 +675,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -712,7 +712,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -790,49 +790,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -869,7 +869,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -906,7 +906,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -943,7 +943,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -980,7 +980,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1017,7 +1017,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1082,7 +1082,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1147,7 +1147,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -150,7 +150,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -187,7 +187,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -280,7 +280,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -317,7 +317,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -354,7 +354,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -432,49 +432,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -511,7 +511,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -548,7 +548,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -585,7 +585,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -622,7 +622,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -659,7 +659,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -724,7 +724,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -789,7 +789,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1156,7 +1156,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1219,7 +1219,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1335,7 +1335,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1398,7 +1398,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1514,7 +1514,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1618,7 +1618,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1655,7 +1655,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1748,7 +1748,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1785,7 +1785,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1822,7 +1822,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1900,49 +1900,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1979,7 +1979,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2016,7 +2016,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2053,7 +2053,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2090,7 +2090,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2127,7 +2127,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2192,7 +2192,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2257,7 +2257,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -150,7 +150,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -187,7 +187,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -280,7 +280,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -317,7 +317,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -354,7 +354,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -432,49 +432,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -511,7 +511,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -548,7 +548,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -585,7 +585,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -622,7 +622,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -659,7 +659,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -724,7 +724,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -789,7 +789,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1156,7 +1156,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1219,7 +1219,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1335,7 +1335,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1398,7 +1398,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1514,7 +1514,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1618,7 +1618,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1655,7 +1655,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1748,7 +1748,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1785,7 +1785,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1822,7 +1822,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1900,49 +1900,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1979,7 +1979,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2016,7 +2016,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2053,7 +2053,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2090,7 +2090,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2127,7 +2127,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2192,7 +2192,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2257,7 +2257,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
@@ -48,7 +48,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -111,7 +111,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -227,7 +227,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -290,7 +290,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -406,7 +406,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -510,7 +510,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -547,7 +547,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -640,7 +640,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -677,7 +677,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -714,7 +714,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -792,49 +792,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -871,7 +871,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -908,7 +908,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -945,7 +945,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -982,7 +982,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1084,7 +1084,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1149,7 +1149,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1763,7 +1763,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1867,7 +1867,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1904,7 +1904,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1997,7 +1997,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2034,7 +2034,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2071,7 +2071,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2149,49 +2149,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2228,7 +2228,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2265,7 +2265,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2302,7 +2302,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2339,7 +2339,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2376,7 +2376,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2441,7 +2441,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2506,7 +2506,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection4.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection4.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -150,7 +150,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -187,7 +187,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -280,7 +280,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -317,7 +317,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -354,7 +354,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -432,49 +432,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -511,7 +511,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -548,7 +548,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -585,7 +585,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -622,7 +622,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -659,7 +659,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -724,7 +724,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -789,7 +789,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -905,7 +905,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -968,7 +968,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": true
@@ -1084,7 +1084,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1147,49 +1147,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1268,7 +1268,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1305,7 +1305,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1398,7 +1398,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1435,7 +1435,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1472,7 +1472,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1550,7 +1550,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1587,7 +1587,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1624,7 +1624,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1661,7 +1661,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1698,7 +1698,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1763,7 +1763,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1828,7 +1828,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get1.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -55,7 +55,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -270,7 +270,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -279,7 +279,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -496,7 +496,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -600,7 +600,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -637,7 +637,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -730,7 +730,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -767,7 +767,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -804,7 +804,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -882,49 +882,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -961,7 +961,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -998,7 +998,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1035,7 +1035,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1072,7 +1072,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1109,7 +1109,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1174,7 +1174,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1239,7 +1239,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -56,7 +56,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -288,7 +288,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -297,7 +297,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -480,7 +480,7 @@
         "metadata": {
           "label": "get",
           "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -489,7 +489,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -718,7 +718,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -822,7 +822,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -859,7 +859,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -952,7 +952,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -989,7 +989,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1026,7 +1026,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1104,49 +1104,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1183,7 +1183,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1220,7 +1220,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1257,7 +1257,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1294,7 +1294,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1331,7 +1331,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1396,7 +1396,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1461,7 +1461,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -151,7 +151,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -188,7 +188,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -281,7 +281,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -318,7 +318,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -355,7 +355,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -433,49 +433,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -512,7 +512,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -549,7 +549,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -586,7 +586,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -623,7 +623,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -660,7 +660,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -725,7 +725,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -790,7 +790,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -951,7 +951,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1055,7 +1055,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1092,7 +1092,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1185,7 +1185,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1222,7 +1222,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1259,7 +1259,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1337,49 +1337,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1416,7 +1416,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1453,7 +1453,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1490,7 +1490,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1527,7 +1527,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1564,7 +1564,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1629,7 +1629,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1694,7 +1694,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post1.json
@@ -46,7 +46,7 @@
         "metadata": {
           "label": "post",
           "description": "Create a new resource or submit data to a resource for processing.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -55,7 +55,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -339,7 +339,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -348,7 +348,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -711,7 +711,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -815,7 +815,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -852,7 +852,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -945,7 +945,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -982,7 +982,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1097,49 +1097,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1176,7 +1176,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1213,7 +1213,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1250,7 +1250,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1287,7 +1287,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1324,7 +1324,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1389,7 +1389,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1454,7 +1454,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "post",
           "description": "Create a new resource or submit data to a resource for processing.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -56,7 +56,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -357,7 +357,7 @@
         "metadata": {
           "label": "post",
           "description": "Create a new resource or submit data to a resource for processing.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -366,7 +366,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -663,7 +663,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -767,7 +767,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -804,7 +804,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -897,7 +897,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -934,7 +934,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -971,7 +971,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1049,49 +1049,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1128,7 +1128,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1165,7 +1165,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1202,7 +1202,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1239,7 +1239,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1276,7 +1276,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1341,7 +1341,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1406,7 +1406,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -151,7 +151,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -188,7 +188,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -281,7 +281,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -318,7 +318,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -355,7 +355,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -433,49 +433,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -512,7 +512,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -549,7 +549,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -586,7 +586,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -623,7 +623,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -660,7 +660,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -725,7 +725,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -790,7 +790,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -951,7 +951,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1055,7 +1055,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1092,7 +1092,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1185,7 +1185,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1222,7 +1222,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1259,7 +1259,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1337,49 +1337,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1416,7 +1416,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1453,7 +1453,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1490,7 +1490,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1527,7 +1527,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1564,7 +1564,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1629,7 +1629,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1694,7 +1694,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -56,7 +56,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -365,7 +365,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -374,7 +374,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -808,7 +808,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -817,7 +817,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1126,7 +1126,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1135,7 +1135,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1507,7 +1507,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1516,7 +1516,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1825,7 +1825,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1834,7 +1834,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -2229,7 +2229,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2238,7 +2238,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -2547,7 +2547,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2556,7 +2556,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -2865,7 +2865,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2874,7 +2874,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -3184,7 +3184,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -3288,7 +3288,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3325,7 +3325,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3418,7 +3418,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3455,7 +3455,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3492,7 +3492,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3570,49 +3570,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3649,7 +3649,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3686,7 +3686,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3723,7 +3723,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3760,7 +3760,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3797,7 +3797,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3862,7 +3862,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3927,7 +3927,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
@@ -47,7 +47,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -56,7 +56,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -434,7 +434,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -443,7 +443,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -822,7 +822,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -831,7 +831,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -1209,7 +1209,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1218,7 +1218,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -1659,7 +1659,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1668,7 +1668,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -2132,7 +2132,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2141,7 +2141,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -2519,7 +2519,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -2528,7 +2528,7 @@
           "packageName": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.16.3",
+          "version": "2.16.4",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -2908,7 +2908,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -3012,7 +3012,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3049,7 +3049,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3142,7 +3142,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3179,7 +3179,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3216,7 +3216,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3294,49 +3294,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3373,7 +3373,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3410,7 +3410,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3447,7 +3447,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3484,7 +3484,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3521,7 +3521,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3586,7 +3586,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3651,7 +3651,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
@@ -111,7 +111,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -120,7 +120,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "simple_flow.bal",
                     "startLine": {
@@ -417,7 +417,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -426,7 +426,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "simple_flow.bal",
                     "startLine": {
@@ -708,7 +708,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -812,7 +812,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -849,7 +849,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -942,7 +942,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -979,7 +979,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1016,7 +1016,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1094,49 +1094,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1173,7 +1173,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1210,7 +1210,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1247,7 +1247,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1284,7 +1284,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1321,7 +1321,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1386,7 +1386,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1451,7 +1451,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1567,7 +1567,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1671,7 +1671,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1708,7 +1708,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1801,7 +1801,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1838,7 +1838,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1875,7 +1875,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1953,49 +1953,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2032,7 +2032,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2069,7 +2069,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2106,7 +2106,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2143,7 +2143,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2180,7 +2180,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2245,7 +2245,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2310,7 +2310,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -799,7 +799,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -903,7 +903,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -940,7 +940,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1033,7 +1033,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1070,7 +1070,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1107,7 +1107,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1185,49 +1185,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1264,7 +1264,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1301,7 +1301,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1338,7 +1338,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1375,7 +1375,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1412,7 +1412,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1477,7 +1477,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1542,7 +1542,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
@@ -116,7 +116,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -220,7 +220,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -257,7 +257,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -350,7 +350,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -387,7 +387,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -424,7 +424,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -502,49 +502,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -581,7 +581,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -618,7 +618,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -655,7 +655,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -692,7 +692,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -729,7 +729,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -794,7 +794,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -859,7 +859,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -730,7 +730,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -834,7 +834,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -871,7 +871,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -964,7 +964,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1001,7 +1001,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1038,7 +1038,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1116,49 +1116,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1195,7 +1195,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1232,7 +1232,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1269,7 +1269,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1306,7 +1306,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1343,7 +1343,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1408,7 +1408,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1473,7 +1473,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -785,7 +785,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -889,7 +889,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -926,7 +926,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1019,7 +1019,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1056,7 +1056,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1093,7 +1093,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1171,49 +1171,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1250,7 +1250,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1287,7 +1287,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1324,7 +1324,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1361,7 +1361,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1398,7 +1398,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1463,7 +1463,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1528,7 +1528,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
@@ -278,7 +278,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -287,7 +287,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -774,7 +774,7 @@
                 "metadata": {
                   "label": "HTTP",
                   "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "NEW_CONNECTION",
@@ -878,7 +878,7 @@
                         "typeMembers": [
                           {
                             "type": "ClientHttp1Settings",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -915,7 +915,7 @@
                         "typeMembers": [
                           {
                             "type": "ClientHttp2Settings",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1008,7 +1008,7 @@
                         "typeMembers": [
                           {
                             "type": "FollowRedirects",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1045,7 +1045,7 @@
                         "typeMembers": [
                           {
                             "type": "PoolConfiguration",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1082,7 +1082,7 @@
                         "typeMembers": [
                           {
                             "type": "CacheConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1160,49 +1160,49 @@
                         "typeMembers": [
                           {
                             "type": "CredentialsConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "BearerTokenConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "JwtIssuerConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "OAuth2ClientCredentialsGrantConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "OAuth2PasswordGrantConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "OAuth2RefreshTokenGrantConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
                           },
                           {
                             "type": "OAuth2JwtBearerGrantConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1239,7 +1239,7 @@
                         "typeMembers": [
                           {
                             "type": "CircuitBreakerConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1276,7 +1276,7 @@
                         "typeMembers": [
                           {
                             "type": "RetryConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1313,7 +1313,7 @@
                         "typeMembers": [
                           {
                             "type": "CookieConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1350,7 +1350,7 @@
                         "typeMembers": [
                           {
                             "type": "ResponseLimitConfigs",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1387,7 +1387,7 @@
                         "typeMembers": [
                           {
                             "type": "ProxyConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1452,7 +1452,7 @@
                         "typeMembers": [
                           {
                             "type": "ClientSocketConfig",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1517,7 +1517,7 @@
                         "typeMembers": [
                           {
                             "type": "ClientSecureSocket",
-                            "packageInfo": "ballerina:http:2.16.3",
+                            "packageInfo": "ballerina:http:2.16.4",
                             "packageName": "http",
                             "kind": "RECORD_TYPE",
                             "selected": false
@@ -1788,7 +1788,7 @@
                         "metadata": {
                           "label": "post",
                           "description": "Create a new resource or submit data to a resource for processing.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -1797,7 +1797,7 @@
                           "packageName": "http",
                           "object": "Client",
                           "symbol": "post",
-                          "version": "2.16.3",
+                          "version": "2.16.4",
                           "lineRange": {
                             "fileName": "while.bal",
                             "startLine": {
@@ -2346,7 +2346,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -2450,7 +2450,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2487,7 +2487,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2580,7 +2580,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2617,7 +2617,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2654,7 +2654,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2732,49 +2732,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2811,7 +2811,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2848,7 +2848,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2885,7 +2885,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2922,7 +2922,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2959,7 +2959,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3024,7 +3024,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -3089,7 +3089,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -806,7 +806,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -910,7 +910,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -947,7 +947,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1040,7 +1040,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1114,7 +1114,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1192,49 +1192,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1271,7 +1271,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1308,7 +1308,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1345,7 +1345,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1382,7 +1382,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1419,7 +1419,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1484,7 +1484,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1549,7 +1549,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -806,7 +806,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -910,7 +910,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -947,7 +947,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1040,7 +1040,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1077,7 +1077,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1114,7 +1114,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1192,49 +1192,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1271,7 +1271,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1308,7 +1308,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1345,7 +1345,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1382,7 +1382,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1419,7 +1419,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1484,7 +1484,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1549,7 +1549,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -276,7 +276,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "Retrieve a representation of a specified resource from an HTTP endpoint.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -285,7 +285,7 @@
                   "packageName": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.16.3",
+                  "version": "2.16.4",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -899,7 +899,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1003,7 +1003,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1040,7 +1040,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1133,7 +1133,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1170,7 +1170,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1207,7 +1207,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1285,49 +1285,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1364,7 +1364,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1401,7 +1401,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1438,7 +1438,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1475,7 +1475,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1512,7 +1512,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1577,7 +1577,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1642,7 +1642,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/flow_model_diagnostics/config/persist_query.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/flow_model_diagnostics/config/persist_query.json
@@ -715,7 +715,7 @@
                           "readonly": false,
                           "isGraphqlId": false,
                           "imports": {
-                            "time": "ballerina/time:2.8.0"
+                            "time": "ballerina/time:2.8.1"
                           },
                           "selected": false
                         },
@@ -741,7 +741,7 @@
                     "docs": "",
                     "annotationAttachments": [],
                     "imports": {
-                      "time": "ballerina/time:2.8.0"
+                      "time": "ballerina/time:2.8.1"
                     },
                     "selected": false
                   }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/agent_model.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/agent_model.json
@@ -875,7 +875,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -979,7 +979,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1016,7 +1016,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1109,7 +1109,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1146,7 +1146,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1183,7 +1183,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1261,49 +1261,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1340,7 +1340,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1377,7 +1377,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1414,7 +1414,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1451,7 +1451,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1488,7 +1488,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1553,7 +1553,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1618,7 +1618,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1981,7 +1981,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2021,7 +2021,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2117,7 +2117,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2157,7 +2157,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2241,7 +2241,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2281,7 +2281,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2321,7 +2321,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2361,7 +2361,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -2401,7 +2401,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/agent_model_with_test.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/agent_model_with_test.json
@@ -123,7 +123,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -227,7 +227,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -264,7 +264,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -357,7 +357,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -394,7 +394,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -431,7 +431,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -509,49 +509,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -588,7 +588,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -625,7 +625,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -662,7 +662,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -699,7 +699,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -736,7 +736,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -801,7 +801,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -866,7 +866,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
@@ -439,7 +439,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -543,7 +543,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -580,7 +580,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -673,7 +673,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -710,7 +710,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -747,7 +747,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -825,49 +825,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -904,7 +904,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -941,7 +941,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -978,7 +978,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1015,7 +1015,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1052,7 +1052,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1117,7 +1117,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1182,7 +1182,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
@@ -439,7 +439,7 @@
         "metadata": {
           "label": "HTTP",
           "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -543,7 +543,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -580,7 +580,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -673,7 +673,7 @@
                 "typeMembers": [
                   {
                     "type": "FollowRedirects",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -710,7 +710,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -747,7 +747,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -825,49 +825,49 @@
                 "typeMembers": [
                   {
                     "type": "CredentialsConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "BearerTokenConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "JwtIssuerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2ClientCredentialsGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2PasswordGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2RefreshTokenGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
                   },
                   {
                     "type": "OAuth2JwtBearerGrantConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -904,7 +904,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -941,7 +941,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -978,7 +978,7 @@
                 "typeMembers": [
                   {
                     "type": "CookieConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1015,7 +1015,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1052,7 +1052,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1117,7 +1117,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSocketConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -1182,7 +1182,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-userImportedType.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_call-userImportedType.json
@@ -40,7 +40,7 @@
             "typeMembers": [
               {
                 "type": "ClientConfiguration",
-                "packageInfo": "ballerina:http:2.16.3",
+                "packageInfo": "ballerina:http:2.16.4",
                 "packageName": "http",
                 "kind": "RECORD_TYPE",
                 "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config1.json
@@ -529,7 +529,7 @@
       "metadata": {
         "label": "HTTP",
         "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
       },
       "codedata": {
         "node": "NEW_CONNECTION",
@@ -633,7 +633,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -670,7 +670,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp2Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -763,7 +763,7 @@
               "typeMembers": [
                 {
                   "type": "FollowRedirects",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -800,7 +800,7 @@
               "typeMembers": [
                 {
                   "type": "PoolConfiguration",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -837,7 +837,7 @@
               "typeMembers": [
                 {
                   "type": "CacheConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -915,49 +915,49 @@
               "typeMembers": [
                 {
                   "type": "CredentialsConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "BearerTokenConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "JwtIssuerConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2ClientCredentialsGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2PasswordGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2RefreshTokenGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2JwtBearerGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -994,7 +994,7 @@
               "typeMembers": [
                 {
                   "type": "CircuitBreakerConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1031,7 +1031,7 @@
               "typeMembers": [
                 {
                   "type": "RetryConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1068,7 +1068,7 @@
               "typeMembers": [
                 {
                   "type": "CookieConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1105,7 +1105,7 @@
               "typeMembers": [
                 {
                   "type": "ResponseLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1142,7 +1142,7 @@
               "typeMembers": [
                 {
                   "type": "ProxyConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1207,7 +1207,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1272,7 +1272,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config11.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config11.json
@@ -529,7 +529,7 @@
       "metadata": {
         "label": "HTTP",
         "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
       },
       "codedata": {
         "node": "NEW_CONNECTION",
@@ -633,7 +633,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -670,7 +670,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp2Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -763,7 +763,7 @@
               "typeMembers": [
                 {
                   "type": "FollowRedirects",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -800,7 +800,7 @@
               "typeMembers": [
                 {
                   "type": "PoolConfiguration",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -837,7 +837,7 @@
               "typeMembers": [
                 {
                   "type": "CacheConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -915,49 +915,49 @@
               "typeMembers": [
                 {
                   "type": "CredentialsConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "BearerTokenConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "JwtIssuerConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2ClientCredentialsGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2PasswordGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2RefreshTokenGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2JwtBearerGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -994,7 +994,7 @@
               "typeMembers": [
                 {
                   "type": "CircuitBreakerConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1031,7 +1031,7 @@
               "typeMembers": [
                 {
                   "type": "RetryConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1068,7 +1068,7 @@
               "typeMembers": [
                 {
                   "type": "CookieConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1105,7 +1105,7 @@
               "typeMembers": [
                 {
                   "type": "ResponseLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1142,7 +1142,7 @@
               "typeMembers": [
                 {
                   "type": "ProxyConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1207,7 +1207,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1272,7 +1272,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config2.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config2.json
@@ -439,7 +439,7 @@
       "metadata": {
         "label": "HTTP",
         "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
       },
       "codedata": {
         "node": "NEW_CONNECTION",
@@ -543,7 +543,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -580,7 +580,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp2Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -673,7 +673,7 @@
               "typeMembers": [
                 {
                   "type": "FollowRedirects",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -710,7 +710,7 @@
               "typeMembers": [
                 {
                   "type": "PoolConfiguration",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -747,7 +747,7 @@
               "typeMembers": [
                 {
                   "type": "CacheConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -825,49 +825,49 @@
               "typeMembers": [
                 {
                   "type": "CredentialsConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "BearerTokenConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "JwtIssuerConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2ClientCredentialsGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2PasswordGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2RefreshTokenGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2JwtBearerGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -904,7 +904,7 @@
               "typeMembers": [
                 {
                   "type": "CircuitBreakerConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -941,7 +941,7 @@
               "typeMembers": [
                 {
                   "type": "RetryConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -978,7 +978,7 @@
               "typeMembers": [
                 {
                   "type": "CookieConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1015,7 +1015,7 @@
               "typeMembers": [
                 {
                   "type": "ResponseLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1052,7 +1052,7 @@
               "typeMembers": [
                 {
                   "type": "ProxyConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1117,7 +1117,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1182,7 +1182,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config7.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search_nodes/config/config7.json
@@ -533,7 +533,7 @@
       "metadata": {
         "label": "HTTP",
         "description": "The HTTP client provides functionality to connect to remote HTTP services and perform requests using standard HTTP methods like GET, POST, PUT, DELETE, etc.\n",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png"
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png"
       },
       "codedata": {
         "node": "NEW_CONNECTION",
@@ -637,7 +637,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -674,7 +674,7 @@
               "typeMembers": [
                 {
                   "type": "ClientHttp2Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -767,7 +767,7 @@
               "typeMembers": [
                 {
                   "type": "FollowRedirects",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -804,7 +804,7 @@
               "typeMembers": [
                 {
                   "type": "PoolConfiguration",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -841,7 +841,7 @@
               "typeMembers": [
                 {
                   "type": "CacheConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -919,49 +919,49 @@
               "typeMembers": [
                 {
                   "type": "CredentialsConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "BearerTokenConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "JwtIssuerConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2ClientCredentialsGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2PasswordGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2RefreshTokenGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
                 },
                 {
                   "type": "OAuth2JwtBearerGrantConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -998,7 +998,7 @@
               "typeMembers": [
                 {
                   "type": "CircuitBreakerConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1035,7 +1035,7 @@
               "typeMembers": [
                 {
                   "type": "RetryConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1072,7 +1072,7 @@
               "typeMembers": [
                 {
                   "type": "CookieConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1109,7 +1109,7 @@
               "typeMembers": [
                 {
                   "type": "ResponseLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1146,7 +1146,7 @@
               "typeMembers": [
                 {
                   "type": "ProxyConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1211,7 +1211,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -1276,7 +1276,7 @@
               "typeMembers": [
                 {
                   "type": "ClientSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/service_field_nodes/config/service_field_nodes.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/service_field_nodes/config/service_field_nodes.json
@@ -350,7 +350,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp1Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -390,7 +390,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientHttp2Settings",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -486,7 +486,7 @@
                 "typeMembers": [
                   {
                     "type": "PoolConfiguration",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -526,7 +526,7 @@
                 "typeMembers": [
                   {
                     "type": "CacheConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -610,7 +610,7 @@
                 "typeMembers": [
                   {
                     "type": "CircuitBreakerConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -650,7 +650,7 @@
                 "typeMembers": [
                   {
                     "type": "RetryConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -690,7 +690,7 @@
                 "typeMembers": [
                   {
                     "type": "ResponseLimitConfigs",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -730,7 +730,7 @@
                 "typeMembers": [
                   {
                     "type": "ClientSecureSocket",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false
@@ -770,7 +770,7 @@
                 "typeMembers": [
                   {
                     "type": "ProxyConfig",
-                    "packageInfo": "ballerina:http:2.16.3",
+                    "packageInfo": "ballerina:http:2.16.4",
                     "packageName": "http",
                     "kind": "RECORD_TYPE",
                     "selected": false

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_error_type_def.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_error_type_def.json
@@ -695,7 +695,7 @@
           "docs": "date of birth",
           "annotationAttachments": [],
           "imports": {
-            "time": "ballerina/time:2.8.0"
+            "time": "ballerina/time:2.8.1"
           },
           "selected": false
         }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_public_record_type.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_public_record_type.json
@@ -171,7 +171,7 @@
               "readonly": false,
               "isGraphqlId": false,
               "imports": {
-                "time": "ballerina/time:2.8.0"
+                "time": "ballerina/time:2.8.1"
               },
               "selected": false
             }
@@ -184,7 +184,7 @@
         "readonly": false,
         "isGraphqlId": false,
         "imports": {
-          "time": "ballerina/time:2.8.0"
+          "time": "ballerina/time:2.8.1"
         },
         "selected": false
       }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_record_type1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_record_type1.json
@@ -234,7 +234,7 @@
         "docs": "date of birth",
         "annotationAttachments": [],
         "imports": {
-          "time": "ballerina/time:2.8.0"
+          "time": "ballerina/time:2.8.1"
         },
         "selected": false
       }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_record_type3.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_record_type3.json
@@ -244,7 +244,7 @@
         "docs": "",
         "annotationAttachments": [],
         "imports": {
-          "time": "ballerina/time:2.8.0"
+          "time": "ballerina/time:2.8.1"
         },
         "selected": false
       }
@@ -816,7 +816,7 @@
           "docs": "date of birth",
           "annotationAttachments": [],
           "imports": {
-            "time": "ballerina/time:2.8.0"
+            "time": "ballerina/time:2.8.1"
           },
           "selected": false
         }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_record_type5.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_record_type5.json
@@ -171,7 +171,7 @@
               "readonly": false,
               "isGraphqlId": false,
               "imports": {
-                "time": "ballerina/time:2.8.0"
+                "time": "ballerina/time:2.8.1"
               },
               "selected": false
             }
@@ -184,7 +184,7 @@
         "readonly": false,
         "isGraphqlId": false,
         "imports": {
-          "time": "ballerina/time:2.8.0"
+          "time": "ballerina/time:2.8.1"
         },
         "selected": false
       }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_record_type_with_custom_and_xml_annot.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_record_type_with_custom_and_xml_annot.json
@@ -145,7 +145,7 @@
               "node": "ANNOTATION_ATTACHMENT",
               "org": "ballerina",
               "module": "data.xmldata",
-              "version": "1.6.2",
+              "version": "1.6.3",
               "lineRange": {
                 "fileName": "types.bal",
                 "startLine": {
@@ -394,7 +394,7 @@
           "node": "ANNOTATION_ATTACHMENT",
           "org": "ballerina",
           "module": "data.xmldata",
-          "version": "1.6.2",
+          "version": "1.6.3",
           "lineRange": {
             "fileName": "types.bal",
             "startLine": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_union_type1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_union_type1.json
@@ -1192,7 +1192,7 @@
           "docs": "date of birth",
           "annotationAttachments": [],
           "imports": {
-            "time": "ballerina/time:2.8.0"
+            "time": "ballerina/time:2.8.1"
           },
           "selected": false
         }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_union_type_of_readonly_and_union_type.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_type/config/get_union_type_of_readonly_and_union_type.json
@@ -868,7 +868,7 @@
           "docs": "date of birth",
           "annotationAttachments": [],
           "imports": {
-            "time": "ballerina/time:2.8.0"
+            "time": "ballerina/time:2.8.1"
           },
           "selected": false
         }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_types/config/get_all_types1.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/get_types/config/get_all_types1.json
@@ -1894,7 +1894,7 @@
                 "readonly": false,
                 "isGraphqlId": false,
                 "imports": {
-                  "time": "ballerina/time:2.8.0"
+                  "time": "ballerina/time:2.8.1"
                 },
                 "selected": false
               },
@@ -1941,7 +1941,7 @@
           "docs": "",
           "annotationAttachments": [],
           "imports": {
-            "time": "ballerina/time:2.8.0",
+            "time": "ballerina/time:2.8.1",
             "test_pack1": "testorg/test_pack1:0.1.0"
           },
           "selected": false
@@ -3046,7 +3046,7 @@
           "docs": "",
           "annotationAttachments": [],
           "imports": {
-            "time": "ballerina/time:2.8.0"
+            "time": "ballerina/time:2.8.1"
           },
           "selected": false
         }
@@ -4295,7 +4295,7 @@
           "docs": "",
           "annotationAttachments": [],
           "imports": {
-            "time": "ballerina/time:2.8.0"
+            "time": "ballerina/time:2.8.1"
           },
           "selected": false
         }
@@ -4535,7 +4535,7 @@
           "docs": "date of birth",
           "annotationAttachments": [],
           "imports": {
-            "time": "ballerina/time:2.8.0"
+            "time": "ballerina/time:2.8.1"
           },
           "selected": false
         }

--- a/packages/ballerina-language-server/gradle.properties
+++ b/packages/ballerina-language-server/gradle.properties
@@ -46,7 +46,7 @@ observeInternalVersion=1.6.0
 # Standard Library Dependencies
 # Stdlib Level 01
 stdlibIoVersion=1.8.1
-stdlibTimeVersion=2.8.0
+stdlibTimeVersion=2.8.1
 stdlibUrlVersion=2.6.1
 
 # Stdlib Level 02
@@ -64,6 +64,7 @@ stdlibUuidVersion=1.10.0
 stdlibAuthVersion=2.14.0
 stdlibOAuth2Version=2.15.0
 stdlibJsonDataVersion=1.1.3
+stdlibXmlDataVersion=1.6.3
 
 # Stdlib Level 05
 stdlibHttpVersion=2.16.3

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_1.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_1.json
@@ -17,10 +17,10 @@
       "description": "Gets invoked during module initialization to initialize the listener.\n",
       "moduleName": "http",
       "orgName": "ballerina",
-      "version": "2.16.3",
+      "version": "2.16.4",
       "packageName": "http",
       "listenerProtocol": "http",
-      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
       "properties": {
         "variableNameKey": {
           "metadata": {
@@ -143,7 +143,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -180,7 +180,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -315,7 +315,7 @@
               "typeMembers": [
                 {
                   "type": "RequestLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -380,7 +380,7 @@
               "typeMembers": [
                 {
                   "type": "ServerSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_2.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_2.json
@@ -17,10 +17,10 @@
       "description": "Gets invoked during module initialization to initialize the listener.\n",
       "moduleName": "http",
       "orgName": "ballerina",
-      "version": "2.16.3",
+      "version": "2.16.4",
       "packageName": "http",
       "listenerProtocol": "http",
-      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
       "properties": {
         "variableNameKey": {
           "metadata": {
@@ -143,7 +143,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -180,7 +180,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -315,7 +315,7 @@
               "typeMembers": [
                 {
                   "type": "RequestLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -380,7 +380,7 @@
               "typeMembers": [
                 {
                   "type": "ServerSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_3.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_3.json
@@ -17,10 +17,10 @@
       "description": "Gets invoked during module initialization to initialize the listener.\n",
       "moduleName": "http",
       "orgName": "ballerina",
-      "version": "2.16.3",
+      "version": "2.16.4",
       "packageName": "http",
       "listenerProtocol": "http",
-      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
       "properties": {
         "variableNameKey": {
           "metadata": {
@@ -115,7 +115,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerConfiguration",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": true

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_4.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_4.json
@@ -17,10 +17,10 @@
       "description": "Gets invoked during module initialization to initialize the listener.\n",
       "moduleName": "http",
       "orgName": "ballerina",
-      "version": "2.16.3",
+      "version": "2.16.4",
       "packageName": "http",
       "listenerProtocol": "http",
-      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
       "properties": {
         "variableNameKey": {
           "metadata": {
@@ -115,7 +115,7 @@
               "typeMembers": [
                 {
                   "type": "ServerSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": true
@@ -208,7 +208,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -245,7 +245,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -352,7 +352,7 @@
               "typeMembers": [
                 {
                   "type": "RequestLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_5.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_5.json
@@ -17,10 +17,10 @@
       "description": "Gets invoked during module initialization to initialize the listener.\n",
       "moduleName": "http",
       "orgName": "ballerina",
-      "version": "2.16.3",
+      "version": "2.16.4",
       "packageName": "http",
       "listenerProtocol": "http",
-      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
       "properties": {
         "listenerType": {
           "metadata": {
@@ -113,7 +113,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerHttp1Settings",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -150,7 +150,7 @@
               "typeMembers": [
                 {
                   "type": "ListenerSecureSocket",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -285,7 +285,7 @@
               "typeMembers": [
                 {
                   "type": "RequestLimitConfigs",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false
@@ -350,7 +350,7 @@
               "typeMembers": [
                 {
                   "type": "ServerSocketConfig",
-                  "packageInfo": "ballerina:http:2.16.3",
+                  "packageInfo": "ballerina:http:2.16.4",
                   "packageName": "http",
                   "kind": "RECORD_TYPE",
                   "selected": false


### PR DESCRIPTION
## Summary
- Scope the LS test Ballerina dependency cache key to the PR's base branch (`github.base_ref`) instead of the PR ref (`github.ref_name`, which resolves to `<pr-number>/merge`), matching upstream's caching strategy. Every PR previously got its own always-cold cache namespace instead of sharing one warm cache per target branch.
- Drop the branch-agnostic third-level cache restore-key fallback, which could inject an unrelated branch's stale cache state — upstream has no equivalent.
- Fix `PublishArtifactsSubscriberTest.assertArtifacts()` to gate on `isJsonPermutation()` (normalized JSON comparison) instead of raw `Map.equals()`, matching the already-correct pattern in `ArtifactsTest` in the same file. The raw-equals gate was version-sensitive to fields (like package icon URLs) that the normalized comparison correctly treats as environment-dependent noise.
- Bump `ballerina/http` 2.16.3 → 2.16.4 across `flow-model-generator` and `service-model-generator` test fixtures. The cache-key fix above removed an accidental stale-cache safety net that had been masking this drift across most of the test suite.
- Bump `stdlibTimeVersion` 2.8.0 → 2.8.1 and add `stdlibXmlDataVersion=1.6.3` (new `io.ballerina.lib:data.xmldata-ballerina` pin), matching versions actually resolved during test runs. Ports [ballerina-platform/ballerina-language-server#955](https://github.com/ballerina-platform/ballerina-language-server/pull/955).