### PR TITLE
Revamp migration prompts with source first strategy

### DIFF
--- a/packages/ballerina-core/src/rpc-types/migrate-integration/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/migrate-integration/interfaces.ts
@@ -90,6 +90,8 @@ export interface MigrateRequest {
     sourcePath?: string;
     /** `true` when the migration ran with --keep-structure, preserving original source file layout. */
     keepStructure?: boolean;
+    /** The source integration platform ('mule' for MuleSoft, 'tibco' for TIBCO BusinessWorks). */
+    sourcePlatform?: 'mule' | 'tibco';
 }
 
 export interface OpenSubProjectReportRequest {

--- a/packages/ballerina-extension/src/features/ai/migration/orchestrator.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/orchestrator.ts
@@ -40,6 +40,7 @@ import {
     AI_MIGRATION_DIR,
     ActiveMigrationSessionLocal,
     EnhanceTomlData,
+    MigrationContext,
     MIGRATION_PROJECT_ROOT_KEY,
     PackageEnhancementResult,
     PENDING_ENHANCEMENT_TTL_MS,
@@ -82,6 +83,7 @@ export function readEnhanceToml(projectRoot: string): EnhanceTomlData | null {
         const currentStageMatch = content.match(/currentStage\s*=\s*(\d+)/);
         const multiProjectMatch = content.match(/multiProject\s*=\s*(true|false)/);
         const keepStructureMatch = content.match(/keepStructure\s*=\s*(true|false)/);
+        const sourcePlatformMatch = content.match(/sourcePlatform\s*=\s*"(mule|tibco)"/);
 
         // Parse completedPackages array
         const completedPackagesMatch = content.match(/completedPackages\s*=\s*\[([^\]]*)\]/);
@@ -102,6 +104,7 @@ export function readEnhanceToml(projectRoot: string): EnhanceTomlData | null {
             currentStage: currentStageMatch ? parseInt(currentStageMatch[1], 10) : undefined,
             multiProject: multiProjectMatch ? multiProjectMatch[1] === "true" : undefined,
             keepStructure: keepStructureMatch ? keepStructureMatch[1] === "true" : undefined,
+            sourcePlatform: sourcePlatformMatch?.[1] as 'mule' | 'tibco' | undefined,
         };
     } catch {
         return null;
@@ -121,6 +124,7 @@ export function writeEnhanceToml(
     currentStage?: number,
     multiProject?: boolean,
     keepStructure?: boolean,
+    sourcePlatform?: 'mule' | 'tibco',
 ): void {
     const dir = path.join(projectRoot, AI_MIGRATION_DIR);
     if (!fs.existsSync(dir)) {
@@ -141,8 +145,9 @@ export function writeEnhanceToml(
     if (currentStage !== undefined) {
         content += `currentStage = ${currentStage}\n`;
     }
-    // When multiProject / keepStructure are not explicitly provided, preserve existing values from disk.
-    const existing = multiProject === undefined || keepStructure === undefined ? readEnhanceToml(projectRoot) : undefined;
+    // When optional fields are not explicitly provided, preserve existing values from disk.
+    const needExisting = multiProject === undefined || keepStructure === undefined || sourcePlatform === undefined;
+    const existing = needExisting ? readEnhanceToml(projectRoot) : undefined;
     const effectiveMultiProject = multiProject !== undefined ? multiProject : existing?.multiProject;
     if (effectiveMultiProject !== undefined) {
         content += `multiProject = ${effectiveMultiProject}\n`;
@@ -150,6 +155,10 @@ export function writeEnhanceToml(
     const effectiveKeepStructure = keepStructure !== undefined ? keepStructure : existing?.keepStructure;
     if (effectiveKeepStructure) {
         content += `keepStructure = true\n`;
+    }
+    const effectiveSourcePlatform = sourcePlatform !== undefined ? sourcePlatform : existing?.sourcePlatform;
+    if (effectiveSourcePlatform) {
+        content += `sourcePlatform = "${effectiveSourcePlatform}"\n`;
     }
     fs.writeFileSync(filePath, content);
 }
@@ -223,6 +232,19 @@ export function getMigrationSourcePathForProject(projectRoot: string): string | 
         return data.sourcePath;
     }
     return undefined;
+}
+
+/**
+ * Builds a `MigrationContext` from the persisted toml for the given project root.
+ * This is the single place that translates toml fields into prompt parameters —
+ * all stage call sites use this instead of passing loose flags.
+ */
+export function buildMigrationContext(projectRoot: string): MigrationContext {
+    const data = readEnhanceToml(projectRoot);
+    return {
+        sourcePlatform: data?.sourcePlatform ?? 'unknown',
+        keepStructure: data?.keepStructure ?? false,
+    };
 }
 
 /**
@@ -772,7 +794,7 @@ export async function runMigrationAgent(): Promise<void> {
                 const fullPkgPath = path.join(projectRoot, pkgRelPath);
                 const pkgName = readPackageName(fullPkgPath) ?? pkgRelPath;
                 const manifest = buildCrossPackageManifest(projectRoot, packagePaths, pkgRelPath);
-                const stages = getPerProjectEnhancementStages(pkgName, pkgRelPath, pkgIdx, packagePaths.length, manifest);
+                const stages = getPerProjectEnhancementStages(pkgName, pkgRelPath, pkgIdx, packagePaths.length, manifest, buildMigrationContext(projectRoot));
                 if (!resumeInjected) {
                     injectResumePreamble(projectRoot, stages);
                     resumeInjected = true;
@@ -845,7 +867,7 @@ export async function runMigrationAgent(): Promise<void> {
             }
         } else {
             // ── Single-package project ───────────────────────────────────
-            const stages = getEnhancementStages();
+            const stages = getEnhancementStages(buildMigrationContext(projectRoot));
             injectResumePreamble(projectRoot, stages);
             console.log(`[MigrationEnhancement] Starting migration agent (${stages.length} stages) – model: ${_selectedModelId}, sourcePath: ${sourcePath ?? 'none'}`);
             debugLogger.logMilestone(`Run start — single package, model: ${_selectedModelId}, projectRoot: ${projectRoot}`);
@@ -1340,7 +1362,7 @@ export async function runWizardMigrationEnhancement(): Promise<void> {
                 const fullPkgPath = path.join(projectRoot, pkgRelPath);
                 const pkgName = readPackageName(fullPkgPath) ?? pkgRelPath;
                 const manifest = buildCrossPackageManifest(projectRoot, packagePaths, pkgRelPath);
-                const stages = getPerProjectEnhancementStages(pkgName, pkgRelPath, pkgIdx, packagePaths.length, manifest, _wizardKeepStructure);
+                const stages = getPerProjectEnhancementStages(pkgName, pkgRelPath, pkgIdx, packagePaths.length, manifest, buildMigrationContext(projectRoot));
                 if (!resumeInjected) {
                     injectResumePreamble(projectRoot, stages);
                     resumeInjected = true;
@@ -1433,7 +1455,7 @@ export async function runWizardMigrationEnhancement(): Promise<void> {
             }
         } else {
             // ── Single-package project ───────────────────────────────────
-            const stages = getEnhancementStages(_wizardKeepStructure);
+            const stages = getEnhancementStages(buildMigrationContext(projectRoot));
             injectResumePreamble(projectRoot, stages);
             console.log(`[MigrationEnhancement] Starting wizard migration agent (${stages.length} stages) – projectRoot: ${projectRoot}, sourcePath: ${sourcePath ?? 'none'}`);
             debugLogger.logMilestone(`Run start — single package (wizard), model: ${_selectedModelId}, projectRoot: ${projectRoot}`);

--- a/packages/ballerina-extension/src/features/ai/migration/orchestrator.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/orchestrator.ts
@@ -1333,6 +1333,7 @@ export async function runWizardMigrationEnhancement(): Promise<void> {
             const completedPackages = new Set<string>(tomlData?.completedPackages ?? []);
             const results: PackageEnhancementResult[] = [];
             let resumeInjected = false;
+            let stagesPerPackage = 0;
 
             // Suppress per-stage "stop" events so the wizard doesn't prematurely
             // show "completed" after the first package. The real final "stop" is
@@ -1363,6 +1364,7 @@ export async function runWizardMigrationEnhancement(): Promise<void> {
                 const pkgName = readPackageName(fullPkgPath) ?? pkgRelPath;
                 const manifest = buildCrossPackageManifest(projectRoot, packagePaths, pkgRelPath);
                 const stages = getPerProjectEnhancementStages(pkgName, pkgRelPath, pkgIdx, packagePaths.length, manifest, buildMigrationContext(projectRoot));
+                stagesPerPackage = stages.length;
                 if (!resumeInjected) {
                     injectResumePreamble(projectRoot, stages);
                     resumeInjected = true;
@@ -1426,8 +1428,8 @@ export async function runWizardMigrationEnhancement(): Promise<void> {
                             packageIndex: packagePaths.length,
                             totalPackages: packagePaths.length,
                             packageName: "",
-                            stageOffset: packagePaths.length * 4,
-                            totalStagesOverall: packagePaths.length * 4 + 1,
+                            stageOffset: packagePaths.length * stagesPerPackage,
+                            totalStagesOverall: packagePaths.length * stagesPerPackage + 1,
                         });
                         debugLogger.logMilestone("Workspace validation — completed (wizard)");
                     } catch (wsError) {

--- a/packages/ballerina-extension/src/features/ai/migration/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/prompts.ts
@@ -20,7 +20,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { AI_MIGRATION_DIR, AI_SUMMARY_FILENAME } from "./types";
+import { AI_MIGRATION_DIR, AI_SUMMARY_FILENAME, MigrationContext } from "./types";
 
 /** Describes a single stage of the multi-stage migration enhancement. */
 export interface EnhancementStage {
@@ -37,22 +37,27 @@ export interface EnhancementStage {
  * The orchestrator runs each stage sequentially, giving each stage a **fresh
  * context window** so the agent never runs out of context mid-work.
  */
-export function getEnhancementStages(keepStructure: boolean = false): EnhancementStage[] {
-    const shared = getSharedEnhancementContext(keepStructure);
+export function getEnhancementStages(context: MigrationContext): EnhancementStage[] {
+    const shared = getSharedEnhancementContext(context);
     return [
         {
-            name: "Stage 1 — Fidelity Check & TODO Resolution",
-            prompt: shared + "\n\n" + getStage1Prompt(keepStructure),
+            name: "Stage 0 — Source Inventory & Gap Analysis",
+            prompt: shared + "\n\n" + getStage0Prompt(context),
+            agentLimits: { maxSteps: 50, maxOutputTokens: 8192 },
+        },
+        {
+            name: "Stage 1 — Source-First Fidelity Implementation",
+            prompt: shared + "\n\n" + getStage1Prompt(context),
             agentLimits: { maxSteps: 200, maxOutputTokens: 16384 },
         },
         {
             name: "Stage 2 — Zero Compilation Diagnostics",
-            prompt: shared + "\n\n" + getStage2Prompt(),
+            prompt: shared + "\n\n" + getStage2Prompt(context),
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
             name: "Stage 3 — Test Refinement",
-            prompt: shared + "\n\n" + getStage3Prompt(),
+            prompt: shared + "\n\n" + getStage3Prompt(context),
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
@@ -100,6 +105,7 @@ their exports are correct as declared.`;
  * @param packageIndex  Zero-based position in the ordered package list.
  * @param totalPackages Total number of packages in the workspace.
  * @param crossPackageManifest  Markdown snippet listing peer packages and symbols.
+ * @param context       Migration context carrying platform and keepStructure.
  */
 export function getPerProjectEnhancementStages(
     packageName: string,
@@ -107,26 +113,31 @@ export function getPerProjectEnhancementStages(
     packageIndex: number,
     totalPackages: number,
     crossPackageManifest: string,
-    keepStructure: boolean = false,
+    context: MigrationContext,
 ): EnhancementStage[] {
     const preamble = getPerProjectPreamble(
         packageName, packagePath, packageIndex, totalPackages, crossPackageManifest,
     );
-    const shared = preamble + "\n\n" + getSharedEnhancementContext(keepStructure);
+    const shared = preamble + "\n\n" + getSharedEnhancementContext(context);
     return [
         {
-            name: `[${packageName}] Stage 1 — Fidelity Check & TODO Resolution`,
-            prompt: shared + "\n\n" + getStage1Prompt(keepStructure),
+            name: `[${packageName}] Stage 0 — Source Inventory & Gap Analysis`,
+            prompt: shared + "\n\n" + getStage0Prompt(context),
+            agentLimits: { maxSteps: 50, maxOutputTokens: 8192 },
+        },
+        {
+            name: `[${packageName}] Stage 1 — Source-First Fidelity Implementation`,
+            prompt: shared + "\n\n" + getStage1Prompt(context),
             agentLimits: { maxSteps: 200, maxOutputTokens: 16384 },
         },
         {
             name: `[${packageName}] Stage 2 — Zero Compilation Diagnostics`,
-            prompt: shared + "\n\n" + getStage2Prompt() + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
+            prompt: shared + "\n\n" + getStage2Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
             name: `[${packageName}] Stage 3 — Test Refinement`,
-            prompt: shared + "\n\n" + getStage3Prompt(),
+            prompt: shared + "\n\n" + getStage3Prompt(context),
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
@@ -159,16 +170,141 @@ You are enhancing **package ${packageIndex + 1} of ${totalPackages}**: \`${packa
 }
 
 // ---------------------------------------------------------------------------
+// Platform helpers
+// ---------------------------------------------------------------------------
+
+function getPlatformName(platform: 'mule' | 'tibco' | 'unknown'): string {
+    if (platform === 'mule') { return 'MuleSoft Mule 3/4'; }
+    if (platform === 'tibco') { return 'TIBCO BusinessWorks 5/6'; }
+    return 'MuleSoft Mule 3/4 / TIBCO BusinessWorks';
+}
+
+function getPlatformExpertise(platform: 'mule' | 'tibco' | 'unknown'): string {
+    if (platform === 'mule') {
+        return `MuleSoft Mule 3/4 (Mule runtime, DataWeave 1.x/2.x, Anypoint Platform connectors, MUnit testing,
+RAML API specs, Mule XML flow DSL, on-error-propagate/on-error-continue, scatter-gather, batch jobs)`;
+    }
+    if (platform === 'tibco') {
+        return `TIBCO BusinessWorks 5/6 (BW processes, TIBCO EMS/JMS, TIBCO Rendezvous, shared resources,
+substitution variables, palette activities, SOAP/REST adapters, BW test harness)`;
+    }
+    return 'MuleSoft Mule 3/4 and TIBCO BusinessWorks';
+}
+
+function getSourceInventoryTable(platform: 'mule' | 'tibco' | 'unknown'): string {
+    if (platform === 'mule') {
+        return `| Source file type | Typical path / extension | → Ballerina target |
+|---|---|---|
+| Mule flow / sub-flow XML | \`src/main/mule/*.xml\` | \`functions.bal\`, \`main.bal\` |
+| DataWeave transforms | \`src/main/resources/*.dwl\`, inline in XML | \`data_mappings.bal\` |
+| RAML API spec | \`*.raml\`, \`api.yaml\` | \`main.bal\` HTTP service + \`types.bal\` |
+| JSON / XML schemas | \`*.xsd\`, \`*.json\` (schema) | \`types.bal\` |
+| Property files / config | \`*.properties\`, \`*.yaml\`, \`*.json\` (config) | \`configs.bal\` + \`Config.toml\` |
+| Global configs (connectors) | Mule global elements in XML | \`connections.bal\` |
+| Error handlers | on-error-propagate/continue blocks | \`on fail\` / \`do{}on fail{}\` in functions |
+| MUnit test files | \`src/test/munit/*.xml\` | \`tests/*.bal\` |
+| Maven build | \`pom.xml\` (dependencies) | \`Ballerina.toml\` \`[[dependency]]\` entries |`;
+    }
+    if (platform === 'tibco') {
+        return `| Source file type | Typical path / extension | → Ballerina target |
+|---|---|---|
+| BW process | \`*.bwp\` | \`functions.bal\`, \`main.bal\` |
+| Substitution variables | \`*.substvar\` | \`configs.bal\` + \`Config.toml\` |
+| WSDL / XSD schemas | \`*.wsdl\`, \`*.xsd\` | \`types.bal\` |
+| Shared HTTP connection | \`*.sharedhttp\` | \`connections.bal\` |
+| Shared JDBC connection | \`*.sharedjdbc\` | \`connections.bal\` |
+| EMS queue / topic | \`*.jmsqueue\`, \`*.jmstopic\` | \`connections.bal\` |
+| TIBCO RV transport | \`*.rvtransport\` | \`connections.bal\` |
+| BW test process | \`*.bwtest\` | \`tests/*.bal\` |
+| Module manifest | \`META-INF/MANIFEST.MF\` | \`Ballerina.toml\` |`;
+    }
+    return `| Source file type | → Ballerina target |
+|---|---|
+| Flow / process files | \`functions.bal\`, \`main.bal\` |
+| Transformations (DataWeave / XPath) | \`data_mappings.bal\` |
+| API specs (RAML / WSDL) | \`main.bal\` service + \`types.bal\` |
+| Schemas (XSD / JSON) | \`types.bal\` |
+| Config / properties / substvar | \`configs.bal\` + \`Config.toml\` |
+| Shared connections | \`connections.bal\` |
+| Test files | \`tests/*.bal\` |`;
+}
+
+function getConnectorMappingTable(platform: 'mule' | 'tibco' | 'unknown'): string {
+    if (platform === 'mule') {
+        return `| Mule construct | Ballerina equivalent |
+|---|---|
+| HTTP listener | \`http:Listener\` + \`service\` |
+| HTTP request | \`http:Client\` |
+| DataWeave transform | Expression-bodied function in \`data_mappings.bal\` |
+| RAML-defined type | \`record {}\` type in \`types.bal\` |
+| Set payload / set variable | Local variable assignment |
+| Choice router | \`if\`/\`else\` or \`match\` |
+| Scatter-gather | \`fork\`/\`worker\` or parallel \`future\` |
+| Batch job / step | \`foreach\` with error collection |
+| Anypoint MQ / JMS | \`ballerinax/rabbitmq\` or \`ballerinax/kafka\` |
+| Object store | \`ballerina/cache\` or \`map<anydata>\` variable |
+| Scheduler | \`ballerina/task\` timer |
+| SOAP consumer | \`ballerina/http\` + \`ballerina/xmldata\` |
+| Custom logger (json-logger) | \`log:printInfo\` with structured fields |
+| on-error-propagate | \`on fail\` / \`check\` — error re-thrown |
+| on-error-continue | \`do { } on fail { }\` — error swallowed |
+| Flow reference | Ballerina function call |
+| Sub-flow | Private Ballerina function |
+| Async processor | \`start\` expression (detached worker) |
+| Property placeholder \`\${prop}\` | \`configurable\` variable in \`configs.bal\` |`;
+    }
+    if (platform === 'tibco') {
+        return `| TIBCO BW construct | Ballerina equivalent |
+|---|---|
+| HTTP Receive / Reply | \`http:Listener\` + \`service\` |
+| HTTP Send | \`http:Client\` |
+| SOAP Call | \`ballerina/http\` + \`ballerina/xmldata\` |
+| Invoke REST API | \`http:Client\` |
+| Mapper / Transform | Expression-bodied function in \`data_mappings.bal\` |
+| XPath expression | Inline expression or \`ballerina/xmldata\` |
+| Substitution variable | \`configurable\` in \`configs.bal\` |
+| EMS Publish | \`ballerinax/java.jms\` producer |
+| EMS Subscribe | \`ballerinax/java.jms\` consumer |
+| JDBC Query / Update | \`ballerinax/jdbc\` or \`ballerinax/mysql\` |
+| File Read / Write | \`ballerina/file\` + \`ballerina/io\` |
+| SFTP Get / Put | \`ballerinax/sftp\` |
+| Catch / Catch All | \`on fail\` / \`do { } on fail { }\` |
+| Compensate | \`transaction { } on fail { }\` |
+| Call Process | Ballerina function call |
+| Group (error handler scope) | \`do { ... } on fail var e { ... }\` |
+| Timer | \`ballerina/task\` timer |
+| BW property \`%%var%%\` | \`configurable\` variable |`;
+    }
+    return `| Source construct | Ballerina equivalent |
+|---|---|
+| HTTP listener / endpoint | \`http:Listener\` + \`service\` |
+| HTTP outbound call | \`http:Client\` |
+| Data transformation | Expression-bodied function in \`data_mappings.bal\` |
+| Configuration / properties | \`configurable\` + \`Config.toml\` |
+| Error handling (propagate) | \`on fail\` / \`check\` |
+| Error handling (continue) | \`do { } on fail { }\` |
+| Message queue | \`ballerinax/rabbitmq\` or \`ballerinax/kafka\` |
+| Scheduler | \`ballerina/task\` timer |
+| Flow/process reference | Ballerina function call |`;
+}
+
+// ---------------------------------------------------------------------------
 // Shared context — included at the top of every stage prompt
 // ---------------------------------------------------------------------------
 
-function getSharedEnhancementContext(keepStructure: boolean = false): string {
-    return `You are enhancing a Ballerina project that was automatically migrated from an external integration
-platform (e.g. MuleSoft Mule 3/4, TIBCO BusinessWorks, or similar) by a static code migration tool. The tool
-produced a structurally valid Ballerina package (or workspace with multiple packages) but left \`// TODO\` and
-\`// FIXME\` comments where it could not fully translate a construct, and may have introduced compilation errors.
+function getSharedEnhancementContext(context: MigrationContext): string {
+    const { keepStructure } = context;
+    const platformName = getPlatformName(context.sourcePlatform);
+    const platformExpertise = getPlatformExpertise(context.sourcePlatform);
 
-**Apply your combined knowledge of the source integration platform and Ballerina throughout this task.**
+    return `You are an integration expert in **${platformExpertise}** and **Ballerina**. You are enhancing a
+Ballerina project that was automatically migrated from **${platformName}** by a static code migration tool.
+
+**Role and goal:** The rule-based migration output is a structural skeleton — it provides a starting point
+and skeleton code, but it is NOT the complete migration. Your job is to verify that every construct from the
+original ${platformName} source is correctly represented in Ballerina and to implement anything that is
+missing or incomplete. The output does not need to follow idiomatic Ballerina style (that is a separate
+refactoring stage) — it must be **functionally correct, complete, and compilable**.
 
 ---
 
@@ -185,7 +321,7 @@ These rules are **non-negotiable**. Violating any of them means the enhancement 
 3. **Edit files in place — always.** Use \`file_edit\` / \`file_multi_edit\` on existing files.
    **NEVER** create \`*_new.bal\`, \`*_backup.bal\`, \`*_v2.bal\`, or any copy of an existing file.
    If a file is large, break your edits into multiple \`file_edit\` calls targeting different regions.
-4. **No stubs or placeholders.** Every TODO must become real, runnable Ballerina logic — not an empty
+4. **No stubs or placeholders.** Every construct must become real, runnable Ballerina logic — not an empty
    function, not a \`return {}\`, not a \`return ""\`, not a \`// placeholder\`. If a DataWeave transform
    is 200 lines, translate all 200 lines.
 5. **No empty files.** Never create a file that contains only comments or is empty.
@@ -193,25 +329,9 @@ These rules are **non-negotiable**. Violating any of them means the enhancement 
    If you are writing more than 3 sentences without a tool call, stop and make an edit instead.
 7. **\`file_write\` is ONLY for new files.** ${keepStructure
     ? `Most \`.bal\` files that correspond to original source files should already exist. Use \`file_edit\` / \`file_multi_edit\` to modify them. Use \`file_write\` only if a required matching \`.bal\` file is missing from the migration output.`
-    : `Files like \`functions.bal\`, \`data_mappings.bal\`, \`main.bal\`, \`configs.bal\`, \`types.bal\` etc. that appear in the initial project source ALREADY EXIST. You must use \`file_edit\` / \`file_multi_edit\` to modify them. Use \`file_write\` only when creating a file that has no content yet (e.g. an entirely new \`.bal\` file the migration tool did not produce).`}
+    : `Files like \`functions.bal\`, \`data_mappings.bal\`, \`main.bal\`, \`configs.bal\`, \`types.bal\` etc. that appear in the initial project source ALREADY EXIST. You must use \`file_edit\` / \`file_multi_edit\` to modify them. Use \`file_write\` only when creating a file that has no content yet.`}
 8. **Never write a "Summary" or "Remaining Work" section.** Do not output a final summary of completed
-   and remaining work. Just keep editing files until every TODO is resolved.
-
----
-
-## Mandatory Workflow: Process One File at a Time
-
-**This is the most important workflow rule.** Do NOT read all original source files upfront. Instead:
-
-1. Pick one \`.bal\` file that has TODOs/FIXMEs (${keepStructure ? 'prioritize files with the most TODOs' : 'start with `main.bal`, then `functions.bal`, then others'}).
-2. For each TODO in that file, read **only** the specific original source file related to that TODO
-   (using \`migration_source_read\`). Do not read unrelated source files.
-3. Implement the fix using \`file_edit\` / \`file_multi_edit\`.
-4. Move to the next TODO in the same file, or the next file.
-5. Output a one-line progress note: "Resolved 3/7 TODOs in functions.bal".
-
-**Why:** Reading all source files at once fills your context window before you make any edits, leaving
-no room for the actual implementation work. Read just-in-time, edit immediately.
+   and remaining work. Just keep editing files until the stage criteria are met.
 
 ---
 
@@ -241,19 +361,17 @@ ${keepStructure ? `### Original Source File Structure Preserved
 
 This project was migrated with **\`--keep-structure\`** enabled. Each \`.bal\` file corresponds
 to one original source file. The source filename and its directory path are encoded into the \`.bal\`
-filename — for example, MuleSoft's \`foo/bar.xml\` becomes \`foo_bar.bal\`; TIBCO may use a similar
-but different encoding. **Do not assume the \`.bal\` filename exactly matches the source filename.**
+filename. For ${platformName === 'MuleSoft Mule 3/4' ? "MuleSoft: `foo/bar.xml` becomes `foo_bar.bal`" : "TIBCO: `foo/Bar.bwp` becomes a similarly named `.bal` file"}.
+**Do not assume the \`.bal\` filename exactly matches the source filename** — use \`migration_source_list\`
+and \`file_list\` together to establish the mapping.
 
 The BI standard layout (\`functions.bal\`, \`main.bal\`, \`data_mappings.bal\`, etc.) does NOT apply here.
-**Do NOT reorganize, rename, or merge files into the BI layout.**
-
-When identifying which \`.bal\` file corresponds to a source file, use \`migration_source_list\` and
-\`file_list\` together in Phase A — compare the two lists rather than guessing by name.` : `### Default BI file structure
+**Do NOT reorganize, rename, or merge files into the BI layout.**` : `### Default BI File Structure
 | File | Contents |
 |---|---|
 | \`main.bal\` | HTTP/scheduler listeners, services, class definitions |
 | \`functions.bal\` | Block-body functions from source flows/sub-flows |
-| \`data_mappings.bal\` | Expression-bodied functions from DataWeave/XSLT transforms |
+| \`data_mappings.bal\` | Expression-bodied functions from DataWeave/XSLT/Mapper transforms |
 | \`automations.bal\` | The \`main\` function (scheduled/batch flows) |
 | \`types.bal\` | All \`type\` definitions |
 | \`configs.bal\` | \`configurable\` variables |
@@ -268,17 +386,18 @@ Every \`configurable\` variable must have a corresponding entry in \`Config.toml
 
 ## Original Source Context
 
-You have two tools for reading the original source project:
-- **\`migration_source_list\`**: List files/directories.
-- **\`migration_source_read\`**: Read a specific file.
+You have two tools for reading the original ${platformName} source project:
+- **\`migration_source_list\`**: List files/directories in the source project.
+- **\`migration_source_read\`**: Read a specific source file.
 
-**Read source files on-demand** — only when you need them for a specific TODO you are about to resolve.
-Do NOT read all source files as a first step.
+### Source file type → Ballerina mapping reference
+
+${getSourceInventoryTable(context.sourcePlatform)}
 
 ### Handling missing original source
-If the source cannot be found:
+If a source file cannot be read:
 1. Implement what can be inferred from surrounding code and platform knowledge.
-2. Must be syntactically and type-correct.
+2. Ensure the result is syntactically and type-correct.
 3. Leave a scoped comment noting the approximation.
 4. **Never leave an empty stub.**
 
@@ -298,90 +417,191 @@ Process one package at a time. Read other packages for context but only modify t
 }
 
 // ---------------------------------------------------------------------------
-// Stage 1 — Fidelity Check + Resolve TODO/FIXME Comments
+// Stage 0 — Source Inventory & Gap Analysis (read-only)
 // ---------------------------------------------------------------------------
 
-function getStage1Prompt(keepStructure: boolean = false): string {
-    return `## Your Task — Stage 1: Fidelity Check + Resolve TODO/FIXME Comments
+function getStage0Prompt(context: MigrationContext): string {
+    const { keepStructure } = context;
+    const platformName = getPlatformName(context.sourcePlatform);
 
-Your sole focus: resolve every TODO/FIXME in source files (excluding \`tests/\`). A later stage handles
-diagnostics, tests, and documentation.
+    return `## Your Task — Stage 0: Source Inventory & Gap Analysis
 
-> **Do NOT** create any documentation files. **Do NOT** fix compilation errors (Stage 2 does that).
-> **Do NOT** create \`functions_new.bal\`, \`data_mappings_new.bal\`, or ANY copy of existing files.
+This is a **read-only stage** — you will NOT edit any files. Your sole output is a structured inventory
+that Stage 1 will use as its work plan.
+
+> **Do NOT edit any Ballerina files.** Do NOT create documentation files. Just list and categorise.
+
+### Why this stage exists
+
+The rule-based migration tool may silently drop ${platformName} constructs without leaving a \`// TODO\`
+marker — for example, DataWeave scripts with complex logic, RAML/WSDL-defined types, substitution
+variables, or secondary flow files. Stage 1 would miss these if it only scanned for TODO comments.
+This stage surfaces the complete scope before any editing begins.
 
 ### Workflow — Follow This Exact Order
 
-**Phase A: Quick fidelity scan (≤ 3 tool calls)**
-1. Call \`migration_source_list\` on the root directory (\`.\`) to see the source project structure.
-2. Compare the listed source files against the Ballerina project files in the initial message.
-3. Note any source constructs that have **no** Ballerina counterpart — you will implement them during Phase B.
-   **Do NOT read every source file now.** Just note which files exist.
+**Step 1: List the full source tree (1–2 tool calls)**
+1. Call \`migration_source_list(".")\` to get the top-level structure.
+2. For directories that likely contain important files (\`src/main/\`, \`src/test/\`, or root for TIBCO),
+   call \`migration_source_list\` once more to see their contents.
+   Do NOT recursively list every subdirectory — 2 calls maximum.
 
-**Phase B: Resolve TODOs file by file**
+**Step 2: Categorize source files**
 
-${keepStructure
-    ? `Start with \`todo.bal\` if present, then process each \`.bal\` file that contains TODOs in the order shown in the initial message.`
-    : `Process files in this order: \`todo.bal\` → \`main.bal\` → \`functions.bal\` → \`data_mappings.bal\` → other \`.bal\` files.`}
+Using the source file type table in the shared context above, classify every meaningful file into one
+of these categories:
+- **Flows/processes** — the main business logic
+- **Transformations** — DataWeave, XPath, XSLT, Mapper
+- **API specs** — RAML, WSDL
+- **Schemas** — XSD, JSON Schema
+- **Configuration** — properties, substvar, YAML config
+- **Connections** — shared resources, global connectors
+- **Tests** — MUnit, BW test processes
+- **Build** — pom.xml, MANIFEST.MF
+- **Skip** — generated files, IDE metadata, irrelevant assets
 
-For each file:
-1. Scan the file content (already in the initial message) for \`// TODO\` and \`// FIXME\` comments.
-2. For each TODO:
-   a. If it references a specific source construct/file, call \`migration_source_read\` to read **only that file**.
-   b. Implement the fix immediately using \`file_edit\` or \`file_multi_edit\`.
-   c. For \`// TODO: UNSUPPORTED ... BLOCK ENCOUNTERED\` comments: the commented-out source between the
-      \`// ---\` lines is the specification. Translate it to Ballerina and remove the entire commented block.
-3. After finishing all TODOs in one file, output one line: "✅ \`<filename>\`: resolved N TODOs".
-4. Move to the next file.
+**Step 3: Cross-reference with Ballerina output**
 
-**Phase C: Fidelity-gap implementation**
+For each meaningful source file, determine its coverage status in the Ballerina project
+(use the file list already in your initial message):
+- **✅ Covered** — a Ballerina file clearly implements this source file's constructs
+- **⚠️ Partial** — a Ballerina file exists but has \`// TODO\` / \`// FIXME\` markers suggesting
+  incomplete translation of this source file
+- **❌ Missing** — no Ballerina counterpart exists; the migration tool silently dropped it
 
-Using the notes from Phase A, implement any source constructs that were silently dropped by the migration
-tool. Read the specific source file, then ${keepStructure
-    ? `add the corresponding Ballerina code to the \`.bal\` file that corresponds to the source file (use \`migration_source_list\` and \`file_list\` to identify the correct file — names are not an exact match). If no matching \`.bal\` file exists, create one with \`file_write\`.`
-    : `add the corresponding Ballerina code to the appropriate \`.bal\` file.`}
+${keepStructure ? `**Note (--keep-structure):** Each \`.bal\` file maps 1:1 to a source file. Use \`file_list\` and \`migration_source_list\` together to establish which \`.bal\` corresponds to which source file by comparing encoded file paths in the names.` : ""}
+
+**Step 4: Output your inventory**
+
+Output the inventory as plain text in this format (this is working notes for Stage 1, NOT a file):
+
+\`\`\`
+SOURCE INVENTORY — ${platformName}
+===================================
+
+FLOWS / PROCESSES
+  [✅/⚠️/❌] <source-file-path>  →  <ballerina-file-or-"MISSING">
+  ...
+
+TRANSFORMATIONS
+  [✅/⚠️/❌] <source-file-path>  →  <ballerina-file-or-"MISSING">
+  ...
+
+API SPECS / SCHEMAS
+  ...
+
+CONFIGURATION
+  ...
+
+CONNECTIONS
+  ...
+
+TESTS
+  ...
+
+GAPS REQUIRING IMPLEMENTATION IN STAGE 1:
+  1. <description of most critical gap>
+  2. ...
+\`\`\`
+
+### Completion Criteria for Stage 0
+
+Output the inventory above, then stop. Do not edit any files. Stage 1 will implement all gaps.`;
+}
+
+// ---------------------------------------------------------------------------
+// Stage 1 — Source-First Fidelity Implementation
+// ---------------------------------------------------------------------------
+
+function getStage1Prompt(context: MigrationContext): string {
+    const { keepStructure } = context;
+    const platformName = getPlatformName(context.sourcePlatform);
+    const connectorTable = getConnectorMappingTable(context.sourcePlatform);
+
+    return `## Your Task — Stage 1: Source-First Fidelity Implementation
+
+Your sole focus: ensure **every construct in the ${platformName} source project is correctly and completely
+represented in the Ballerina output**. A later stage handles compilation diagnostics, tests, and documentation.
+
+> **Do NOT** create any documentation files. **Do NOT** fix compilation errors unless they block you
+> from implementing a construct (Stage 2 does that). **Do NOT** create any \`*_new.bal\` or copy files.
+
+### Core Principle: Source Is Ground Truth
+
+The rule-based migration output is a **skeleton** — it guides file structure and provides a starting
+point, but it does not define completeness. Your work is driven by the ${platformName} source, not by
+what the migration tool flagged with \`// TODO\`.
+
+**A source construct with no \`// TODO\` marker is NOT automatically complete — it must still be verified.**
+
+### Workflow — Follow This Exact Order
+
+**Phase A: Load your work plan from Stage 0**
+
+The Stage 0 inventory is in your context (from the previous stage output). Use it as your work list.
+Process source files in this priority order:
+1. ❌ Missing — constructs the tool silently dropped (highest priority)
+2. ⚠️ Partial — constructs with \`// TODO\` or \`// FIXME\` markers
+3. ✅ Covered — verify correctness of already-translated constructs (spot-check, don't skip)
+
+If Stage 0 output is not in your context (e.g. this is a resumed session), call
+\`migration_source_list(".")\` to re-establish the source structure, then proceed.
+
+**Phase B: Process one source file at a time**
+
+For each source file in your work plan:
+
+1. **Read the source file** using \`migration_source_read\`.
+2. **Identify all constructs**: flows, sub-flows, transformations, error handlers, connectors, configs,
+   type definitions — everything meaningful.
+3. **Locate the Ballerina counterpart**:
+   ${keepStructure
+       ? '- Use `migration_source_list` + `file_list` to find the matching `.bal` file (names are encoded, not exact).'
+       : '- Map to the appropriate BI layout file using the source file type table.'}
+4. **Verify completeness**: Does the Ballerina code implement every construct from the source?
+   Check for: missing flows, stub functions, incomplete DataWeave translations, missing type definitions,
+   missing config variables, empty error handlers, TODO/FIXME comments.
+5. **Implement gaps immediately** using \`file_edit\` / \`file_multi_edit\`.
+   - For \`// TODO: UNSUPPORTED ... BLOCK ENCOUNTERED\`: the commented-out source between \`// ---\` lines
+     is the spec — translate it to Ballerina and remove the entire commented block.
+   - For silently dropped constructs: add them to the correct \`.bal\` file.
+6. Output one line after each source file: "✅ \`<source-file>\`: verified / implemented N constructs."
+7. Move to the next source file.
+
+**Phase C: Check configuration coverage**
+
+${context.sourcePlatform === 'mule'
+    ? `- Read all \`.properties\` files from the source. Ensure every property key has a \`configurable\` in \`configs.bal\` and an entry in \`Config.toml\`.
+- Read the RAML spec (if present). Ensure all RAML-defined types are in \`types.bal\` and all endpoints are in \`main.bal\`.`
+    : context.sourcePlatform === 'tibco'
+    ? `- Read all \`.substvar\` files. Ensure every substitution variable has a \`configurable\` in \`configs.bal\` and an entry in \`Config.toml\`.
+- Read all \`.sharedhttp\`, \`.sharedjdbc\`, \`.jmsqueue\`, \`.jmstopic\` files. Ensure connections are in \`connections.bal\`.`
+    : `- Read configuration files (properties, substvar, YAML). Ensure every config key is in \`configs.bal\` and \`Config.toml\`.`}
 
 **Phase D: Clean up todo.bal**
 
 If all constructs from \`todo.bal\` have been moved to their correct files, delete \`todo.bal\`.
 If some remain, continue implementing them.
 
-### Connector / Construct Mapping Quick Reference
+### Construct Mapping Reference — ${platformName}
 
-| Source construct | Ballerina equivalent |
-|---|---|
-| Custom loggers (json-logger, etc.) | \`log:printInfo\` / \`log:printError\` with structured fields |
-| Object stores / caches | \`ballerina/cache\` or \`map\` variable |
-| Message queues (Anypoint MQ, JMS) | \`ballerinax/rabbitmq\`, \`kafka\`, or \`java.jms\` |
-| Batch processors | \`foreach\` with error collection, or \`fork\`/\`worker\` |
-| Schedulers | \`ballerina/task\` or \`@schedule\` annotation |
-| DataWeave transforms | Expression-bodied Ballerina functions |
-| SOAP/XML services | \`ballerina/http\` + \`ballerina/xmldata\` |
-| Choice routers | \`if\`/\`else\` or \`match\` |
-| Error handling (on-error-propagate) | \`on fail\` / \`check\` |
-| Error handling (on-error-continue) | \`do { } on fail { }\` (no re-throw) |
-| Scatter-gather | \`fork\`/\`worker\` or \`future\` types |
-| Flow references | Ballerina function calls |
+${connectorTable}
 
 ### Anti-Patterns — DO NOT DO THESE
 
-The following actions are **failures**. If you catch yourself doing any of them, stop immediately:
-
-❌ Reading 4+ original source files before making your first \`file_edit\` call.
+❌ Starting with TODO/FIXME scanning instead of source file reading.
+❌ Marking a source file as "done" without reading it.
 ❌ Creating \`functions_new.bal\`, \`data_mappings_new.bal\`, or any "-new" / "-v2" / "_backup" file.
-❌ Using \`file_write\` on a file that already has content (\`functions.bal\`, \`main.bal\`, etc.).
-❌ Writing a "Summary", "Remaining Work", "Next Steps", or "Recommendation" section.
-❌ Saying "Due to complexity..." or "Given the size..." or "time constraints" and stopping.
-❌ Creating a function that returns \`{}\`, \`""\`, \`()\`, or \`0\` as a "placeholder".
+❌ Using \`file_write\` on a file that already exists.
+❌ Translating only part of a DataWeave script or Mapper and leaving stubs for the rest.
+❌ Writing a "Summary", "Remaining Work", "Next Steps" section.
+❌ Saying "Due to complexity..." or "token limits" and stopping.
 ❌ Writing more than 3 sentences of text between two consecutive tool calls.
-
-If a DataWeave file is 400 lines, you translate all 400 lines. Break the work into multiple
-\`file_edit\` calls if needed, each handling a section of the file.
 
 ### Completion Criteria
 
-When every TODO/FIXME in source files (excluding \`tests/\`) is resolved, output one line:
-"Stage 1 complete: resolved N TODOs across M files. todo.bal: [deleted | N constructs remain]."
+When every source file in your work plan has been read and verified/implemented, output one line:
+"Stage 1 complete: processed N source files, implemented M constructs. todo.bal: [deleted | N remain]."
 Then stop. Do not write anything else.`;
 }
 
@@ -389,12 +609,13 @@ Then stop. Do not write anything else.`;
 // Stage 2 — Zero Compilation Diagnostics
 // ---------------------------------------------------------------------------
 
-function getStage2Prompt(): string {
+function getStage2Prompt(context: MigrationContext): string {
+    const platformName = getPlatformName(context.sourcePlatform);
     return `## Your Task — Stage 2: Achieve Zero Compilation Diagnostics
 
-You are running **Stage 2** of the enhancement pipeline. The previous stage resolved all TODO/FIXME comments.
-Your sole focus is achieving **zero error-level compilation diagnostics** across all source files
-(excluding \`tests/\`).
+You are running **Stage 2** of the enhancement pipeline. The previous stage verified all ${platformName}
+source constructs and implemented missing ones. Your sole focus is achieving **zero error-level compilation
+diagnostics** across all source files (excluding \`tests/\`).
 
 > **Do NOT** create \`ENHANCEMENT_SUMMARY.md\` or any documentation files during this stage.
 > **Do NOT** work on test files — that is Stage 3.
@@ -421,8 +642,8 @@ Your sole focus is achieving **zero error-level compilation diagnostics** across
 - If a diagnostic cannot be fixed by consulting the original source (because the source itself was broken
   or absent), apply the minimum change that makes the code compile: widen a type to \`anydata\`, extract a
   helper function with a compatible signature, etc. Always add a scoped comment explaining the approximation.
-- You may use \`migration_source_read\` if you need to check original source for context while fixing errors.
-- If the previous stage left any unresolved TODOs that cause compilation errors, fix them now.
+- You may use \`migration_source_read\` if you need to check original ${platformName} source for context.
+- If Stage 1 left any unresolved constructs that cause compilation errors, fix them now.
 
 ### Completion Criteria for Stage 2
 
@@ -437,12 +658,19 @@ Then stop. Stage 3 will handle test files.`;
 // Stage 3 — Test Refinement
 // ---------------------------------------------------------------------------
 
-function getStage3Prompt(): string {
+function getStage3Prompt(context: MigrationContext): string {
+    const platformName = getPlatformName(context.sourcePlatform);
+    const testFileRef = context.sourcePlatform === 'mule'
+        ? 'MUnit XML files (typically under `src/test/munit/`)'
+        : context.sourcePlatform === 'tibco'
+        ? 'BW test processes (`*.bwtest` files)'
+        : 'original test files';
+
     return `## Your Task — Stage 3: Refine and Validate Test Files
 
-You are running **Stage 3** of the enhancement pipeline. Stages 1 and 2 have already resolved all TODOs
-and achieved zero compilation diagnostics in source files. Your sole focus is making the test files in
-\`tests/\` complete, correctly typed, and compilation-error free.
+You are running **Stage 3** of the enhancement pipeline. Stages 1 and 2 have verified all ${platformName}
+constructs and achieved zero compilation diagnostics in source files. Your sole focus is making the test
+files in \`tests/\` complete, correctly typed, and compilation-error free.
 
 > **Tests are not executed during this stage.** The goal is to produce structurally complete, correctly-typed
 > test files. Test execution and pass/fail validation is handled in a separate subsequent step.
@@ -453,15 +681,15 @@ and achieved zero compilation diagnostics in source files. Your sole focus is ma
 Before touching any test file:
 1. Read the enhanced Ballerina source files (\`functions.bal\`, \`data_mappings.bal\`, \`main.bal\`, etc.) to
    understand actual function signatures, return types, error paths, and data shapes.
-2. Use \`migration_source_list\` and \`migration_source_read\` to read original test files (e.g. MUnit XML
-   under \`src/test/munit/\`) to understand the original test scenarios.
+2. Use \`migration_source_list\` and \`migration_source_read\` to read the ${testFileRef}
+   to understand the original test scenarios and assertions.
 
 ### For each test file in \`tests/\`:
 
 1. **Align with enhanced implementation**: Verify test calls match current function signatures. Update
    call sites if signatures changed during Stages 1/2.
-2. **Align with original test intent**: Cross-reference each test against original test files. If the
-   original mocked a connector, mock the equivalent \`ballerinax/\` client using \`@test:Mock\`.
+2. **Align with original test intent**: Cross-reference each test against the ${testFileRef}.
+   If the original mocked a connector, mock the equivalent \`ballerinax/\` client using \`@test:Mock\`.
 3. **Resolve all \`// TODO\` and \`// FIXME\` comments** with correct test logic.
 4. **Ensure meaningful assertions**: Every \`@test:Config\` function must have at least one substantive
    assertion (\`test:assertEquals\`, \`test:assertTrue\`, \`test:assertFail\`, etc.). No trivially-true checks.
@@ -488,8 +716,9 @@ Then stop. Stage 4 will handle final validation and documentation.`;
 function getStage4Prompt(): string {
     return `## Your Task — Stage 4: Final Validation & Documentation
 
-You are running the **final stage** of the enhancement pipeline. Stages 1–3 have resolved TODOs, fixed
-diagnostics, and refined test files. Your focus is verifying completeness and writing \`ENHANCEMENT_SUMMARY.md\`.
+You are running the **final stage** of the enhancement pipeline. Stages 1–3 have verified all source
+constructs, fixed diagnostics, and refined test files. Your focus is verifying completeness and writing
+\`ENHANCEMENT_SUMMARY.md\`.
 
 ### Validation Checklist
 
@@ -517,8 +746,8 @@ After the checklist passes, create \`ENHANCEMENT_SUMMARY.md\` in the package roo
 
 ## Changes Made
 
-### Fidelity Fixes
-List constructs silently dropped by the static tool that were completed during fidelity check.
+### Source Constructs Implemented
+List constructs that were missing or incomplete in the migration output and were implemented in Stage 1.
 
 ### TODO / FIXME Resolutions
 List every TODO/FIXME resolved: file, original comment, what was implemented.
@@ -622,7 +851,7 @@ Output: "Workspace validation complete — 0 errors across ${packageCount} packa
 
 /**
  * Returns a lightweight enhancement prompt for demo or quick validation scenarios.
- * This prompt is NOT used in the main wizard flow, but can be used for lightweight demos.
+ * This prompt is NOT used in the main wizard flow.
  */
 export function getLightweightEnhancementPrompt(): string {
   return `You are enhancing a Ballerina project that was automatically migrated from a legacy integration platform.

--- a/packages/ballerina-extension/src/features/ai/migration/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/prompts.ts
@@ -65,6 +65,11 @@ export function getEnhancementStages(context: MigrationContext): EnhancementStag
             prompt: shared + "\n\n" + getStage4Prompt(),
             agentLimits: { maxSteps: 50, maxOutputTokens: 16384 },
         },
+        {
+            name: "Stage 5 — Idiomatic Refactoring",
+            prompt: shared + "\n\n" + getStage5Prompt(context),
+            agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
+        },
     ];
 }
 
@@ -144,6 +149,11 @@ export function getPerProjectEnhancementStages(
             name: `[${packageName}] Stage 4 — Final Validation & Documentation`,
             prompt: shared + "\n\n" + getStage4Prompt() + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 50, maxOutputTokens: 16384 },
+        },
+        {
+            name: `[${packageName}] Stage 5 — Idiomatic Refactoring`,
+            prompt: shared + "\n\n" + getStage5Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
+            agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
         },
     ];
 }
@@ -799,6 +809,93 @@ Summarise anything requiring human review.
 ### Completion Criteria for Stage 4
 
 Output the final status: checklist results and confirmation that \`ENHANCEMENT_SUMMARY.md\` was written.`;
+}
+
+// ---------------------------------------------------------------------------
+// Stage 5 – Idiomatic refactoring (wrapper elimination, renaming, check normalization)
+// ---------------------------------------------------------------------------
+
+function getStage5Prompt(context: MigrationContext): string {
+    const platform = getPlatformName(context.sourcePlatform);
+    return `## Your Task — Stage 5: Idiomatic Refactoring
+
+Stages 0–4 produced functionally correct, compilable Ballerina code migrated from ${platform}.
+Stage 5 refactors that code toward idiomatic Ballerina style without changing any observable behaviour.
+
+**Scope constraint — public symbols are frozen:**
+Only modify \`private\` functions, types, and variables. Functions, types, and \`public\` variables
+exported from this package MUST NOT be renamed or have their signatures changed. This protects callers
+in other packages and in tests.
+
+**After each phase:** run diagnostics and confirm zero new errors before proceeding to the next.
+
+### Phase A — Eliminate Redundant Wrapper Functions
+
+A redundant wrapper is a **private** function whose entire body is a single \`return otherFn(args)\` call
+with no additional logic (e.g. \`function setPayload_3(...) { return transformSetPayload_3(...); }\`).
+
+Steps:
+1. Scan all \`.bal\` files for private functions with single-expression bodies.
+2. For each candidate:
+   a. Confirm it does not have the \`public\` keyword.
+   b. Collect every call site across the package (including test files).
+   c. Replace each call site with the inner call.
+   d. Delete the wrapper function.
+3. Run diagnostics after each deletion. Fix any errors before moving to the next wrapper.
+
+Do NOT inline if:
+- The function has the \`public\` keyword.
+- The function is recursive.
+- Any call site inlining would exceed 120 characters and cannot be cleanly split.
+
+### Phase B — Rename Auto-Generated Private Identifiers
+
+Auto-generated identifiers match patterns like: \`var_payload_2\`, \`processOrder_1\`,
+\`SetVariable_4_Output\`, \`get_api_orders_orderId_application_json_apiConfig_1\`,
+\`transform_setCorrelationId_3\`.
+
+A name is auto-generated if it:
+- Ends with \`_<digits>\` (e.g. \`_1\`, \`_3\`)
+- Contains platform DSL segments (e.g. \`application_json\`, \`on_error_propagate\`, \`ProcessService\`)
+- Uses PascalCase for a function (Ballerina convention is camelCase for functions)
+
+Steps:
+1. List all private function names, local variable names, and private type names in \`.bal\` files.
+2. For each auto-generated identifier:
+   a. Read the corresponding source file via \`migration_source_read\` to understand semantic intent.
+   b. Derive a camelCase name (functions/variables) or PascalCase name (types).
+   c. Find all references in the package.
+   d. Rename declaration + all references atomically with \`file_multi_edit\`.
+3. Run diagnostics after all renames. Fix any name collisions before continuing.
+
+Rules:
+- Skip \`main\`, \`init\`, and test functions (names beginning with \`test\`).
+- If the existing name is already readable (e.g. \`processOrder\`), skip it.
+- When source context is unavailable, derive the name from the function body's logic.
+
+### Phase C — Normalize Error Propagation
+
+Convert verbose error re-return patterns to idiomatic \`check\`:
+
+| Before | After |
+|---|---|
+| \`T|error result = expr;\` followed by \`if result is error { return result; }\` | \`T result = check expr;\` |
+| \`if x is error { return error("msg", x); }\` | Leave unchanged — error is transformed |
+| \`if x is error { log:printError(...); return x; }\` | Leave unchanged — has a side effect |
+
+Steps:
+1. Scan \`.bal\` files for: assignment to a \`T|error\` union type, immediately followed by a guard that
+   re-returns the error **unchanged** (no wrapping, no logging, no transformation).
+2. Combine into a single \`check\` expression and remove the now-unused guard.
+3. Run diagnostics after each file.
+
+### Completion
+
+1. Run diagnostics. Confirm zero new errors vs. the Stage 4 baseline.
+2. Append a \`## Refactoring Changes (Stage 5)\` section to the existing \`ENHANCEMENT_SUMMARY.md\`:
+   - Wrapper functions eliminated (count)
+   - Private identifiers renamed (old → new list)
+   - Error propagation patterns simplified (count)`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ballerina-extension/src/features/ai/migration/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/prompts.ts
@@ -41,32 +41,32 @@ export function getEnhancementStages(context: MigrationContext): EnhancementStag
     const shared = getSharedEnhancementContext(context);
     return [
         {
-            name: "Stage 0 — Source Inventory & Gap Analysis",
+            name: "Stage 1 — Source Inventory & Gap Analysis",
             prompt: shared + "\n\n" + getStage0Prompt(context),
             agentLimits: { maxSteps: 50, maxOutputTokens: 8192 },
         },
         {
-            name: "Stage 1 — Source-First Fidelity Implementation",
+            name: "Stage 2 — Source-First Fidelity Implementation",
             prompt: shared + "\n\n" + getStage1Prompt(context),
             agentLimits: { maxSteps: 200, maxOutputTokens: 16384 },
         },
         {
-            name: "Stage 2 — Zero Compilation Diagnostics",
+            name: "Stage 3 — Zero Compilation Diagnostics",
             prompt: shared + "\n\n" + getStage2Prompt(context),
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
-            name: "Stage 3 — Test Refinement",
+            name: "Stage 4 — Test Refinement",
             prompt: shared + "\n\n" + getStage3Prompt(context),
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
-            name: "Stage 4 — Final Validation & Documentation",
+            name: "Stage 5 — Final Validation & Documentation",
             prompt: shared + "\n\n" + getStage4Prompt(),
             agentLimits: { maxSteps: 50, maxOutputTokens: 16384 },
         },
         {
-            name: "Stage 5 — Idiomatic Refactoring",
+            name: "Stage 6 — Idiomatic Refactoring",
             prompt: shared + "\n\n" + getStage5Prompt(context),
             agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
         },
@@ -126,32 +126,32 @@ export function getPerProjectEnhancementStages(
     const shared = preamble + "\n\n" + getSharedEnhancementContext(context);
     return [
         {
-            name: `[${packageName}] Stage 0 — Source Inventory & Gap Analysis`,
+            name: `[${packageName}] Stage 1 — Source Inventory & Gap Analysis`,
             prompt: shared + "\n\n" + getStage0Prompt(context),
             agentLimits: { maxSteps: 50, maxOutputTokens: 8192 },
         },
         {
-            name: `[${packageName}] Stage 1 — Source-First Fidelity Implementation`,
+            name: `[${packageName}] Stage 2 — Source-First Fidelity Implementation`,
             prompt: shared + "\n\n" + getStage1Prompt(context),
             agentLimits: { maxSteps: 200, maxOutputTokens: 16384 },
         },
         {
-            name: `[${packageName}] Stage 2 — Zero Compilation Diagnostics`,
+            name: `[${packageName}] Stage 3 — Zero Compilation Diagnostics`,
             prompt: shared + "\n\n" + getStage2Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
-            name: `[${packageName}] Stage 3 — Test Refinement`,
+            name: `[${packageName}] Stage 4 — Test Refinement`,
             prompt: shared + "\n\n" + getStage3Prompt(context),
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
-            name: `[${packageName}] Stage 4 — Final Validation & Documentation`,
+            name: `[${packageName}] Stage 5 — Final Validation & Documentation`,
             prompt: shared + "\n\n" + getStage4Prompt() + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 50, maxOutputTokens: 16384 },
         },
         {
-            name: `[${packageName}] Stage 5 — Idiomatic Refactoring`,
+            name: `[${packageName}] Stage 6 — Idiomatic Refactoring`,
             prompt: shared + "\n\n" + getStage5Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
         },
@@ -324,7 +324,7 @@ These rules are **non-negotiable**. Violating any of them means the enhancement 
 
 1. **IMPLEMENT, do not document.** Write working Ballerina code. Never produce summaries, roadmaps,
    remaining-work lists, or explanations of what _should_ be done instead of doing it.
-   **Do NOT create** \`NEXT_STEPS.md\`, \`README_MIGRATION.md\`, \`ENHANCEMENT_SUMMARY.md\` (unless Stage 4),
+   **Do NOT create** \`NEXT_STEPS.md\`, \`README_MIGRATION.md\`, \`ENHANCEMENT_SUMMARY.md\` (unless Stage 5),
    or any guide/roadmap/documentation file.
 2. **Never stop early.** "This project is complex", "time constraints", "token limits", "escaping issues"
    are NOT valid reasons to stop. You have ample budget. Keep making \`file_edit\` calls.
@@ -431,14 +431,14 @@ Process one package at a time. Read other packages for context but only modify t
 }
 
 // ---------------------------------------------------------------------------
-// Stage 0 — Source Inventory & Gap Analysis (read-only)
+// Stage 1 — Source Inventory & Gap Analysis (read-only)
 // ---------------------------------------------------------------------------
 
 function getStage0Prompt(context: MigrationContext): string {
     const { keepStructure } = context;
     const platformName = getPlatformName(context.sourcePlatform);
 
-    return `## Your Task — Stage 0: Source Inventory & Gap Analysis
+    return `## Your Task — Stage 1: Source Inventory & Gap Analysis
 
 This is a **read-only stage** — you will NOT edit any files. Your sole output is a structured inventory
 that Stage 1 will use as its work plan.
@@ -518,13 +518,13 @@ GAPS REQUIRING IMPLEMENTATION IN STAGE 1:
   2. ...
 \`\`\`
 
-### Completion Criteria for Stage 0
+### Completion Criteria for Stage 1
 
-Output the inventory above, then stop. Do not edit any files. Stage 1 will implement all gaps.`;
+Output the inventory above, then stop. Do not edit any files. Stage 2 will implement all gaps.`;
 }
 
 // ---------------------------------------------------------------------------
-// Stage 1 — Source-First Fidelity Implementation
+// Stage 2 — Source-First Fidelity Implementation
 // ---------------------------------------------------------------------------
 
 function getStage1Prompt(context: MigrationContext): string {
@@ -532,7 +532,7 @@ function getStage1Prompt(context: MigrationContext): string {
     const platformName = getPlatformName(context.sourcePlatform);
     const connectorTable = getConnectorMappingTable(context.sourcePlatform);
 
-    return `## Your Task — Stage 1: Source-First Fidelity Implementation
+    return `## Your Task — Stage 2: Source-First Fidelity Implementation
 
 Your sole focus: ensure **every construct in the ${platformName} source project is correctly and completely
 represented in the Ballerina output**. A later stage handles compilation diagnostics, tests, and documentation.
@@ -558,7 +558,7 @@ Process source files in this priority order:
 2. ⚠️ Partial — constructs with \`// TODO\` or \`// FIXME\` markers
 3. ✅ Covered — verify correctness of already-translated constructs (spot-check, don't skip)
 
-If Stage 0 output is not in your context (e.g. this is a resumed session), call
+If Stage 1 output is not in your context (e.g. this is a resumed session), call
 \`migration_source_list(".")\` to re-establish the source structure, then proceed.
 
 **Phase B: Process one source file at a time**
@@ -617,19 +617,19 @@ ${connectorTable}
 ### Completion Criteria
 
 When every source file in your work plan has been read and verified/implemented, output one line:
-"Stage 1 complete: processed N source files, implemented M constructs. todo.bal: [deleted | N remain]."
+"Stage 2 complete: processed N source files, implemented M constructs. todo.bal: [deleted | N remain]."
 Then stop. Do not write anything else.`;
 }
 
 // ---------------------------------------------------------------------------
-// Stage 2 — Zero Compilation Diagnostics
+// Stage 3 — Zero Compilation Diagnostics
 // ---------------------------------------------------------------------------
 
 function getStage2Prompt(context: MigrationContext): string {
     const platformName = getPlatformName(context.sourcePlatform);
-    return `## Your Task — Stage 2: Achieve Zero Compilation Diagnostics
+    return `## Your Task — Stage 3: Achieve Zero Compilation Diagnostics
 
-You are running **Stage 2** of the enhancement pipeline. The previous stage verified all ${platformName}
+You are running **Stage 3** of the enhancement pipeline. The previous stage verified all ${platformName}
 source constructs and implemented missing ones. Your sole focus is achieving **zero error-level compilation
 diagnostics** across all source files (excluding \`tests/\`).
 
@@ -659,19 +659,19 @@ diagnostics** across all source files (excluding \`tests/\`).
   or absent), apply the minimum change that makes the code compile: widen a type to \`anydata\`, extract a
   helper function with a compatible signature, etc. Always add a scoped comment explaining the approximation.
 - You may use \`migration_source_read\` if you need to check original ${platformName} source for context.
-- If Stage 1 left any unresolved constructs that cause compilation errors, fix them now.
+- If Stage 2 left any unresolved constructs that cause compilation errors, fix them now.
 
-### Completion Criteria for Stage 2
+### Completion Criteria for Stage 3
 
 When the diagnostics tool reports zero error-level diagnostics for all source files (excluding \`tests/\`):
 - Output the final diagnostics count (should be 0 errors).
 - List any best-effort approximations you made to fix diagnostics.
 
-Then stop. Stage 3 will handle test files.`;
+Then stop. Stage 4 will handle test files.`;
 }
 
 // ---------------------------------------------------------------------------
-// Stage 3 — Test Refinement
+// Stage 4 — Test Refinement
 // ---------------------------------------------------------------------------
 
 function getStage3Prompt(context: MigrationContext): string {
@@ -682,15 +682,15 @@ function getStage3Prompt(context: MigrationContext): string {
         ? 'BW test processes (`*.bwtest` files)'
         : 'original test files';
 
-    return `## Your Task — Stage 3: Refine and Validate Test Files
+    return `## Your Task — Stage 4: Refine and Validate Test Files
 
-You are running **Stage 3** of the enhancement pipeline. Stages 1 and 2 have verified all ${platformName}
+You are running **Stage 4** of the enhancement pipeline. Stages 2 and 3 have verified all ${platformName}
 constructs and achieved zero compilation diagnostics in source files. Your sole focus is making the test
 files in \`tests/\` complete, correctly typed, and compilation-error free.
 
 > **Tests are not executed during this stage.** The goal is to produce structurally complete, correctly-typed
 > test files. Test execution and pass/fail validation is handled in a separate subsequent step.
-> **Do NOT** create \`ENHANCEMENT_SUMMARY.md\` during this stage — that is Stage 4.
+> **Do NOT** create \`ENHANCEMENT_SUMMARY.md\` during this stage — that is Stage 5.
 
 ### Preparation: Build a Behaviour Map
 
@@ -703,7 +703,7 @@ Before touching any test file:
 ### For each test file in \`tests/\`:
 
 1. **Align with enhanced implementation**: Verify test calls match current function signatures. Update
-   call sites if signatures changed during Stages 1/2.
+   call sites if signatures changed during Stages 2/3.
 2. **Align with original test intent**: Cross-reference each test against the ${testFileRef}.
    If the original mocked a connector, mock the equivalent \`ballerinax/\` client using \`@test:Mock\`.
 3. **Resolve all \`// TODO\` and \`// FIXME\` comments** with correct test logic.
@@ -716,23 +716,23 @@ Before touching any test file:
 8. **Ensure test files compile**: Run the diagnostics tool **including** the \`tests/\` directory and fix errors.
 9. **Do not delete or comment out existing test cases.**
 
-### Completion Criteria for Stage 3
+### Completion Criteria for Stage 4
 
 When all test files are complete and compilation-error free:
 - Output the diagnostics count for test files (should be 0 errors).
 - List test functions added or significantly modified.
 
-Then stop. Stage 4 will handle final validation and documentation.`;
+Then stop. Stage 5 will handle final validation and documentation.`;
 }
 
 // ---------------------------------------------------------------------------
-// Stage 4 — Final Validation & Documentation
+// Stage 5 — Final Validation & Documentation
 // ---------------------------------------------------------------------------
 
 function getStage4Prompt(): string {
-    return `## Your Task — Stage 4: Final Validation & Documentation
+    return `## Your Task — Stage 5: Final Validation & Documentation
 
-You are running the **final stage** of the enhancement pipeline. Stages 1–3 have verified all source
+You are running **Stage 5** of the enhancement pipeline. Stages 2–4 have verified all source
 constructs, fixed diagnostics, and refined test files. Your focus is verifying completeness and writing
 \`ENHANCEMENT_SUMMARY.md\`.
 
@@ -806,20 +806,20 @@ List stubs written in one package to unblock another.
 Summarise anything requiring human review.
 \`\`\`
 
-### Completion Criteria for Stage 4
+### Completion Criteria for Stage 5
 
 Output the final status: checklist results and confirmation that \`ENHANCEMENT_SUMMARY.md\` was written.`;
 }
 
 // ---------------------------------------------------------------------------
-// Stage 5 – Idiomatic refactoring (wrapper elimination, renaming, check normalization)
+// Stage 6 — Idiomatic Refactoring (wrapper elimination, renaming, check normalization)
 // ---------------------------------------------------------------------------
 
 function getStage5Prompt(context: MigrationContext): string {
     const platform = getPlatformName(context.sourcePlatform);
-    return `## Your Task — Stage 5: Idiomatic Refactoring
+    return `## Your Task — Stage 6: Idiomatic Refactoring
 
-Stages 0–4 produced functionally correct, compilable Ballerina code migrated from ${platform}.
+Stages 1–5 produced functionally correct, compilable Ballerina code migrated from ${platform}.
 Stage 5 refactors that code toward idiomatic Ballerina style without changing any observable behaviour.
 
 **Scope constraint — public symbols are frozen:**
@@ -891,8 +891,8 @@ Steps:
 
 ### Completion
 
-1. Run diagnostics. Confirm zero new errors vs. the Stage 4 baseline.
-2. Append a \`## Refactoring Changes (Stage 5)\` section to the existing \`ENHANCEMENT_SUMMARY.md\`:
+1. Run diagnostics. Confirm zero new errors vs. the Stage 5 baseline.
+2. Append a \`## Refactoring Changes (Stage 6)\` section to the existing \`ENHANCEMENT_SUMMARY.md\`:
    - Wrapper functions eliminated (count)
    - Private identifiers renamed (old → new list)
    - Error propagation patterns simplified (count)`;
@@ -942,7 +942,7 @@ fix any remaining cross-package issues so that all packages build together succe
 
 ### Important Notes
 
-- Do NOT re-run Stage 1–4 work here — only fix errors that span package boundaries.
+- Do NOT re-run Stage 2–5 work here — only fix errors that span package boundaries.
 - Only make changes that are strictly necessary to achieve zero workspace-level errors.
 - Do NOT create \`ENHANCEMENT_SUMMARY.md\` or any documentation in this stage.
 

--- a/packages/ballerina-extension/src/features/ai/migration/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/prompts.ts
@@ -42,32 +42,32 @@ export function getEnhancementStages(context: MigrationContext): EnhancementStag
     return [
         {
             name: "Stage 1 — Source Inventory & Gap Analysis",
-            prompt: shared + "\n\n" + getStage0Prompt(context),
+            prompt: shared + "\n\n" + getStage1Prompt(context),
             agentLimits: { maxSteps: 50, maxOutputTokens: 8192 },
         },
         {
             name: "Stage 2 — Source-First Fidelity Implementation",
-            prompt: shared + "\n\n" + getStage1Prompt(context),
+            prompt: shared + "\n\n" + getStage2Prompt(context),
             agentLimits: { maxSteps: 200, maxOutputTokens: 16384 },
         },
         {
             name: "Stage 3 — Zero Compilation Diagnostics",
-            prompt: shared + "\n\n" + getStage2Prompt(context),
-            agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
-        },
-        {
-            name: "Stage 4 — Test Refinement",
             prompt: shared + "\n\n" + getStage3Prompt(context),
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
+            name: "Stage 4 — Test Migration & Gap Coverage",
+            prompt: shared + "\n\n" + getStage4Prompt(context),
+            agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
+        },
+        {
             name: "Stage 5 — Final Validation & Documentation",
-            prompt: shared + "\n\n" + getStage4Prompt(),
+            prompt: shared + "\n\n" + getStage5Prompt(),
             agentLimits: { maxSteps: 50, maxOutputTokens: 16384 },
         },
         {
             name: "Stage 6 — Idiomatic Refactoring",
-            prompt: shared + "\n\n" + getStage5Prompt(context),
+            prompt: shared + "\n\n" + getStage6Prompt(context),
             agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
         },
     ];
@@ -127,32 +127,32 @@ export function getPerProjectEnhancementStages(
     return [
         {
             name: `[${packageName}] Stage 1 — Source Inventory & Gap Analysis`,
-            prompt: shared + "\n\n" + getStage0Prompt(context),
+            prompt: shared + "\n\n" + getStage1Prompt(context),
             agentLimits: { maxSteps: 50, maxOutputTokens: 8192 },
         },
         {
             name: `[${packageName}] Stage 2 — Source-First Fidelity Implementation`,
-            prompt: shared + "\n\n" + getStage1Prompt(context),
+            prompt: shared + "\n\n" + getStage2Prompt(context),
             agentLimits: { maxSteps: 200, maxOutputTokens: 16384 },
         },
         {
             name: `[${packageName}] Stage 3 — Zero Compilation Diagnostics`,
-            prompt: shared + "\n\n" + getStage2Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
+            prompt: shared + "\n\n" + getStage3Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
         },
         {
-            name: `[${packageName}] Stage 4 — Test Refinement`,
-            prompt: shared + "\n\n" + getStage3Prompt(context),
-            agentLimits: { maxSteps: 100, maxOutputTokens: 16384 },
+            name: `[${packageName}] Stage 4 — Test Migration & Gap Coverage`,
+            prompt: shared + "\n\n" + getStage4Prompt(context),
+            agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
         },
         {
             name: `[${packageName}] Stage 5 — Final Validation & Documentation`,
-            prompt: shared + "\n\n" + getStage4Prompt() + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
+            prompt: shared + "\n\n" + getStage5Prompt() + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 50, maxOutputTokens: 16384 },
         },
         {
             name: `[${packageName}] Stage 6 — Idiomatic Refactoring`,
-            prompt: shared + "\n\n" + getStage5Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
+            prompt: shared + "\n\n" + getStage6Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
         },
     ];
@@ -434,7 +434,7 @@ Process one package at a time. Read other packages for context but only modify t
 // Stage 1 — Source Inventory & Gap Analysis (read-only)
 // ---------------------------------------------------------------------------
 
-function getStage0Prompt(context: MigrationContext): string {
+function getStage1Prompt(context: MigrationContext): string {
     const { keepStructure } = context;
     const platformName = getPlatformName(context.sourcePlatform);
 
@@ -470,24 +470,27 @@ of these categories:
 - **Schemas** — XSD, JSON Schema
 - **Configuration** — properties, substvar, YAML config
 - **Connections** — shared resources, global connectors
-- **Tests** — MUnit, BW test processes
+- **Tests** — MUnit XML, BW test processes, any test-only file *(list for awareness — do NOT
+  cross-reference or analyse; test migration is handled entirely in Stage 4)*
 - **Build** — pom.xml, MANIFEST.MF
 - **Skip** — generated files, IDE metadata, irrelevant assets
 
 **Step 3: Cross-reference with Ballerina output**
 
-For each meaningful source file, determine its coverage status in the Ballerina project
+For each **non-test** source file, determine its coverage status in the Ballerina project
 (use the file list already in your initial message):
 - **✅ Covered** — a Ballerina file clearly implements this source file's constructs
 - **⚠️ Partial** — a Ballerina file exists but has \`// TODO\` / \`// FIXME\` markers suggesting
   incomplete translation of this source file
 - **❌ Missing** — no Ballerina counterpart exists; the migration tool silently dropped it
 
+**Do NOT apply ✅/⚠️/❌ to test files** — just list their paths in the TESTS section.
+
 ${keepStructure ? `**Note (--keep-structure):** Each \`.bal\` file maps 1:1 to a source file. Use \`file_list\` and \`migration_source_list\` together to establish which \`.bal\` corresponds to which source file by comparing encoded file paths in the names.` : ""}
 
 **Step 4: Output your inventory**
 
-Output the inventory as plain text in this format (this is working notes for Stage 1, NOT a file):
+Output the inventory as plain text in this format (this is working notes for Stage 2, NOT a file):
 
 \`\`\`
 SOURCE INVENTORY — ${platformName}
@@ -502,32 +505,35 @@ TRANSFORMATIONS
   ...
 
 API SPECS / SCHEMAS
-  ...
+  [✅/⚠️/❌] ...
 
 CONFIGURATION
-  ...
+  [✅/⚠️/❌] ...
 
 CONNECTIONS
+  [✅/⚠️/❌] ...
+
+TESTS  (listed for Stage 4 — no coverage check here)
+  <source-test-file-path>
   ...
 
-TESTS
-  ...
-
-GAPS REQUIRING IMPLEMENTATION IN STAGE 1:
-  1. <description of most critical gap>
+GAPS REQUIRING IMPLEMENTATION IN STAGE 2:
+  (main-code gaps only — do NOT include test gaps here)
+  1. <description of most critical main-code gap>
   2. ...
 \`\`\`
 
 ### Completion Criteria for Stage 1
 
-Output the inventory above, then stop. Do not edit any files. Stage 2 will implement all gaps.`;
+Output the inventory above, then stop. Do not edit any files.
+Stage 2 will implement all main-code gaps. Test files will be addressed in Stage 4.`;
 }
 
 // ---------------------------------------------------------------------------
 // Stage 2 — Source-First Fidelity Implementation
 // ---------------------------------------------------------------------------
 
-function getStage1Prompt(context: MigrationContext): string {
+function getStage2Prompt(context: MigrationContext): string {
     const { keepStructure } = context;
     const platformName = getPlatformName(context.sourcePlatform);
     const connectorTable = getConnectorMappingTable(context.sourcePlatform);
@@ -625,7 +631,7 @@ Then stop. Do not write anything else.`;
 // Stage 3 — Zero Compilation Diagnostics
 // ---------------------------------------------------------------------------
 
-function getStage2Prompt(context: MigrationContext): string {
+function getStage3Prompt(context: MigrationContext): string {
     const platformName = getPlatformName(context.sourcePlatform);
     return `## Your Task — Stage 3: Achieve Zero Compilation Diagnostics
 
@@ -674,62 +680,102 @@ Then stop. Stage 4 will handle test files.`;
 // Stage 4 — Test Refinement
 // ---------------------------------------------------------------------------
 
-function getStage3Prompt(context: MigrationContext): string {
+function getStage4Prompt(context: MigrationContext): string {
     const platformName = getPlatformName(context.sourcePlatform);
-    const testFileRef = context.sourcePlatform === 'mule'
+    const testSourceRef = context.sourcePlatform === 'mule'
         ? 'MUnit XML files (typically under `src/test/munit/`)'
         : context.sourcePlatform === 'tibco'
-        ? 'BW test processes (`*.bwtest` files)'
+        ? 'BW test processes (`*.bwtest` files in the source root)'
         : 'original test files';
+    const testSourceFind = context.sourcePlatform === 'mule'
+        ? 'call `migration_source_list("src/test/munit")` (or `migration_source_list("src/test")`).'
+        : context.sourcePlatform === 'tibco'
+        ? 'call `migration_source_list(".")` and look for `*.bwtest` files.'
+        : 'call `migration_source_list(".")` and look for test files.';
 
-    return `## Your Task — Stage 4: Refine and Validate Test Files
+    return `## Your Task — Stage 4: Test Migration & Gap Coverage
 
 You are running **Stage 4** of the enhancement pipeline. Stages 2 and 3 have verified all ${platformName}
-constructs and achieved zero compilation diagnostics in source files. Your sole focus is making the test
-files in \`tests/\` complete, correctly typed, and compilation-error free.
+constructs and fixed compilation errors in source files. Your sole focus is tests.
 
-> **Tests are not executed during this stage.** The goal is to produce structurally complete, correctly-typed
-> test files. Test execution and pass/fail validation is handled in a separate subsequent step.
+> **Tests are not executed during this stage.** The goal is complete, correctly-typed, compilable
+> test files. Test execution and pass/fail validation happens in a separate step.
 > **Do NOT** create \`ENHANCEMENT_SUMMARY.md\` during this stage — that is Stage 5.
 
-### Preparation: Build a Behaviour Map
+This stage has **two strictly separate phases**. Always complete Phase A before starting Phase B.
+**Never write Phase A and Phase B tests in the same file.**
 
-Before touching any test file:
-1. Read the enhanced Ballerina source files (\`functions.bal\`, \`data_mappings.bal\`, \`main.bal\`, etc.) to
-   understand actual function signatures, return types, error paths, and data shapes.
-2. Use \`migration_source_list\` and \`migration_source_read\` to read the ${testFileRef}
-   to understand the original test scenarios and assertions.
+---
 
-### For each test file in \`tests/\`:
+### Preparation
 
-1. **Align with enhanced implementation**: Verify test calls match current function signatures. Update
-   call sites if signatures changed during Stages 2/3.
-2. **Align with original test intent**: Cross-reference each test against the ${testFileRef}.
-   If the original mocked a connector, mock the equivalent \`ballerinax/\` client using \`@test:Mock\`.
-3. **Resolve all \`// TODO\` and \`// FIXME\` comments** with correct test logic.
-4. **Ensure meaningful assertions**: Every \`@test:Config\` function must have at least one substantive
-   assertion (\`test:assertEquals\`, \`test:assertTrue\`, \`test:assertFail\`, etc.). No trivially-true checks.
-5. **Check for dropped test coverage**: If a test exists in the original source but has no counterpart
-   in \`tests/\`, create the missing test function.
-6. **Mock connectors and external services**: Use \`@test:Mock\` for \`http:Client\`, database clients, etc.
-7. **Wire setup/teardown correctly**: \`@test:BeforeSuite\`, \`@test:AfterSuite\`, etc.
-8. **Ensure test files compile**: Run the diagnostics tool **including** the \`tests/\` directory and fix errors.
-9. **Do not delete or comment out existing test cases.**
+1. From the Stage 1 inventory in your context, collect the TESTS section — these are the source
+   test files to migrate. If the Stage 1 inventory is not available, ${testSourceFind}
+2. Read the enhanced Ballerina source files (\`functions.bal\`, \`main.bal\`, \`data_mappings.bal\`,
+   etc.) to understand current function signatures, return types, and error paths.
+
+---
+
+### Phase A — Migrate Source Tests (Priority 1)
+
+Faithfully translate every ${testSourceRef} into Ballerina.
+These migrated tests are the ground truth for verifying migration correctness.
+
+For each source test file:
+
+1. **Read it** with \`migration_source_read\`.
+2. **Translate every test scenario 1:1**:
+   - Map every assertion to \`test:assertEquals\`, \`test:assertTrue\`, \`test:assertFail\`, etc.
+   - Map every source mock (e.g. MUnit \`mock:when\`, BW stub process) to \`@test:Mock\` on the
+     equivalent \`ballerinax/\` client.
+   - Map \`@BeforeClass\`/\`@AfterClass\` (MUnit) or setup processes (TIBCO) to
+     \`@test:BeforeSuite\`/\`@test:AfterSuite\`.
+   - Do NOT skip or simplify any test scenario. A source assertion silently dropped = a migration gap.
+3. **Write the output** to \`tests/<source-name>_migrated.bal\`, where \`<source-name>\` is the
+   source file's base name without extension (e.g. \`orderFlowTest.xml\` → \`tests/orderFlow_migrated.bal\`).
+   - If the file already exists (partial output from the migration tool), **overwrite it entirely**
+     with the faithful translation — do NOT keep old half-converted content.
+   - Use \`file_write\` to create / overwrite; use \`file_edit\` only for targeted fixes to an
+     already-written \`_migrated.bal\` file.
+4. **Run diagnostics** on the new file immediately. Fix all compilation errors before moving on.
+5. Output one line per file: "✅ \`<source-file>\` → \`tests/<name>_migrated.bal\`: N scenarios."
+
+---
+
+### Phase B — Write Gap Tests (Priority 2)
+
+After **all** Phase A files are written and compile:
+
+1. **List** every public function and service-exposed resource in the Ballerina implementation.
+2. **Cross-reference** against the \`*_migrated.bal\` files from Phase A: which functions/flows
+   have **zero coverage** from the migrated test set?
+3. For each uncovered area, write targeted \`@test:Config\` functions with meaningful assertions.
+   - Every test must have at least one \`test:assertEquals\`, \`test:assertTrue\`, or \`test:assertFail\`.
+   - Mock connectors and external services with \`@test:Mock\`.
+4. **Group by functional area** and write to \`tests/<area>_additional.bal\`
+   (e.g. \`tests/errorHandling_additional.bal\`, \`tests/dataMapping_additional.bal\`).
+   **Never add gap tests to a \`*_migrated.bal\` file.**
+5. Run diagnostics on each \`*_additional.bal\` file. Fix errors before continuing.
+6. Output: "Phase B: N gap areas identified, M test functions written across K files."
+
+---
 
 ### Completion Criteria for Stage 4
 
-When all test files are complete and compilation-error free:
-- Output the diagnostics count for test files (should be 0 errors).
-- List test functions added or significantly modified.
+1. Every source test file has a corresponding \`tests/*_migrated.bal\`.
+2. All \`*_migrated.bal\` files compile with zero errors.
+3. All \`*_additional.bal\` files (if any) compile with zero errors.
+4. No file mixes migrated and gap tests.
 
-Then stop. Stage 5 will handle final validation and documentation.`;
+Output the final diagnostics count (should be 0 errors for all test files), then stop.
+Stage 5 will handle final validation and documentation.`;
 }
 
 // ---------------------------------------------------------------------------
 // Stage 5 — Final Validation & Documentation
 // ---------------------------------------------------------------------------
 
-function getStage4Prompt(): string {
+function getStage5Prompt(): string {
     return `## Your Task — Stage 5: Final Validation & Documentation
 
 You are running **Stage 5** of the enhancement pipeline. Stages 2–4 have verified all source
@@ -815,7 +861,7 @@ Output the final status: checklist results and confirmation that \`ENHANCEMENT_S
 // Stage 6 — Idiomatic Refactoring (wrapper elimination, renaming, check normalization)
 // ---------------------------------------------------------------------------
 
-function getStage5Prompt(context: MigrationContext): string {
+function getStage6Prompt(context: MigrationContext): string {
     const platform = getPlatformName(context.sourcePlatform);
     return `## Your Task — Stage 6: Idiomatic Refactoring
 

--- a/packages/ballerina-extension/src/features/ai/migration/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/prompts.ts
@@ -332,6 +332,10 @@ These rules are **non-negotiable**. Violating any of them means the enhancement 
     : `Files like \`functions.bal\`, \`data_mappings.bal\`, \`main.bal\`, \`configs.bal\`, \`types.bal\` etc. that appear in the initial project source ALREADY EXIST. You must use \`file_edit\` / \`file_multi_edit\` to modify them. Use \`file_write\` only when creating a file that has no content yet.`}
 8. **Never write a "Summary" or "Remaining Work" section.** Do not output a final summary of completed
    and remaining work. Just keep editing files until the stage criteria are met.
+9. **Delete every TODO/FIXME comment you address.** When you implement a construct that was annotated
+   with \`// TODO\`, \`// FIXME\`, or \`// TODO: UNSUPPORTED ... BLOCK ENCOUNTERED\`, always remove the
+   comment line(s) as part of the same \`file_edit\` call. A TODO comment left in the file after the
+   implementation is a bug — it signals incomplete work even when the code is there.
 
 ---
 
@@ -563,8 +567,10 @@ For each source file in your work plan:
    missing config variables, empty error handlers, TODO/FIXME comments.
 5. **Implement gaps immediately** using \`file_edit\` / \`file_multi_edit\`.
    - For \`// TODO: UNSUPPORTED ... BLOCK ENCOUNTERED\`: the commented-out source between \`// ---\` lines
-     is the spec — translate it to Ballerina and remove the entire commented block.
-   - For silently dropped constructs: add them to the correct \`.bal\` file.
+     is the spec — translate it to Ballerina and **remove the entire commented block including the TODO line**.
+   - For any \`// TODO\` or \`// FIXME\` comment: implement the required code, then **delete the comment
+     line in the same edit**. Never leave a TODO/FIXME behind after you have addressed it.
+   - For silently dropped constructs: add them to the correct \`.bal\` file (no TODO to delete).
 6. Output one line after each source file: "✅ \`<source-file>\`: verified / implemented N constructs."
 7. Move to the next source file.
 

--- a/packages/ballerina-extension/src/features/ai/migration/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/prompts.ts
@@ -441,7 +441,7 @@ function getStage1Prompt(context: MigrationContext): string {
     return `## Your Task — Stage 1: Source Inventory & Gap Analysis
 
 This is a **read-only stage** — you will NOT edit any files. Your sole output is a structured inventory
-that Stage 1 will use as its work plan.
+that Stage 2 will use as its work plan.
 
 > **Do NOT edit any Ballerina files.** Do NOT create documentation files. Just list and categorise.
 
@@ -449,7 +449,7 @@ that Stage 1 will use as its work plan.
 
 The rule-based migration tool may silently drop ${platformName} constructs without leaving a \`// TODO\`
 marker — for example, DataWeave scripts with complex logic, RAML/WSDL-defined types, substitution
-variables, or secondary flow files. Stage 1 would miss these if it only scanned for TODO comments.
+variables, or secondary flow files. Stage 2 would miss these if it only scanned for TODO comments.
 This stage surfaces the complete scope before any editing begins.
 
 ### Workflow — Follow This Exact Order
@@ -544,7 +544,7 @@ Your sole focus: ensure **every construct in the ${platformName} source project 
 represented in the Ballerina output**. A later stage handles compilation diagnostics, tests, and documentation.
 
 > **Do NOT** create any documentation files. **Do NOT** fix compilation errors unless they block you
-> from implementing a construct (Stage 2 does that). **Do NOT** create any \`*_new.bal\` or copy files.
+> from implementing a construct (Stage 3 does that). **Do NOT** create any \`*_new.bal\` or copy files.
 
 ### Core Principle: Source Is Ground Truth
 
@@ -556,9 +556,9 @@ what the migration tool flagged with \`// TODO\`.
 
 ### Workflow — Follow This Exact Order
 
-**Phase A: Load your work plan from Stage 0**
+**Phase A: Load your work plan from Stage 1**
 
-The Stage 0 inventory is in your context (from the previous stage output). Use it as your work list.
+The Stage 1 inventory is in your context (from the previous stage output). Use it as your work list.
 Process source files in this priority order:
 1. ❌ Missing — constructs the tool silently dropped (highest priority)
 2. ⚠️ Partial — constructs with \`// TODO\` or \`// FIXME\` markers
@@ -640,7 +640,7 @@ source constructs and implemented missing ones. Your sole focus is achieving **z
 diagnostics** across all source files (excluding \`tests/\`).
 
 > **Do NOT** create \`ENHANCEMENT_SUMMARY.md\` or any documentation files during this stage.
-> **Do NOT** work on test files — that is Stage 3.
+> **Do NOT** work on test files — that is Stage 4.
 > Focus entirely on fixing compilation errors.
 
 ### Workflow
@@ -809,7 +809,7 @@ After the checklist passes, create \`ENHANCEMENT_SUMMARY.md\` in the package roo
 ## Changes Made
 
 ### Source Constructs Implemented
-List constructs that were missing or incomplete in the migration output and were implemented in Stage 1.
+List constructs that were missing or incomplete in the migration output and were implemented in Stage 2.
 
 ### TODO / FIXME Resolutions
 List every TODO/FIXME resolved: file, original comment, what was implemented.
@@ -818,10 +818,10 @@ List every TODO/FIXME resolved: file, original comment, what was implemented.
 List places where original source was missing and a best-effort implementation was produced.
 
 ### Compilation Fixes
-List diagnostics fixed in Stage 2.
+List diagnostics fixed in Stage 3.
 
 ### Test Changes
-Summarise Stage 3 work: tests updated, added, mocks added, scenarios not covered.
+Summarise Stage 4 work: tests updated, added, mocks added, scenarios not covered.
 
 ## Remaining Scoped TODOs
 List all remaining \`// TODO\` comments (best-effort notes only).
@@ -866,7 +866,7 @@ function getStage6Prompt(context: MigrationContext): string {
     return `## Your Task — Stage 6: Idiomatic Refactoring
 
 Stages 1–5 produced functionally correct, compilable Ballerina code migrated from ${platform}.
-Stage 5 refactors that code toward idiomatic Ballerina style without changing any observable behaviour.
+Stage 6 refactors that code toward idiomatic Ballerina style without changing any observable behaviour.
 
 **Scope constraint — public symbols are frozen:**
 Only modify \`private\` functions, types, and variables. Functions, types, and \`public\` variables
@@ -988,7 +988,7 @@ fix any remaining cross-package issues so that all packages build together succe
 
 ### Important Notes
 
-- Do NOT re-run Stage 2–5 work here — only fix errors that span package boundaries.
+- Do NOT re-run Stage 2–6 work here — only fix errors that span package boundaries.
 - Only make changes that are strictly necessary to achieve zero workspace-level errors.
 - Do NOT create \`ENHANCEMENT_SUMMARY.md\` or any documentation in this stage.
 

--- a/packages/ballerina-extension/src/features/ai/migration/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/prompts.ts
@@ -132,7 +132,7 @@ export function getPerProjectEnhancementStages(
         },
         {
             name: `[${packageName}] Stage 2 — Source-First Fidelity Implementation`,
-            prompt: shared + "\n\n" + getStage2Prompt(context),
+            prompt: shared + "\n\n" + getStage2Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 200, maxOutputTokens: 16384 },
         },
         {
@@ -142,7 +142,7 @@ export function getPerProjectEnhancementStages(
         },
         {
             name: `[${packageName}] Stage 4 — Test Migration & Gap Coverage`,
-            prompt: shared + "\n\n" + getStage4Prompt(context),
+            prompt: shared + "\n\n" + getStage4Prompt(context) + "\n\n" + CROSS_PACKAGE_ISOLATION_NOTE,
             agentLimits: { maxSteps: 150, maxOutputTokens: 16384 },
         },
         {
@@ -306,6 +306,11 @@ function getSharedEnhancementContext(context: MigrationContext): string {
     const { keepStructure } = context;
     const platformName = getPlatformName(context.sourcePlatform);
     const platformExpertise = getPlatformExpertise(context.sourcePlatform);
+    const filenameEncodingHint = context.sourcePlatform === 'mule'
+        ? "MuleSoft: `foo/bar.xml` becomes `foo_bar.bal`"
+        : context.sourcePlatform === 'tibco'
+            ? "TIBCO: `foo/Bar.bwp` becomes a similarly named `.bal` file"
+            : "MuleSoft: `foo/bar.xml` becomes `foo_bar.bal`; TIBCO: `foo/Bar.bwp` becomes a similarly named `.bal` file";
 
     return `You are an integration expert in **${platformExpertise}** and **Ballerina**. You are enhancing a
 Ballerina project that was automatically migrated from **${platformName}** by a static code migration tool.
@@ -375,7 +380,7 @@ ${keepStructure ? `### Original Source File Structure Preserved
 
 This project was migrated with **\`--keep-structure\`** enabled. Each \`.bal\` file corresponds
 to one original source file. The source filename and its directory path are encoded into the \`.bal\`
-filename. For ${platformName === 'MuleSoft Mule 3/4' ? "MuleSoft: `foo/bar.xml` becomes `foo_bar.bal`" : "TIBCO: `foo/Bar.bwp` becomes a similarly named `.bal` file"}.
+filename. For ${filenameEncodingHint}.
 **Do not assume the \`.bal\` filename exactly matches the source filename** — use \`migration_source_list\`
 and \`file_list\` together to establish the mapping.
 
@@ -677,7 +682,7 @@ Then stop. Stage 4 will handle test files.`;
 }
 
 // ---------------------------------------------------------------------------
-// Stage 4 — Test Refinement
+// Stage 4 — Test Migration & Gap Coverage
 // ---------------------------------------------------------------------------
 
 function getStage4Prompt(context: MigrationContext): string {

--- a/packages/ballerina-extension/src/features/ai/migration/types.ts
+++ b/packages/ballerina-extension/src/features/ai/migration/types.ts
@@ -76,6 +76,18 @@ export interface EnhanceTomlData {
     multiProject?: boolean;
     /** `true` when the migration ran with --keep-structure, preserving the original source file layout. */
     keepStructure?: boolean;
+    /** The source integration platform ('mule' for MuleSoft, 'tibco' for TIBCO BusinessWorks). */
+    sourcePlatform?: 'mule' | 'tibco';
+}
+
+/**
+ * Runtime context derived from the toml, passed to all prompt-generation functions.
+ * Adding a new wizard parameter here automatically makes it available to every stage prompt.
+ */
+export interface MigrationContext {
+    /** The source integration platform. 'unknown' when the toml predates this field. */
+    sourcePlatform: 'mule' | 'tibco' | 'unknown';
+    keepStructure: boolean;
 }
 
 /**

--- a/packages/ballerina-extension/src/utils/bi.ts
+++ b/packages/ballerina-extension/src/utils/bi.ts
@@ -712,7 +712,7 @@ export async function createBIProjectFromMigration(params: MigrateRequest) {
     // Write the AI enhancement state file – acts as the source of truth for the
     // migration UI banner.  This is done for ALL values of aiFeatureUsed so
     // the card can offer a "Start Enhancement" button even when the user skipped.
-    writeEnhanceToml(resolvedRoot, aiEnabled, false, params.sourcePath);
+    writeEnhanceToml(resolvedRoot, aiEnabled, false, params.sourcePath, undefined, undefined, undefined, undefined, undefined, params.sourcePlatform);
 
     if (aiEnabled) {
         // When AI enhancement is enabled, return the project root to the caller

--- a/packages/ballerina-extension/src/utils/bi.ts
+++ b/packages/ballerina-extension/src/utils/bi.ts
@@ -713,7 +713,7 @@ export async function createBIProjectFromMigration(params: MigrateRequest) {
     // Write the AI enhancement state file – acts as the source of truth for the
     // migration UI banner.  This is done for ALL values of aiFeatureUsed so
     // the card can offer a "Start Enhancement" button even when the user skipped.
-    writeEnhanceToml(resolvedRoot, aiEnabled, false, params.sourcePath, undefined, undefined, undefined, undefined, undefined, params.sourcePlatform);
+    writeEnhanceToml(resolvedRoot, aiEnabled, false, params.sourcePath, undefined, undefined, undefined, undefined, params.keepStructure, params.sourcePlatform);
 
     if (aiEnabled) {
         // When AI enhancement is enabled, return the project root to the caller

--- a/packages/ballerina-visualizer/src/views/BI/ImportIntegration/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ImportIntegration/index.tsx
@@ -113,6 +113,9 @@ export function ImportIntegration() {
                 aiFeatureUsed: aiFeatureUsed,
                 sourcePath: importParams?.importSourcePath,
                 keepStructure: importParams?.parameters?.["keepStructure"] as boolean | undefined,
+                sourcePlatform: selectedIntegration?.commandName === 'migrate-mule' ? 'mule'
+                    : selectedIntegration?.commandName === 'migrate-tibco' ? 'tibco'
+                    : undefined,
             };
             rpcClient.getMigrateIntegrationRpcClient().migrateProject(params);
 


### PR DESCRIPTION
$subject.

Fixes https://github.com/wso2/product-integrator/issues/1802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Revamped migration prompts to use source-first verification.
- Added MuleSoft and TIBCO source context across migration requests, settings, workflows, and prompts.
- Added six migration stages for source inventory, implementation, diagnostics, tests, validation, and refactoring.
- Improved coverage checks for source constructs, configuration, and migration gaps without generated TODO or FIXME comments.
- Updated multi-package progress tracking to use the generated stage count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->