### PR TITLE
Fix daily-build failures: Trivy scan and SpotBugs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
           # Must be a single line: trivy splits on ',' verbatim. A folded
           # YAML string (>-) introduces a space after each comma, which
           # makes every entry except the first start with ' ' and never match.
-          skip-dirs: 'common/temp,submodules,packages/ballerina-language-server/**/src/test/resources,packages/ballerina-language-server/**/src/test/data'
+          skip-dirs: 'common/temp,submodules,packages/ballerina-language-server/**/src/test/resources,packages/ballerina-language-server/**/src/test/data,packages/ballerina-language-server/**/build/resources/test'
           ignore-unfixed: true
           trivyignores: .trivyignore,submodules/wso2-vscode-extensions/.trivyignore
 

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -253,6 +253,7 @@ jobs:
           format: 'table'
           timeout: '10m0s'
           exit-code: '1'
+          trivyignores: packages/ballerina-language-server/.trivyignore
 
   # ─────────────────────────────────────────────────────────────────────────
   # Ballerina VSCode extension — build VSIX + tests

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/WorkflowManagementService.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/WorkflowManagementService.java
@@ -142,15 +142,19 @@ public class WorkflowManagementService implements ExtendedLanguageServerService 
                 Path mainPath = sourceRoot.resolve(MAIN_BAL);
 
                 Path targetPath;
+                String targetFileName;
                 boolean targetExists;
                 if (Files.exists(functionsPath)) {
                     targetPath = functionsPath;
+                    targetFileName = FUNCTIONS_BAL;
                     targetExists = true;
                 } else if (Files.exists(mainPath)) {
                     targetPath = mainPath;
+                    targetFileName = MAIN_BAL;
                     targetExists = true;
                 } else {
                     targetPath = functionsPath;
+                    targetFileName = FUNCTIONS_BAL;
                     targetExists = false;
                 }
 
@@ -160,7 +164,7 @@ public class WorkflowManagementService implements ExtendedLanguageServerService 
                     Node node = targetDoc.get().syntaxTree().rootNode();
                     edit = new TextEdit(PositionUtil.toRange(node.lineRange().startLine()), IMPORT_STMT.formatted());
                 } else {
-                    edit = new TextEdit(PositionUtil.toRange(LineRange.from(targetPath.getFileName().toString(),
+                    edit = new TextEdit(PositionUtil.toRange(LineRange.from(targetFileName,
                             LinePosition.from(0, 0), LinePosition.from(0, 0))), IMPORT_STMT.formatted());
                 }
                 textEdits.put(targetPath.toString(), List.of(edit));

--- a/packages/ballerina-language-server/package.json
+++ b/packages/ballerina-language-server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Ballerina Language Server (Gradle build wrapped for rush).",
   "scripts": {
-    "build": "./gradlew build pack -x test -x check",
+    "build": "./gradlew build pack -x test",
     "clean": "./gradlew clean",
     "test": "./gradlew test"
   }


### PR DESCRIPTION
## Purpose

Fixes two failures in the daily build on `main`, closes the CI gap that let one of them reach `main` undetected, and fixes a follow-on Trivy false positive introduced by that gap fix.

### 1. LS Trivy scan
`CVE-2026-54515` (jackson-databind) was failing the `ls-trivy` job even though it's listed in `packages/ballerina-language-server/.trivyignore`. That job's Trivy step never passed `trivyignores`, so the ignore file was inert. Wired it in, matching how `build.yml` references its ignore files. (jackson-databind 2.18.9 — the patched 2.x release — is not yet on Maven Central, so suppressing remains the only option.)

### 2. SpotBugs null-dereference
`WorkflowManagementService.addWorkflowManagement` dereferenced `Path.getFileName()` (which can return `null`) via `.toString()`. The target filename is always a known constant (`functions.bal`/`main.bal`), so it's now tracked in a `targetFileName` variable instead of being re-derived from the path.

### 3. Run SpotBugs/checkstyle in the LS build (prevent recurrence)
The SpotBugs bug above sat on `main` for ~12 days because static analysis ran in **no** PR job — the LS build script used `./gradlew build pack -x test -x check`, and `-x check` skips `validateSpotbugs`/checkstyle. It was only caught by the daily build's full `./gradlew build` (the one job not passing `-x check`).

Dropped `-x check` (kept `-x test`, since tests run in a dedicated job), so `check` — checkstyle + `spotbugsMain` → `validateSpotbugs` — now runs on every LS build and blocks the PR instead of surfacing later on `main`.

Note: this script is also the `rush build` script, so local LS builds now run checkstyle + SpotBugs too (slower inner loop, intentional tradeoff for pre-merge coverage).

### 4. Skip build/resources/test in the Trivy fs scan
Change 3 has a side effect: running `check` triggers `processTestResources`, which copies the LS test fixtures (intentionally-old Mule migration projects with vulnerable c3p0/Spring/commons-io deps) from `src/test/resources` into `build/resources/test`. The `build.yml` fs scan's `skip-dirs` excluded the `src/` location but not the `build/` copy, so those false positives started failing the scan. Added `packages/ballerina-language-server/**/build/resources/test` to `skip-dirs` (kept as a single line — Trivy splits on `,` verbatim).

## Checks

- `validateSpotbugs` passes locally for `flow-model-generator-ls-extension`.
- `./gradlew build pack -x test --dry-run` confirms `validateSpotbugs`/`checkstyleMain` are in the task graph and the `test` task is excluded.