### PR TITLE
Improve Copilot review diff diagram

### DIFF
--- a/packages/ballerina-core/src/interfaces/bi.ts
+++ b/packages/ballerina-core/src/interfaces/bi.ts
@@ -56,12 +56,14 @@ export type FlowNode = {
     returning: boolean;
     suggested?: boolean;
     diffState?: FlowNodeDiffState;
+    /** Previous source/text of a modified node, set by the review-diff merge (rendered by the note chip for COMMENT nodes). */
+    diffPreviousText?: string;
     viewState?: ViewState;
     hasBreakpoint?: boolean;
     isActiveBreakpoint?: boolean;
 };
 
-export type FlowNodeDiffState = "added" | "removed";
+export type FlowNodeDiffState = "added" | "removed" | "modified";
 
 export type FunctionNode = {
     id: string;

--- a/packages/ballerina-core/src/interfaces/bi.ts
+++ b/packages/ballerina-core/src/interfaces/bi.ts
@@ -55,10 +55,13 @@ export type FlowNode = {
     flags?: number;
     returning: boolean;
     suggested?: boolean;
+    diffState?: FlowNodeDiffState;
     viewState?: ViewState;
     hasBreakpoint?: boolean;
     isActiveBreakpoint?: boolean;
 };
+
+export type FlowNodeDiffState = "added" | "removed";
 
 export type FunctionNode = {
     id: string;
@@ -546,6 +549,7 @@ export type NodeKind =
     | "DATA_MAPPER_CALL"
     | "DATA_MAPPER_DEFINITION"
     | "DATA_MAPPER_CREATION"
+    | "DIFF_HUNK"
     | "DRAFT"
     | "ELSE"
     | "EMPTY"

--- a/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -135,6 +135,7 @@ export interface AIPanelAPI {
     clearChat: () => Promise<void>;
     updateChatMessage: (params: UpdateChatMessageRequest) => Promise<void>;
     getActiveTempDir: () => Promise<string>;
+    hasPendingReview: () => Promise<boolean>;
     getUsage: () => Promise<UsageResponse | undefined>;
     openFileDiff: (params: OpenFileDiffRequest) => void;
     approveWebTool: (params: WebToolApprovalRequest) => Promise<void>;

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -411,6 +411,7 @@ export interface SemanticDiff {
     nodeKind: number;   // API returns numeric value
     uri: string;
     lineRange: LineRange;
+    previousLineRange?: LineRange;
     metadata?: ResourceMetadata | IdentifierMetadata;
 }
 

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -80,6 +80,7 @@ export interface AddFilesToProjectRequest {
 export interface FileChanges {
     filePath: string;
     content: string;
+    deleted?: boolean;
 }
 
 export interface ProjectImports {
@@ -757,4 +758,3 @@ export interface AgentsMdFileInfoDTO {
     isEmpty?: boolean;
     hasWorkspace: boolean;
 }
-

--- a/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -123,6 +123,7 @@ export const restoreCheckpoint: RequestType<RestoreCheckpointRequest, void> = { 
 export const clearChat: RequestType<void, void> = { method: `${_preFix}/clearChat` };
 export const updateChatMessage: RequestType<UpdateChatMessageRequest, void> = { method: `${_preFix}/updateChatMessage` };
 export const getActiveTempDir: RequestType<void, string> = { method: `${_preFix}/getActiveTempDir` };
+export const hasPendingReview: RequestType<void, boolean> = { method: `${_preFix}/hasPendingReview` };
 export const getUsage: RequestType<void, UsageResponse | undefined> = { method: `${_preFix}/getUsage` };
 export const openFileDiff: NotificationType<OpenFileDiffRequest> = { method: `${_preFix}/openFileDiff` };
 export const approveWebTool: RequestType<WebToolApprovalRequest, void> = { method: `${_preFix}/approveWebTool` };

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -39,6 +39,7 @@ import { updateAndSaveChat, calculateTotalCost } from '../utils/events';
 import { chatStateStorage } from '../../../views/ai-panel/chatStateStorage';
 import * as path from 'path';
 import { approvalViewManager } from '../state/ApprovalViewManager';
+import { savePendingReviewRestore } from '../state/reviewRestoreStore';
 import {
     buildContextManagementOptions,
     detectAppliedCompaction,
@@ -949,6 +950,18 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
             };
 
             approvalViewManager.openReviewMode(reviewData, false);
+
+            // The chat persistence schema drops tempProjectPath/affectedPackagePaths, so
+            // stash what the diff view needs to reopen after an extension host restart.
+            savePendingReviewRestore({
+                generationId: context.messageId,
+                tempProjectPath: context.ctx.tempProjectPath!,
+                modifiedFiles: accumulatedModifiedFiles,
+                affectedPackagePaths: affectedPackages,
+                semanticDiffs,
+                loadDesignDiagrams,
+                isWorkspace,
+            });
 
             context.eventHandler({
                 type: "chat_component",

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -953,7 +953,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
 
             // The chat persistence schema drops tempProjectPath/affectedPackagePaths, so
             // stash what the diff view needs to reopen after an extension host restart.
-            savePendingReviewRestore({
+            await savePendingReviewRestore({
                 generationId: context.messageId,
                 tempProjectPath: context.ctx.tempProjectPath!,
                 modifiedFiles: accumulatedModifiedFiles,

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -30,7 +30,7 @@ import { createToolRegistry } from './tool-registry';
 import { loadSkillsContext } from './skills/context';
 
 import { refreshMcpClientManager } from './mcp';
-import { getProjectSource, cleanupTempProject } from '../utils/project/temp-project';
+import { getProjectSource, cleanupTempProject, getReviewBaselinePath } from '../utils/project/temp-project';
 import { integrateCodeToWorkspace } from './utils';
 import { getWorkspaceTomlValues } from '../../../utils';
 import { StreamContext } from './stream-handlers/stream-context';
@@ -956,6 +956,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
             await savePendingReviewRestore({
                 generationId: context.messageId,
                 tempProjectPath: context.ctx.tempProjectPath!,
+                baselineProjectPath: getReviewBaselinePath(context.ctx.tempProjectPath!),
                 modifiedFiles: accumulatedModifiedFiles,
                 affectedPackagePaths: affectedPackages,
                 semanticDiffs,

--- a/packages/ballerina-extension/src/features/ai/agent/utils.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/utils.ts
@@ -93,7 +93,12 @@ export async function integrateCodeToWorkspace(
                 });
                 console.log(`[Agent Integration] Prepared modified file: ${relativePath}`);
             } else {
-                console.warn(`[Agent Integration] Modified file not found: ${relativePath}`);
+                fileChanges.push({
+                    filePath: relativePath,
+                    content: "",
+                    deleted: true,
+                });
+                console.log(`[Agent Integration] Prepared deleted file: ${relativePath}`);
             }
         }
     } else {

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -347,6 +347,9 @@ export class ApprovalViewManager {
     }
 
     private cachedReviewData: ReviewModeData | null = null;
+    // Shared while a restore-rebuild is running so concurrent navigateReviewMode calls
+    // await the same result instead of each re-opening the same LS documents.
+    private rebuildInFlight: Promise<ReviewModeData | null> | null = null;
 
     /**
      * Open ReviewMode with review data passed via OPEN_VIEW reviewData field.
@@ -377,7 +380,12 @@ export class ApprovalViewManager {
             return;
         }
         if (!this.cachedReviewData) {
-            this.cachedReviewData = await this.rebuildReviewDataFromStorage();
+            this.rebuildInFlight ??= this.rebuildReviewDataFromStorage();
+            try {
+                this.cachedReviewData = await this.rebuildInFlight;
+            } finally {
+                this.rebuildInFlight = null;
+            }
         }
         if (this.cachedReviewData) {
             openMainView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.ReviewMode, reviewData: { ...this.cachedReviewData, currentIndex: index } });
@@ -403,10 +411,13 @@ export class ApprovalViewManager {
         const restore = getPendingReviewRestore();
         if (!restore || restore.generationId !== generation.id) {
             console.error('[ApprovalViewManager] No restore data for pending review generation', generation.id);
+            // Drop the stale payload so we don't repeat this failed lookup every navigation.
+            await clearPendingReviewRestore();
             return null;
         }
         if (!fs.existsSync(restore.tempProjectPath)) {
             console.error('[ApprovalViewManager] Temp project of the pending review no longer exists:', restore.tempProjectPath);
+            await clearPendingReviewRestore();
             return null;
         }
 
@@ -437,7 +448,9 @@ export class ApprovalViewManager {
      */
     clearReviewData(): void {
         this.cachedReviewData = null;
-        clearPendingReviewRestore();
+        // Fire-and-forget: a lost clear only leaves stale restore data, which
+        // rebuildReviewDataFromStorage detects and clears on the next navigation.
+        void clearPendingReviewRestore();
     }
 }
 

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -29,6 +29,9 @@ import { notifyApprovalOverlayState, RPCLayer } from '../../../RPCLayer';
 
 export type ApprovalType = 'configuration' | 'task' | 'plan' | 'connector_spec';
 
+const REVIEW_NAVIGATION_DEBOUNCE_MS = 150;
+const REVIEW_MODE_READY_TIMEOUT_MS = 15_000;
+
 interface OpenedApprovalView {
     requestId: string;
     viewType: 'popup' | 'main' | 'inline';
@@ -350,6 +353,120 @@ export class ApprovalViewManager {
     // Shared while a restore-rebuild is running so concurrent navigateReviewMode calls
     // await the same result instead of each re-opening the same LS documents.
     private rebuildInFlight: Promise<ReviewModeData | null> | null = null;
+    // Chat entries send fire-and-forget navigation notifications. Keep a single open
+    // transition in flight and coalesce rapid clicks to the most recent requested view.
+    private reviewOpenInFlight: Promise<void> | null = null;
+    private queuedReviewIndex: number | null = null;
+    private reviewNavigationTimer: ReturnType<typeof setTimeout> | null = null;
+    private reviewOpenAttempt = 0;
+    private lastReviewNavigationRequestAt = 0;
+
+    private isReviewModeReady(): boolean {
+        return StateMachine.isReady()
+            && StateMachine.context().view === MACHINE_VIEW.ReviewMode
+            && !!VisualizerWebview.currentPanel;
+    }
+
+    private async waitForReviewModeReady(attempt: number): Promise<boolean> {
+        const timeoutAt = Date.now() + REVIEW_MODE_READY_TIMEOUT_MS;
+        while (attempt === this.reviewOpenAttempt && Date.now() < timeoutAt) {
+            if (this.isReviewModeReady()) {
+                return true;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        return false;
+    }
+
+    private async waitForReviewNavigationQuiet(attempt: number): Promise<boolean> {
+        while (attempt === this.reviewOpenAttempt) {
+            const remaining = this.lastReviewNavigationRequestAt
+                + REVIEW_NAVIGATION_DEBOUNCE_MS
+                - Date.now();
+            if (remaining <= 0) {
+                return true;
+            }
+            await new Promise((resolve) => setTimeout(resolve, remaining));
+        }
+        return false;
+    }
+
+    private scheduleQueuedReviewNavigation(): void {
+        if (this.reviewNavigationTimer) {
+            clearTimeout(this.reviewNavigationTimer);
+        }
+        // The small trailing-edge delay both collapses click bursts and lets the newly
+        // mounted ReviewMode register its navigateReviewIndex listener.
+        this.reviewNavigationTimer = setTimeout(() => {
+            this.reviewNavigationTimer = null;
+            const index = this.queuedReviewIndex;
+            if (index === null || !this.isReviewModeReady()) {
+                return;
+            }
+            this.queuedReviewIndex = null;
+            RPCLayer._messenger.sendNotification(navigateReviewIndex, {
+                type: 'webview',
+                webviewType: VisualizerWebview.viewType
+            }, index);
+        }, REVIEW_NAVIGATION_DEBOUNCE_MS);
+    }
+
+    private resetReviewNavigationState(): void {
+        this.reviewOpenAttempt++;
+        this.queuedReviewIndex = null;
+        this.lastReviewNavigationRequestAt = 0;
+        if (this.reviewNavigationTimer) {
+            clearTimeout(this.reviewNavigationTimer);
+            this.reviewNavigationTimer = null;
+        }
+    }
+
+    private async openQueuedReviewMode(): Promise<void> {
+        const pendingAttempt = this.reviewOpenAttempt;
+        if (!this.cachedReviewData) {
+            this.rebuildInFlight ??= this.rebuildReviewDataFromStorage();
+            try {
+                const rebuiltReviewData = await this.rebuildInFlight;
+                if (pendingAttempt !== this.reviewOpenAttempt) {
+                    return;
+                }
+                this.cachedReviewData = rebuiltReviewData;
+            } finally {
+                this.rebuildInFlight = null;
+            }
+        }
+        if (!this.cachedReviewData) {
+            this.queuedReviewIndex = null;
+            return;
+        }
+
+        // Wait for a trailing-edge pause before opening so a burst chooses one initial
+        // index instead of loading the first diagram and immediately replacing it.
+        if (!await this.waitForReviewNavigationQuiet(pendingAttempt)) {
+            return;
+        }
+
+        const initialIndex = this.queuedReviewIndex ?? 0;
+        this.queuedReviewIndex = null;
+        const attempt = ++this.reviewOpenAttempt;
+        openMainView(EVENT_TYPE.OPEN_VIEW, {
+            view: MACHINE_VIEW.ReviewMode,
+            reviewData: { ...this.cachedReviewData, currentIndex: initialIndex }
+        });
+        RPCLayer._messenger.sendNotification(reviewModeOpened, {
+            type: 'webview',
+            webviewType: AiPanelWebview.viewType
+        });
+
+        if (await this.waitForReviewModeReady(attempt)) {
+            if (this.queuedReviewIndex !== null) {
+                this.scheduleQueuedReviewNavigation();
+            }
+        } else if (attempt === this.reviewOpenAttempt) {
+            console.warn('[ApprovalViewManager] Timed out waiting for ReviewMode to become ready');
+            this.queuedReviewIndex = null;
+        }
+    }
 
     /**
      * Open ReviewMode with review data passed via OPEN_VIEW reviewData field.
@@ -359,37 +476,38 @@ export class ApprovalViewManager {
         if (!AiPanelWebview.currentPanel) { return; }
         this.cachedReviewData = data;
         if (!autoOpen) { return; }
-        openMainView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.ReviewMode, reviewData: data });
-        RPCLayer._messenger.sendNotification(reviewModeOpened, { type: 'webview', webviewType: AiPanelWebview.viewType });
+        void this.navigateReviewMode(data.currentIndex).catch((error) =>
+            console.error('[ApprovalViewManager] Failed to open ReviewMode:', error));
     }
 
     /**
      * Navigate ReviewMode to a specific index.
-     * If ReviewMode is already open, sends navigateReviewIndex notification directly.
+     * If ReviewMode is already open, coalesces rapid index requests before notifying it.
      * If not open, opens it with cached data — rebuilt from the persisted review
-     * state when the cache is gone (extension host restarted mid-review).
+     * state when the cache is gone (extension host restarted mid-review). Concurrent
+     * requests share one open transition so they cannot create competing view loads.
      */
     async navigateReviewMode(index: number): Promise<void> {
         if (!AiPanelWebview.currentPanel) { return; }
-        const isReviewModeOpen = StateMachine.context().view === MACHINE_VIEW.ReviewMode && !!VisualizerWebview.currentPanel;
-        if (isReviewModeOpen) {
-            RPCLayer._messenger.sendNotification(navigateReviewIndex, {
-                type: 'webview',
-                webviewType: VisualizerWebview.viewType
-            }, index);
+        this.queuedReviewIndex = index;
+        this.lastReviewNavigationRequestAt = Date.now();
+
+        if (this.isReviewModeReady()) {
+            this.scheduleQueuedReviewNavigation();
             return;
         }
-        if (!this.cachedReviewData) {
-            this.rebuildInFlight ??= this.rebuildReviewDataFromStorage();
-            try {
-                this.cachedReviewData = await this.rebuildInFlight;
-            } finally {
-                this.rebuildInFlight = null;
-            }
+
+        if (!this.reviewOpenInFlight) {
+            const openPromise = this.openQueuedReviewMode();
+            this.reviewOpenInFlight = openPromise;
         }
-        if (this.cachedReviewData) {
-            openMainView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.ReviewMode, reviewData: { ...this.cachedReviewData, currentIndex: index } });
-            RPCLayer._messenger.sendNotification(reviewModeOpened, { type: 'webview', webviewType: AiPanelWebview.viewType });
+        const openPromise = this.reviewOpenInFlight;
+        try {
+            await openPromise;
+        } finally {
+            if (this.reviewOpenInFlight === openPromise) {
+                this.reviewOpenInFlight = null;
+            }
         }
     }
 
@@ -421,7 +539,19 @@ export class ApprovalViewManager {
             return null;
         }
 
-        sendReviewRestoreDidOpenBatch(restore.tempProjectPath, restore.modifiedFiles, generation.checkpoint?.workspaceSnapshot);
+        // Rehydrate runtime-only state as well as the view. Accept/decline can now clean up
+        // restored temp projects even though chat persistence deliberately omits these fields.
+        chatStateStorage.updateReviewState(projectRootPath, 'default', generation.id, {
+            tempProjectPath: restore.tempProjectPath,
+            affectedPackagePaths: restore.affectedPackagePaths,
+        });
+
+        sendReviewRestoreDidOpenBatch(
+            restore.tempProjectPath,
+            restore.modifiedFiles,
+            restore.baselineProjectPath,
+            generation.checkpoint?.workspaceSnapshot
+        );
 
         return {
             views: [],
@@ -439,6 +569,7 @@ export class ApprovalViewManager {
      * Notify the AI panel webview that ReviewMode has been closed.
      */
     notifyReviewModeClosed(): void {
+        this.resetReviewNavigationState();
         if (!AiPanelWebview.currentPanel) { return; }
         RPCLayer._messenger.sendNotification(reviewModeClosed, { type: 'webview', webviewType: AiPanelWebview.viewType });
     }
@@ -447,6 +578,7 @@ export class ApprovalViewManager {
      * Clear cached review data after accept or discard.
      */
     clearReviewData(): void {
+        this.resetReviewNavigationState();
         this.cachedReviewData = null;
         // Fire-and-forget: a lost clear only leaves stale restore data, which
         // rebuildReviewDataFromStorage detects and clears on the next navigation.

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -17,9 +17,10 @@
  */
 
 import * as fs from 'fs';
-import { MACHINE_VIEW, EVENT_TYPE, VisualizerLocation, PopupVisualizerLocation, AgentMetadata, navigateReviewIndex, reviewModeOpened, reviewModeClosed, ReviewModeData, SemanticDiff, PROJECT_KIND } from '@wso2/ballerina-core';
+import { MACHINE_VIEW, EVENT_TYPE, VisualizerLocation, PopupVisualizerLocation, AgentMetadata, navigateReviewIndex, reviewModeOpened, reviewModeClosed, ReviewModeData } from '@wso2/ballerina-core';
 import { AiPanelWebview } from '../../../views/ai-panel/webview';
 import { chatStateStorage } from '../../../views/ai-panel/chatStateStorage';
+import { getPendingReviewRestore, clearPendingReviewRestore } from './reviewRestoreStore';
 import { sendReviewRestoreDidOpenBatch } from '../utils/project/ls-schema-notifications';
 import { VisualizerWebview } from '../../../views/visualizer/webview';
 import { openView as openMainView, StateMachine } from '../../../stateMachine';
@@ -385,52 +386,41 @@ export class ApprovalViewManager {
     }
 
     /**
-     * Rebuild ReviewModeData for the pending review from persisted chat state.
-     * Needed after an extension host restart: chatStateStorage (with checkpoint
-     * snapshots) survives on disk, but the in-memory cache and the Language
-     * Server's ai:// and file:// documents do not — so the modified files are
-     * re-opened in the LS and the semantic diffs re-collected.
+     * Rebuild ReviewModeData for the pending review after an extension host
+     * restart: the review payload survives in the workspace Memento
+     * (reviewRestoreStore) and the checkpoint snapshot in chatStateStorage,
+     * but the Language Server restarted with the in-memory ai:// (modified)
+     * and file:// (original) documents — so the modified files are re-opened
+     * in the LS before reopening the view.
      */
     private async rebuildReviewDataFromStorage(): Promise<ReviewModeData | null> {
         const ctx = StateMachine.context();
         const projectRootPath = ctx.workspacePath || ctx.projectPath || '';
         const generation = chatStateStorage.getPendingReviewGeneration(projectRootPath, 'default');
-        const reviewState = generation?.reviewState;
-        if (!reviewState?.tempProjectPath || !fs.existsSync(reviewState.tempProjectPath)) {
+        if (!generation) {
+            return null;
+        }
+        const restore = getPendingReviewRestore();
+        if (!restore || restore.generationId !== generation.id) {
+            console.error('[ApprovalViewManager] No restore data for pending review generation', generation.id);
+            return null;
+        }
+        if (!fs.existsSync(restore.tempProjectPath)) {
+            console.error('[ApprovalViewManager] Temp project of the pending review no longer exists:', restore.tempProjectPath);
             return null;
         }
 
-        const { tempProjectPath, modifiedFiles, affectedPackagePaths } = reviewState;
-        sendReviewRestoreDidOpenBatch(tempProjectPath, modifiedFiles ?? [], generation.checkpoint?.workspaceSnapshot);
-
-        const isWorkspace = ctx.projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
-        const affectedPackages = affectedPackagePaths?.length ? affectedPackagePaths : [tempProjectPath];
-        const semanticDiffs: SemanticDiff[] = [];
-        let loadDesignDiagrams = false;
-        for (const pkg of affectedPackages) {
-            // Skip workspace root — it only contains Ballerina.toml, not a real package
-            if (isWorkspace && pkg === tempProjectPath) { continue; }
-            try {
-                const res = await ctx.langClient.getSemanticDiff({ projectPath: pkg });
-                if (res) {
-                    semanticDiffs.push(...res.semanticDiffs);
-                    loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
-                }
-            } catch (err) {
-                console.error(`[ApprovalViewManager] getSemanticDiff failed for package ${pkg} while rebuilding review data`, err);
-                return null;
-            }
-        }
+        sendReviewRestoreDidOpenBatch(restore.tempProjectPath, restore.modifiedFiles, generation.checkpoint?.workspaceSnapshot);
 
         return {
             views: [],
             currentIndex: 0,
-            semanticDiffs,
-            loadDesignDiagrams,
-            affectedPackages,
-            modifiedFiles: modifiedFiles ?? [],
-            tempProjectPath,
-            isWorkspace,
+            semanticDiffs: restore.semanticDiffs,
+            loadDesignDiagrams: restore.loadDesignDiagrams,
+            affectedPackages: restore.affectedPackagePaths,
+            modifiedFiles: restore.modifiedFiles,
+            tempProjectPath: restore.tempProjectPath,
+            isWorkspace: restore.isWorkspace,
         };
     }
 
@@ -447,6 +437,7 @@ export class ApprovalViewManager {
      */
     clearReviewData(): void {
         this.cachedReviewData = null;
+        clearPendingReviewRestore();
     }
 }
 

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -16,8 +16,11 @@
  * under the License.
  */
 
-import { MACHINE_VIEW, EVENT_TYPE, VisualizerLocation, PopupVisualizerLocation, AgentMetadata, navigateReviewIndex, reviewModeOpened, reviewModeClosed, ReviewModeData } from '@wso2/ballerina-core';
+import * as fs from 'fs';
+import { MACHINE_VIEW, EVENT_TYPE, VisualizerLocation, PopupVisualizerLocation, AgentMetadata, navigateReviewIndex, reviewModeOpened, reviewModeClosed, ReviewModeData, SemanticDiff, PROJECT_KIND } from '@wso2/ballerina-core';
 import { AiPanelWebview } from '../../../views/ai-panel/webview';
+import { chatStateStorage } from '../../../views/ai-panel/chatStateStorage';
+import { sendReviewRestoreDidOpenBatch } from '../utils/project/ls-schema-notifications';
 import { VisualizerWebview } from '../../../views/visualizer/webview';
 import { openView as openMainView, StateMachine } from '../../../stateMachine';
 import { openPopupView, StateMachinePopup } from '../../../stateMachinePopup';
@@ -359,9 +362,10 @@ export class ApprovalViewManager {
     /**
      * Navigate ReviewMode to a specific index.
      * If ReviewMode is already open, sends navigateReviewIndex notification directly.
-     * If not open and data is cached, re-opens ReviewMode with cached data then navigates.
+     * If not open, opens it with cached data — rebuilt from the persisted review
+     * state when the cache is gone (extension host restarted mid-review).
      */
-    navigateReviewMode(index: number): void {
+    async navigateReviewMode(index: number): Promise<void> {
         if (!AiPanelWebview.currentPanel) { return; }
         const isReviewModeOpen = StateMachine.context().view === MACHINE_VIEW.ReviewMode && !!VisualizerWebview.currentPanel;
         if (isReviewModeOpen) {
@@ -369,10 +373,65 @@ export class ApprovalViewManager {
                 type: 'webview',
                 webviewType: VisualizerWebview.viewType
             }, index);
-        } else if (this.cachedReviewData) {
+            return;
+        }
+        if (!this.cachedReviewData) {
+            this.cachedReviewData = await this.rebuildReviewDataFromStorage();
+        }
+        if (this.cachedReviewData) {
             openMainView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.ReviewMode, reviewData: { ...this.cachedReviewData, currentIndex: index } });
             RPCLayer._messenger.sendNotification(reviewModeOpened, { type: 'webview', webviewType: AiPanelWebview.viewType });
         }
+    }
+
+    /**
+     * Rebuild ReviewModeData for the pending review from persisted chat state.
+     * Needed after an extension host restart: chatStateStorage (with checkpoint
+     * snapshots) survives on disk, but the in-memory cache and the Language
+     * Server's ai:// and file:// documents do not — so the modified files are
+     * re-opened in the LS and the semantic diffs re-collected.
+     */
+    private async rebuildReviewDataFromStorage(): Promise<ReviewModeData | null> {
+        const ctx = StateMachine.context();
+        const projectRootPath = ctx.workspacePath || ctx.projectPath || '';
+        const generation = chatStateStorage.getPendingReviewGeneration(projectRootPath, 'default');
+        const reviewState = generation?.reviewState;
+        if (!reviewState?.tempProjectPath || !fs.existsSync(reviewState.tempProjectPath)) {
+            return null;
+        }
+
+        const { tempProjectPath, modifiedFiles, affectedPackagePaths } = reviewState;
+        sendReviewRestoreDidOpenBatch(tempProjectPath, modifiedFiles ?? [], generation.checkpoint?.workspaceSnapshot);
+
+        const isWorkspace = ctx.projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
+        const affectedPackages = affectedPackagePaths?.length ? affectedPackagePaths : [tempProjectPath];
+        const semanticDiffs: SemanticDiff[] = [];
+        let loadDesignDiagrams = false;
+        for (const pkg of affectedPackages) {
+            // Skip workspace root — it only contains Ballerina.toml, not a real package
+            if (isWorkspace && pkg === tempProjectPath) { continue; }
+            try {
+                const res = await ctx.langClient.getSemanticDiff({ projectPath: pkg });
+                if (res) {
+                    semanticDiffs.push(...res.semanticDiffs);
+                    loadDesignDiagrams = loadDesignDiagrams || res.loadDesignDiagrams;
+                }
+            } catch (err) {
+                console.error(`[ApprovalViewManager] getSemanticDiff failed for package ${pkg} while rebuilding review data`, err);
+                return null;
+            }
+        }
+
+        return {
+            views: [],
+            currentIndex: 0,
+            semanticDiffs,
+            loadDesignDiagrams,
+            affectedPackages,
+            modifiedFiles: modifiedFiles ?? [],
+            tempProjectPath,
+            isWorkspace,
+        };
     }
 
     /**

--- a/packages/ballerina-extension/src/features/ai/state/reviewRestoreStore.ts
+++ b/packages/ballerina-extension/src/features/ai/state/reviewRestoreStore.ts
@@ -29,6 +29,8 @@ import { extension } from '../../../BalExtensionContext';
 export interface ReviewRestoreData {
     generationId: string;
     tempProjectPath: string;
+    /** Frozen pre-generation Ballerina sources. Optional for payloads written by older versions. */
+    baselineProjectPath?: string;
     modifiedFiles: string[];
     affectedPackagePaths: string[];
     semanticDiffs: object[];

--- a/packages/ballerina-extension/src/features/ai/state/reviewRestoreStore.ts
+++ b/packages/ballerina-extension/src/features/ai/state/reviewRestoreStore.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { extension } from '../../../BalExtensionContext';
+
+/**
+ * Everything needed to reopen the review diff view for a pending generation
+ * after an extension host restart. The chat persistence schema
+ * (@wso2/copilot-utilities) deliberately drops tempProjectPath and
+ * affectedPackagePaths as runtime-only, so this payload is kept separately in
+ * the workspace Memento, written when a review starts and read by
+ * ApprovalViewManager.rebuildReviewDataFromStorage().
+ */
+export interface ReviewRestoreData {
+    generationId: string;
+    tempProjectPath: string;
+    modifiedFiles: string[];
+    affectedPackagePaths: string[];
+    semanticDiffs: object[];
+    loadDesignDiagrams: boolean;
+    isWorkspace: boolean;
+}
+
+const REVIEW_RESTORE_KEY = 'ballerina.copilot.pendingReviewRestore';
+
+export function savePendingReviewRestore(data: ReviewRestoreData): void {
+    extension.context.workspaceState.update(REVIEW_RESTORE_KEY, data);
+}
+
+export function getPendingReviewRestore(): ReviewRestoreData | undefined {
+    return extension.context.workspaceState.get<ReviewRestoreData>(REVIEW_RESTORE_KEY);
+}
+
+export function clearPendingReviewRestore(): void {
+    extension.context.workspaceState.update(REVIEW_RESTORE_KEY, undefined);
+}

--- a/packages/ballerina-extension/src/features/ai/state/reviewRestoreStore.ts
+++ b/packages/ballerina-extension/src/features/ai/state/reviewRestoreStore.ts
@@ -38,14 +38,17 @@ export interface ReviewRestoreData {
 
 const REVIEW_RESTORE_KEY = 'ballerina.copilot.pendingReviewRestore';
 
-export function savePendingReviewRestore(data: ReviewRestoreData): void {
-    extension.context.workspaceState.update(REVIEW_RESTORE_KEY, data);
+// Awaited so the Memento write is flushed before we return: this payload's whole
+// purpose is to survive an extension host restart, so a crash right after the call
+// must not be able to leave it unpersisted.
+export async function savePendingReviewRestore(data: ReviewRestoreData): Promise<void> {
+    await extension.context.workspaceState.update(REVIEW_RESTORE_KEY, data);
 }
 
 export function getPendingReviewRestore(): ReviewRestoreData | undefined {
     return extension.context.workspaceState.get<ReviewRestoreData>(REVIEW_RESTORE_KEY);
 }
 
-export function clearPendingReviewRestore(): void {
-    extension.context.workspaceState.update(REVIEW_RESTORE_KEY, undefined);
+export async function clearPendingReviewRestore(): Promise<void> {
+    await extension.context.workspaceState.update(REVIEW_RESTORE_KEY, undefined);
 }

--- a/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -143,12 +143,11 @@ export function sendAISchemaDidChange(tempProjectPath: string, filePath: string)
 
   try {
     const tempFileFullPath = path.join(tempProjectPath, filePath);
-    if (!fs.existsSync(tempFileFullPath)) {
-      console.warn(`[AgentNotification] File does not exist, skipping didChange: ${tempFileFullPath}`);
-      return;
-    }
-
-    const fileContent = fs.readFileSync(tempFileFullPath, 'utf-8');
+    // Empty content represents a deletion while the frozen file:// document retains the
+    // original. Skipping the notification made whole-file deletions invisible to semantic diff.
+    const fileContent = fs.existsSync(tempFileFullPath)
+      ? fs.readFileSync(tempFileFullPath, 'utf-8')
+      : '';
 
     // Send didChange to 'ai' schema only (file schema stays frozen at initial state)
     // Both schemas point to temp project path for semantic diff comparison
@@ -329,33 +328,62 @@ export function sendAgentDidCloseForProjects(tempProjectPath: string, projects: 
  * Re-opens a pending review's modified files in the Language Server after it has
  * restarted (e.g. a VS Code window reload): the in-memory file:// (original
  * baseline) and ai:// (modified) documents are gone, while the temp project on
- * disk holds the modified content and the generation checkpoint holds the
- * originals. Restores both schemas so semantic diff and flow-model lookups work.
+ * disk holds the modified content and its review baseline holds the originals.
+ * Older payloads can fall back to a generation checkpoint. Restores both schemas
+ * so semantic diff and flow-model lookups work.
  * @param tempProjectPath The root path of the temporary project
  * @param modifiedFiles Relative paths of the generation's modified files
- * @param originalContents Checkpoint workspace snapshot ('/'-separated relative path -> original content)
+ * @param baselineProjectPath Frozen pre-generation Ballerina sources. Its presence explicitly
+ * distinguishes added files (modified only), deleted files (baseline only), and modifications.
+ * @param fallbackOriginalContents Checkpoint snapshot for payloads written before baselines existed
  */
 export function sendReviewRestoreDidOpenBatch(
   tempProjectPath: string,
   modifiedFiles: string[],
-  originalContents: Record<string, string> | undefined
+  baselineProjectPath: string | undefined,
+  fallbackOriginalContents?: Record<string, string>
 ): void {
+  const normalizedTempRoot = path.resolve(tempProjectPath);
+  const baselineAvailable = !!baselineProjectPath && fs.existsSync(baselineProjectPath);
+
   for (const filePath of modifiedFiles) {
     if (!filePath.endsWith('.bal') && !filePath.endsWith('Ballerina.toml')) {
       continue;
     }
 
     try {
-      const tempFileFullPath = path.join(tempProjectPath, filePath);
-      if (!fs.existsSync(tempFileFullPath)) {
-        console.warn(`[AgentNotification] File does not exist, skipping review restore: ${tempFileFullPath}`);
+      const tempFileFullPath = path.resolve(tempProjectPath, filePath);
+      if (tempFileFullPath !== normalizedTempRoot && !tempFileFullPath.startsWith(normalizedTempRoot + path.sep)) {
+        console.warn(`[AgentNotification] Review restore path escapes temp project, skipping: ${filePath}`);
         continue;
       }
 
-      const modifiedContent = fs.readFileSync(tempFileFullPath, 'utf-8');
-      // Files created by the generation have no snapshot entry: empty baseline (whole file added)
       const snapshotKey = filePath.split(path.sep).join('/');
-      const originalContent = originalContents?.[snapshotKey] ?? '';
+      const tempFileExists = fs.existsSync(tempFileFullPath);
+      const baselineFileFullPath = baselineProjectPath ? path.resolve(baselineProjectPath, filePath) : undefined;
+      const baselineFileExists = !!baselineFileFullPath && baselineAvailable && fs.existsSync(baselineFileFullPath);
+      const hasFallbackOriginal = Object.prototype.hasOwnProperty.call(fallbackOriginalContents ?? {}, snapshotKey);
+
+      let originalContent: string;
+      if (baselineFileExists) {
+        originalContent = fs.readFileSync(baselineFileFullPath!, 'utf-8');
+      } else if (hasFallbackOriginal) {
+        originalContent = fallbackOriginalContents![snapshotKey];
+      } else if (baselineAvailable) {
+        // The baseline is authoritative: absence means the generation created this file.
+        originalContent = '';
+      } else {
+        console.warn(`[AgentNotification] Original content unavailable, skipping review restore: ${filePath}`);
+        continue;
+      }
+
+      if (!tempFileExists && !baselineFileExists && !hasFallbackOriginal) {
+        console.warn(`[AgentNotification] File is absent from both review versions, skipping: ${filePath}`);
+        continue;
+      }
+
+      // Empty modified content explicitly represents a whole-file deletion.
+      const modifiedContent = tempFileExists ? fs.readFileSync(tempFileFullPath, 'utf-8') : '';
       const languageId = filePath.endsWith('.bal') ? 'ballerina' : 'toml';
       const tempFileUri = Uri.file(tempFileFullPath).toString();
       const aiUri = 'ai' + tempFileUri.substring(4); // Replace 'file' prefix with 'ai'

--- a/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -324,3 +324,51 @@ export function sendAgentDidCloseForProjects(tempProjectPath: string, projects: 
   console.log(`[AgentNotification] Sending didClose for ${allFiles.length} files across ${projects.length} project(s)`);
   sendAgentDidCloseBatch(tempProjectPath, allFiles);
 }
+
+/**
+ * Re-opens a pending review's modified files in the Language Server after it has
+ * restarted (e.g. a VS Code window reload): the in-memory file:// (original
+ * baseline) and ai:// (modified) documents are gone, while the temp project on
+ * disk holds the modified content and the generation checkpoint holds the
+ * originals. Restores both schemas so semantic diff and flow-model lookups work.
+ * @param tempProjectPath The root path of the temporary project
+ * @param modifiedFiles Relative paths of the generation's modified files
+ * @param originalContents Checkpoint workspace snapshot ('/'-separated relative path -> original content)
+ */
+export function sendReviewRestoreDidOpenBatch(
+  tempProjectPath: string,
+  modifiedFiles: string[],
+  originalContents: Record<string, string> | undefined
+): void {
+  for (const filePath of modifiedFiles) {
+    if (!filePath.endsWith('.bal') && !filePath.endsWith('Ballerina.toml')) {
+      continue;
+    }
+
+    try {
+      const tempFileFullPath = path.join(tempProjectPath, filePath);
+      if (!fs.existsSync(tempFileFullPath)) {
+        console.warn(`[AgentNotification] File does not exist, skipping review restore: ${tempFileFullPath}`);
+        continue;
+      }
+
+      const modifiedContent = fs.readFileSync(tempFileFullPath, 'utf-8');
+      // Files created by the generation have no snapshot entry: empty baseline (whole file added)
+      const snapshotKey = filePath.split(path.sep).join('/');
+      const originalContent = originalContents?.[snapshotKey] ?? '';
+      const languageId = filePath.endsWith('.bal') ? 'ballerina' : 'toml';
+      const tempFileUri = Uri.file(tempFileFullPath).toString();
+      const aiUri = 'ai' + tempFileUri.substring(4); // Replace 'file' prefix with 'ai'
+
+      StateMachine.langClient().didOpen({
+        textDocument: { uri: tempFileUri, languageId, version: 1, text: originalContent }
+      });
+      StateMachine.langClient().didOpen({
+        textDocument: { uri: aiUri, languageId, version: 1, text: modifiedContent }
+      });
+      console.log(`[AgentNotification] Restored review schemas for: ${filePath}`);
+    } catch (error) {
+      console.error(`[AgentNotification] Failed to restore review schemas for ${filePath}:`, error);
+    }
+  }
+}

--- a/packages/ballerina-extension/src/features/ai/utils/project/temp-project.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/temp-project.ts
@@ -50,6 +50,41 @@ interface BallerinaModule {
     isGenerated: boolean;
 }
 
+const REVIEW_BASELINE_SUFFIX = '-review-baseline';
+const REVIEW_BASELINE_IGNORED_DIRECTORIES = new Set([
+    '.git',
+    'node_modules',
+    'target',
+    'build',
+    'dist',
+]);
+
+export function getReviewBaselinePath(tempProjectPath: string): string {
+    return `${tempProjectPath}${REVIEW_BASELINE_SUFFIX}`;
+}
+
+async function copyReviewBaselineFiles(sourceRoot: string, baselineRoot: string, relativeDir = ''): Promise<void> {
+    const sourceDir = path.join(sourceRoot, relativeDir);
+    const entries = await fs.promises.readdir(sourceDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            if (!REVIEW_BASELINE_IGNORED_DIRECTORIES.has(entry.name)) {
+                await copyReviewBaselineFiles(sourceRoot, baselineRoot, path.join(relativeDir, entry.name));
+            }
+            continue;
+        }
+        if (!entry.isFile() || (!entry.name.endsWith('.bal') && entry.name !== 'Ballerina.toml')) {
+            continue;
+        }
+
+        const relativeFile = path.join(relativeDir, entry.name);
+        const baselineFile = path.join(baselineRoot, relativeFile);
+        await fs.promises.mkdir(path.dirname(baselineFile), { recursive: true });
+        await fs.promises.copyFile(path.join(sourceRoot, relativeFile), baselineFile);
+    }
+}
+
 /**
  * Recursively finds all .bal files in a directory
  * @param dir Directory to search
@@ -113,6 +148,7 @@ export async function getTempProject(ctx: ExecutionContext): Promise<TempProject
     const timestamp = Date.now();
     const randomSuffix = crypto.randomBytes(4).toString('hex');
     const tempDir = path.join(os.tmpdir(), `bal-proj-${projectHash}-${timestamp}-${randomSuffix}`);
+    const baselineDir = getReviewBaselinePath(tempDir);
 
     if (fs.existsSync(tempDir)) {
         const existingFiles = findAllBalFiles(tempDir);
@@ -125,11 +161,28 @@ export async function getTempProject(ctx: ExecutionContext): Promise<TempProject
         fs.rmSync(tempDir, { recursive: true, force: true });
     }
 
-    // Create temp directory
-    fs.mkdirSync(tempDir, { recursive: true });
+    try {
+        // Create temp directory
+        fs.mkdirSync(tempDir, { recursive: true });
 
-    // Copy entire project to temp directory
-    await fs.promises.cp(projectRoot, tempDir, { recursive: true });
+        // Copy entire project to temp directory
+        await fs.promises.cp(projectRoot, tempDir, { recursive: true });
+
+        // Keep a compact, on-disk original for review restoration. Checkpoints are optional and
+        // size-limited, while this baseline only contains files used by semantic/diagram diffs.
+        await fs.promises.mkdir(baselineDir, { recursive: true });
+        await copyReviewBaselineFiles(tempDir, baselineDir);
+    } catch (error) {
+        // A partial project/baseline is never usable and must not outlive a failed setup.
+        for (const directory of [tempDir, baselineDir]) {
+            try {
+                fs.rmSync(directory, { recursive: true, force: true });
+            } catch (cleanupError) {
+                console.error(`Failed to remove partial temp project artifact at ${directory}:`, cleanupError);
+            }
+        }
+        throw error;
+    }
 
     return {
         path: tempDir
@@ -144,22 +197,29 @@ export async function getTempProject(ctx: ExecutionContext): Promise<TempProject
  * @param tempPath Path to the temporary project to delete
  */
 export async function cleanupTempProject(tempPath: string): Promise<void> {
-    if (!fs.existsSync(tempPath)) {
+    const baselinePath = getReviewBaselinePath(tempPath);
+    if (!fs.existsSync(tempPath) && !fs.existsSync(baselinePath)) {
         return;
     }
 
     try {
         // Find all .bal files and send didClose notifications
-        const balFiles = findAllBalFiles(tempPath);
+        const balFiles = fs.existsSync(tempPath) ? findAllBalFiles(tempPath) : [];
         if (balFiles.length > 0) {
             sendAgentDidCloseBatch(tempPath, balFiles); // Handles both file:// and ai:// schemas
             await new Promise(resolve => setTimeout(resolve, 300)); // Wait for LS to process
         }
-
-        // Delete temp directory
-        fs.rmSync(tempPath, { recursive: true, force: true });
     } catch (error) {
-        console.error(`Failed to cleanup temp project at ${tempPath}:`, error);
+        console.error(`Failed to notify the language server before cleaning up ${tempPath}:`, error);
+    } finally {
+        // Remove both directories even when an LS notification fails.
+        for (const directory of [tempPath, baselinePath]) {
+            try {
+                fs.rmSync(directory, { recursive: true, force: true });
+            } catch (error) {
+                console.error(`Failed to cleanup temp project artifact at ${directory}:`, error);
+            }
+        }
     }
 }
 

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -47,6 +47,7 @@ import {
     generateOpenAPI,
     GenerateOpenAPIRequest,
     getActiveTempDir,
+    hasPendingReview,
     getAIMachineSnapshot,
     getChatMessages,
     getCheckpoints,
@@ -190,6 +191,7 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(clearChat, () => rpcManger.clearChat());
     messenger.onRequest(updateChatMessage, (args: UpdateChatMessageRequest) => rpcManger.updateChatMessage(args));
     messenger.onRequest(getActiveTempDir, () => rpcManger.getActiveTempDir());
+    messenger.onRequest(hasPendingReview, () => rpcManger.hasPendingReview());
     messenger.onRequest(getUsage, () => rpcManger.getUsage());
     messenger.onNotification(openFileDiff, (args: OpenFileDiffRequest) => rpcManger.openFileDiff(args));
     messenger.onRequest(approveWebTool, (args: WebToolApprovalRequest) => rpcManger.approveWebTool(args));

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -134,6 +134,7 @@ import { clearCompactionDisabledWarning } from '../../features/ai/agent/AgentExe
 import { LLM_API_BASE_PATH, WI_EXTENSION_ID } from "../../features/ai/constants";
 import { ContextTypesExecutor } from '../../features/ai/executors/datamapper/ContextTypesExecutor';
 import { approvalManager } from '../../features/ai/state/ApprovalManager';
+import { clearPendingReviewRestore, getPendingReviewRestore } from '../../features/ai/state/reviewRestoreStore';
 import { cleanupTempProject } from "../../features/ai/utils/project/temp-project";
 import { chatStateStorage } from '../../views/ai-panel/chatStateStorage';
 import { restoreWorkspaceSnapshot } from '../../views/ai-panel/checkpoint/checkpointUtils';
@@ -157,6 +158,37 @@ function validateMcpServerConfig(cfg: any): string | null {
         }
     }
     return null;
+}
+
+interface ReviewCleanupGeneration {
+    id: string;
+    reviewState: { tempProjectPath?: string };
+}
+
+async function cleanupReviewTempProjects(generations: ReviewCleanupGeneration[]): Promise<void> {
+    const generationIds = new Set(generations.map((generation) => generation.id));
+    const tempPaths = new Set(
+        generations
+            .map((generation) => generation.reviewState.tempProjectPath)
+            .filter((tempPath): tempPath is string => !!tempPath)
+    );
+    const restore = getPendingReviewRestore();
+    const restoreMatches = !!restore && generationIds.has(restore.generationId);
+    if (restoreMatches) {
+        tempPaths.add(restore.tempProjectPath);
+    }
+
+    try {
+        if (!process.env.AI_TEST_ENV) {
+            for (const tempPath of tempPaths) {
+                await cleanupTempProject(tempPath);
+            }
+        }
+    } finally {
+        if (restoreMatches) {
+            await clearPendingReviewRestore();
+        }
+    }
 }
 
 export class AiPanelRpcManager implements AIPanelAPI {
@@ -478,14 +510,8 @@ export class AiPanelRpcManager implements AIPanelAPI {
             const latestReview = underReviewGenerations[underReviewGenerations.length - 1];
             console.log(`[Review Actions] Accepting generation ${latestReview.id} with ${latestReview.reviewState.modifiedFiles.length} modified file(s)`);
 
-            // Cleanup ALL under_review temp projects (prevents memory leak)
-            if (!process.env.AI_TEST_ENV) {
-                for (const generation of underReviewGenerations) {
-                    if (generation.reviewState.tempProjectPath) {
-                        await cleanupTempProject(generation.reviewState.tempProjectPath);
-                    }
-                }
-            }
+            // Cleanup all runtime and restored temp projects before dropping review state.
+            await cleanupReviewTempProjects(underReviewGenerations);
 
             // Mark ALL under_review generations as accepted (also clears affectedPackagePaths)
             chatStateStorage.acceptAllReviews(projectRootPath, threadId);
@@ -532,14 +558,8 @@ export class AiPanelRpcManager implements AIPanelAPI {
                 console.warn("[Review Actions] No checkpoint found for generation — workspace changes will not be reverted");
             }
 
-            // Cleanup ALL under_review temp projects (prevents memory leak)
-            if (!process.env.AI_TEST_ENV) {
-                for (const generation of underReviewGenerations) {
-                    if (generation.reviewState.tempProjectPath) {
-                        await cleanupTempProject(generation.reviewState.tempProjectPath);
-                    }
-                }
-            }
+            // Cleanup all runtime and restored temp projects before dropping review state.
+            await cleanupReviewTempProjects(underReviewGenerations);
 
             // Append revert notification to model messages so the LLM knows changes were reverted
             const existingMessages = latestReview.modelMessages || [];

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -750,6 +750,11 @@ User reverted the last made changes. The files have been restored to the state b
         return projectPath;
     }
 
+    async hasPendingReview(): Promise<boolean> {
+        const projectRootPath = resolveProjectRootPath();
+        return !!chatStateStorage.getPendingReviewGeneration(projectRootPath, 'default');
+    }
+
     async compactConversation(_params: CompactConversationRequest): Promise<CompactConversationResponse> {
         // Manual compaction is no longer supported. Context is managed automatically
         // server-side via the compact_20260112 API during agent execution.

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
@@ -52,6 +52,11 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
         }
         isBalFileAdded = true;
 
+        if (fileChange.deleted) {
+            formattedWorkspaceEdit.deleteFile(fileUri, { ignoreIfNotExists: true });
+            continue;
+        }
+
         formattedWorkspaceEdit.createFile(fileUri, { ignoreIfExists: true });
 
         formattedWorkspaceEdit.replace(
@@ -71,6 +76,10 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
     // Write non ballerina files separately as ls doesn't need to be notified of those changes
     for (const fileChange of nonBalFiles) {
         let absoluteFilePath = path.join(workspaceFolderPath, fileChange.filePath);
+        if (fileChange.deleted) {
+            fs.rmSync(absoluteFilePath, { force: true });
+            continue;
+        }
         const directory = path.dirname(absoluteFilePath);
         if (!fs.existsSync(directory)) {
             fs.mkdirSync(directory, { recursive: true });

--- a/packages/ballerina-extension/src/rpc-managers/visualizer/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/visualizer/rpc-manager.ts
@@ -346,7 +346,8 @@ export class VisualizerRpcManager implements VisualizerAPI {
     }
 
     navigateReviewMode(index: number): void {
-        approvalViewManager.navigateReviewMode(index);
+        approvalViewManager.navigateReviewMode(index).catch((err) =>
+            console.error("[Visualizer] Failed to navigate review mode:", err));
     }
 
     async saveEvalThread(params: SaveEvalThreadRequest): Promise<SaveEvalThreadResponse> {

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -71,6 +71,14 @@ export let undoRedoManager: IUndoRedoManager;
 let pendingProjectRootUpdateResolvers: Array<() => void> = [];
 let scaffoldPromptTriggered = false;
 
+// Bounded wait for `workspace.workspaceFolders` to be populated before deciding whether the
+// opened project is a BI project. VS Code can activate the extension before the folders/config
+// are settled (notably on window reload), which otherwise makes detection fall back to "not BI".
+const WORKSPACE_FOLDERS_WAIT_TIMEOUT_MS = 5000;
+// `getProjectInfo` can transiently fail while the LS is still warming up right after activation.
+const MAX_PROJECT_INFO_RETRIES = 3;
+const PROJECT_INFO_RETRY_DELAY_MS = 1000;
+
 const stateMachine = createMachine<MachineContext>(
     {
         /** @xstate-layout N4IgpgJg5mDOIC5QDUCWsCuBDANqgXmAE4DEASgKIDKFAKgPq0Dy9FAGrRQHJUCSTXepQCCAEQCaAbQAMAXUSgADgHtYqAC6plAOwUgAHogDsRgDQgAnogCMADgBsAVgB0ATkcAmawGZX0owAsRrYBtgC+YeZomLgExCQAqgAKosKc9ElkTABSFADCDFS0ZAkFCZQy8kggKmqaOnqGCNYervbOtkbW0gG+AR4B0t7mVs3Sts4Bjt7Wg66uAdZd9q4RUejYeISkyanpmTn5DFlMtJV6tRpautVNPl7OM-beL0Hjsx4jNgsTU17e0mk9ls81WkRA0U2cR2KTSFAyWVyBXoABkmHk0vwuOdqpd6jdQHcAQFnNIPEYPPYuk93GZLDYPGsIRtYtsSFQAOq8Wh5AASCMOBRxSlUVwatxs-i+zQ8HhcQNc3lsMzs5McRiZkNZxGcsAA7hoAMYAC3oiiIygAVmBDeoSBAdGBnKhtAA3ZQAaydWq2Ov1RtN5qtNvUCBd7sNWHxlWFNVF+MaiCC1jcPnmnm8rUc0kc0us1j8znz9mswL89iG5M1LN9RGd2iu2vtjvr7q9zh90Prjd9Ybdykj0bksbx10TCA8DlJ9jlOaC3lCM+lXQm3QWbXJRgXmerMVr3c0TYd2id4c93prXZdPbifYjUeuMesVRFdTHEonU6Bs8c88Xn3pBB1RJbxHAWQEjBLbpgV3KFtgPVAm2IC060UHAowAM2UIgAFsO0veDr0PXsz0HR9hzkC543fQlEHJdpv2zX8t3-aUQW8ZxHFsMCQVLCkjC42DtTrIgwG0CBiF4BtiLQMA9WbE9W3PfC9y7UTxMk6TEJwWS9TvAcHx0GNKNxajxVohBFQ4ycWgBVwQjlLjl0CR5QJBewgnJVxrEcIT93UiSiCkntdJIZDsOcNDMOwvDO3ggLNJC1A5P0sijIol84zfcyDEQKznBsjw7IcxwnMAil2mVCsVknPxxl88E4p1LBbVQV0ozAFEqAU09+3bJq6xazR2vUTqqFSwztGMzLRxyu5+lcDp7NAgIAkVNbHHsZdWkmbjXCMfw5RWJY-K7Ia2o6rqwqIFDIvQ9QsNwlS4Oa1qRrGiah1kEczIJXLLLpUZZnsdpNsVPw+l-AJTvgjCwHUE0kgta1bSodQiAwW0MFEnqlP6gidThhHjSR4NUfRzH1GxsBPvI76TNfMU-qafoOKmOzoJWRxSzzA6PAK0JbFsHNFSK0qYcJ+HEeRkM0YxrGcfC1D7se2KCbrInpbJ9Q5cp6nafS+mZt+8dWcmaZpG8oEuZ5wDS3GZwjHcIWunJVb8wluscFgCgbuw8g6DIKQGaypnx28QG6JmDowN8bjbFlOUE895wwH0UbtDUHQyDALAIAsEgmCSbh6GQXgKA5H7suZvKhkeXonGeYIneVXn-Dcey2kBfwwNWlPXWSvVhDep0B7k4K7WPXq2wvVT4LHoeR+cBeJ4NqaMqo6vxx8IEluVOxuK3YEtrt7mSR6CsIOFpUq0a9Xl8H4fhtHweJ9xs98bnnUF6ftqX-H6Sa8nzGy3h+HelVloH3VN4Y+eZG6Oy7iqYEgwXj90fkvUSsBlA4FdGAAAsugNQ2goCiDAIoMSEltCGmSrAd+fVZ4vTrD-DBcBsG4IIbAIhJCyEULEtQuAQCN6mVARZAsk5SQBCpO8LoPRXB5jWimBUixIK+AjjBO+X8mHoOfs4PUYAABGukUTKDzi6KAdCZ7PWEg-OSv9cG6IMUYkxEAzGCKNpvMOH4Bj5jcMCHiSwgixzgYsR2LRgQmBzBSeYaDbFLz0YYwexi86QAscpAaNjF46PiU45JEA3FV08RZbxKY2h7VsAEgSio8wLhJFxCsiowLTAjuEDRjCMl2P-nqHOecC5FxLmXCuBSExeOth0HonhZGZhWCfIGC4XDlMVA4ASHlLYtPWJo9pS8F7dPziQAZHJ6C7DhEMmi-1im+LKRUoJp8pgFTAjOcpXgE4CRiZkv+GSdkFwAGK8BRPCCgohuQnLmnRRYJS-H2SuVUu2rRz4OH8ICCO0gfJrOZBs5hOiF4UBcZoYhJAAXcnoKIAQFBgU1wnL0CYAx7ITP2isSOMpeicXhZIoIDhFkRHBNoZQEl4DVAGh44ZFkAC0+Z5EgVjm0FBNTOgp39MTM0MtbSCtOU0AERgY4+VlJmUCFI8weDJNOBpzxgRKlcIyVp1iiLaTiCqkFYwGXqgmEqMCfhFi9AEha9ZbSEpBS0rgXSdryVdBJMEFo7qarmoAqMZYzL7mUkTgWBq3rrHnXel1IN29Zi-DTIEDc2ZgjSldW4Pa2ZJEHXzF6tFbTNYkyVTrCmCswCZo-OauBDxPADDLb4ckIQU7e19ihFtFktwpmmHVJYcpBh6rtm5SYq1QIFkGNxQSlr9xpwzlnbQnzh3-S3PzToCjSzlMpTMmwo7JgCV-DMRcryOm7ruEMFwcdWhUmCK0QIeYfIMT2k7JYPl9rJurdYjF7yV7SQfZKZUjx7KvpMAnfaAR5GdAkRWSRwsgjmrvSwrBOD8GELMaQ8hGkqE0Mg80EsGqDVZgGJmZZthkOLV-P4qkThIJAfSaB+x2TEnOLMeR2UpYY5RorAa+yq04FLAKmE4+yLzUR2w1kxxvHckCd7kWUI5IyT7SdqVPMjSOgRwEvmQERUQaKbA4PHdwjClnIGKuezq0-G9DkbOks0nyRLoEk8Cz9isU4v4zZoVZz1PZq0x+3TuYYUglJGSDykqqQNQiEAA */
@@ -517,18 +525,28 @@ const stateMachine = createMachine<MachineContext>(
             });
         },
         fetchProjectInfo: (context, event) => {
-            return new Promise(async (resolve, reject) => {
-                try {
-                    const projectPath = context.workspacePath || context.projectPath;
-                    if (!projectPath) {
-                        resolve({ projectInfo: undefined });
-                    } else {
+            return new Promise(async (resolve) => {
+                const projectPath = context.workspacePath || context.projectPath;
+                if (!projectPath || !context.langClient) {
+                    resolve({ projectInfo: undefined });
+                    return;
+                }
+                // Retry a few times to ride out the LS still warming up. On persistent failure,
+                // resolve with undefined so the machine still reaches `extensionReady` (degraded)
+                // instead of throwing into the `lsError` dead-end and hanging activate().
+                for (let attempt = 1; attempt <= MAX_PROJECT_INFO_RETRIES; attempt++) {
+                    try {
                         const projectInfo = await context.langClient.getProjectInfo({ projectPath });
                         resolve({ projectInfo });
+                        return;
+                    } catch (error) {
+                        console.error(`Error occurred while fetching project info (attempt ${attempt}/${MAX_PROJECT_INFO_RETRIES}).`, error);
+                        if (attempt < MAX_PROJECT_INFO_RETRIES) {
+                            await new Promise((r) => setTimeout(r, PROJECT_INFO_RETRY_DELAY_MS));
+                        }
                     }
-                } catch (error) {
-                    throw new Error("Error occurred while fetching project info.", error);
                 }
+                resolve({ projectInfo: undefined });
             });
         },
         registerProjectArtifactsStructure: (context, event) => {
@@ -841,9 +859,13 @@ const stateMachine = createMachine<MachineContext>(
 const stateService = interpret(stateMachine);
 
 function startMachine(): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
+    return new Promise<void>((resolve) => {
         stateService.start().onTransition((state) => {
-            if (state.value === "extensionReady") {
+            // Resolve on `lsError` as well so activate() never hangs when an init step fails on a
+            // path that can't be safely auto-retried (activateBallerina is not idempotent). The
+            // extension then activates in a degraded state (BI.status reflects the LS failure)
+            // rather than staying stuck "activating" forever.
+            if (state.value === "extensionReady" || state.value === "lsError") {
                 resolve();
             }
         });
@@ -1020,10 +1042,36 @@ function getLastHistory() {
     return historyStack?.[historyStack?.length - 1];
 }
 
-async function checkForProjects() {
-    const workspaceFolders = workspace.workspaceFolders;
+/**
+ * VS Code can call extension activation before `workspace.workspaceFolders` is populated
+ * (e.g. on window reload). Reading it too early makes BI detection fall back to "not a BI
+ * project", so wait (bounded) for the folders to appear before deciding.
+ */
+async function waitForWorkspaceFolders(
+    timeoutMs = WORKSPACE_FOLDERS_WAIT_TIMEOUT_MS
+): Promise<readonly WorkspaceFolder[] | undefined> {
+    if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+        return workspace.workspaceFolders;
+    }
+    return new Promise((resolve) => {
+        const finish = () => {
+            clearTimeout(timer);
+            disposable.dispose();
+            resolve(workspace.workspaceFolders);
+        };
+        const disposable = workspace.onDidChangeWorkspaceFolders(() => {
+            if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+                finish();
+            }
+        });
+        const timer = setTimeout(finish, timeoutMs);
+    });
+}
 
-    if (!workspaceFolders) {
+async function checkForProjects() {
+    const workspaceFolders = await waitForWorkspaceFolders();
+
+    if (!workspaceFolders || workspaceFolders.length === 0) {
         return { isBI: false, projects: [] };
     }
 

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -71,14 +71,6 @@ export let undoRedoManager: IUndoRedoManager;
 let pendingProjectRootUpdateResolvers: Array<() => void> = [];
 let scaffoldPromptTriggered = false;
 
-// Bounded wait for `workspace.workspaceFolders` to be populated before deciding whether the
-// opened project is a BI project. VS Code can activate the extension before the folders/config
-// are settled (notably on window reload), which otherwise makes detection fall back to "not BI".
-const WORKSPACE_FOLDERS_WAIT_TIMEOUT_MS = 5000;
-// `getProjectInfo` can transiently fail while the LS is still warming up right after activation.
-const MAX_PROJECT_INFO_RETRIES = 3;
-const PROJECT_INFO_RETRY_DELAY_MS = 1000;
-
 const stateMachine = createMachine<MachineContext>(
     {
         /** @xstate-layout N4IgpgJg5mDOIC5QDUCWsCuBDANqgXmAE4DEASgKIDKFAKgPq0Dy9FAGrRQHJUCSTXepQCCAEQCaAbQAMAXUSgADgHtYqAC6plAOwUgAHogDsRgDQgAnogCMADgBsAVgB0ATkcAmawGZX0owAsRrYBtgC+YeZomLgExCQAqgAKosKc9ElkTABSFADCDFS0ZAkFCZQy8kggKmqaOnqGCNYervbOtkbW0gG+AR4B0t7mVs3Sts4Bjt7Wg66uAdZd9q4RUejYeISkyanpmTn5DFlMtJV6tRpautVNPl7OM-beL0Hjsx4jNgsTU17e0mk9ls81WkRA0U2cR2KTSFAyWVyBXoABkmHk0vwuOdqpd6jdQHcAQFnNIPEYPPYuk93GZLDYPGsIRtYtsSFQAOq8Wh5AASCMOBRxSlUVwatxs-i+zQ8HhcQNc3lsMzs5McRiZkNZxGcsAA7hoAMYAC3oiiIygAVmBDeoSBAdGBnKhtAA3ZQAaydWq2Ov1RtN5qtNvUCBd7sNWHxlWFNVF+MaiCC1jcPnmnm8rUc0kc0us1j8znz9mswL89iG5M1LN9RGd2iu2vtjvr7q9zh90Prjd9Ybdykj0bksbx10TCA8DlJ9jlOaC3lCM+lXQm3QWbXJRgXmerMVr3c0TYd2id4c93prXZdPbifYjUeuMesVRFdTHEonU6Bs8c88Xn3pBB1RJbxHAWQEjBLbpgV3KFtgPVAm2IC060UHAowAM2UIgAFsO0veDr0PXsz0HR9hzkC543fQlEHJdpv2zX8t3-aUQW8ZxHFsMCQVLCkjC42DtTrIgwG0CBiF4BtiLQMA9WbE9W3PfC9y7UTxMk6TEJwWS9TvAcHx0GNKNxajxVohBFQ4ycWgBVwQjlLjl0CR5QJBewgnJVxrEcIT93UiSiCkntdJIZDsOcNDMOwvDO3ggLNJC1A5P0sijIol84zfcyDEQKznBsjw7IcxwnMAil2mVCsVknPxxl88E4p1LBbVQV0ozAFEqAU09+3bJq6xazR2vUTqqFSwztGMzLRxyu5+lcDp7NAgIAkVNbHHsZdWkmbjXCMfw5RWJY-K7Ia2o6rqwqIFDIvQ9QsNwlS4Oa1qRrGiah1kEczIJXLLLpUZZnsdpNsVPw+l-AJTvgjCwHUE0kgta1bSodQiAwW0MFEnqlP6gidThhHjSR4NUfRzH1GxsBPvI76TNfMU-qafoOKmOzoJWRxSzzA6PAK0JbFsHNFSK0qYcJ+HEeRkM0YxrGcfC1D7se2KCbrInpbJ9Q5cp6nafS+mZt+8dWcmaZpG8oEuZ5wDS3GZwjHcIWunJVb8wluscFgCgbuw8g6DIKQGaypnx28QG6JmDowN8bjbFlOUE895wwH0UbtDUHQyDALAIAsEgmCSbh6GQXgKA5H7suZvKhkeXonGeYIneVXn-Dcey2kBfwwNWlPXWSvVhDep0B7k4K7WPXq2wvVT4LHoeR+cBeJ4NqaMqo6vxx8IEluVOxuK3YEtrt7mSR6CsIOFpUq0a9Xl8H4fhtHweJ9xs98bnnUF6ftqX-H6Sa8nzGy3h+HelVloH3VN4Y+eZG6Oy7iqYEgwXj90fkvUSsBlA4FdGAAAsugNQ2goCiDAIoMSEltCGmSrAd+fVZ4vTrD-DBcBsG4IIbAIhJCyEULEtQuAQCN6mVARZAsk5SQBCpO8LoPRXB5jWimBUixIK+AjjBO+X8mHoOfs4PUYAABGukUTKDzi6KAdCZ7PWEg-OSv9cG6IMUYkxEAzGCKNpvMOH4Bj5jcMCHiSwgixzgYsR2LRgQmBzBSeYaDbFLz0YYwexi86QAscpAaNjF46PiU45JEA3FV08RZbxKY2h7VsAEgSio8wLhJFxCsiowLTAjuEDRjCMl2P-nqHOecC5FxLmXCuBSExeOth0HonhZGZhWCfIGC4XDlMVA4ASHlLYtPWJo9pS8F7dPziQAZHJ6C7DhEMmi-1im+LKRUoJp8pgFTAjOcpXgE4CRiZkv+GSdkFwAGK8BRPCCgohuQnLmnRRYJS-H2SuVUu2rRz4OH8ICCO0gfJrOZBs5hOiF4UBcZoYhJAAXcnoKIAQFBgU1wnL0CYAx7ITP2isSOMpeicXhZIoIDhFkRHBNoZQEl4DVAGh44ZFkAC0+Z5EgVjm0FBNTOgp39MTM0MtbSCtOU0AERgY4+VlJmUCFI8weDJNOBpzxgRKlcIyVp1iiLaTiCqkFYwGXqgmEqMCfhFi9AEha9ZbSEpBS0rgXSdryVdBJMEFo7qarmoAqMZYzL7mUkTgWBq3rrHnXel1IN29Zi-DTIEDc2ZgjSldW4Pa2ZJEHXzF6tFbTNYkyVTrCmCswCZo-OauBDxPADDLb4ckIQU7e19ihFtFktwpmmHVJYcpBh6rtm5SYq1QIFkGNxQSlr9xpwzlnbQnzh3-S3PzToCjSzlMpTMmwo7JgCV-DMRcryOm7ruEMFwcdWhUmCK0QIeYfIMT2k7JYPl9rJurdYjF7yV7SQfZKZUjx7KvpMAnfaAR5GdAkRWSRwsgjmrvSwrBOD8GELMaQ8hGkqE0Mg80EsGqDVZgGJmZZthkOLV-P4qkThIJAfSaB+x2TEnOLMeR2UpYY5RorAa+yq04FLAKmE4+yLzUR2w1kxxvHckCd7kWUI5IyT7SdqVPMjSOgRwEvmQERUQaKbA4PHdwjClnIGKuezq0-G9DkbOks0nyRLoEk8Cz9isU4v4zZoVZz1PZq0x+3TuYYUglJGSDykqqQNQiEAA */
@@ -525,28 +517,18 @@ const stateMachine = createMachine<MachineContext>(
             });
         },
         fetchProjectInfo: (context, event) => {
-            return new Promise(async (resolve) => {
-                const projectPath = context.workspacePath || context.projectPath;
-                if (!projectPath || !context.langClient) {
-                    resolve({ projectInfo: undefined });
-                    return;
-                }
-                // Retry a few times to ride out the LS still warming up. On persistent failure,
-                // resolve with undefined so the machine still reaches `extensionReady` (degraded)
-                // instead of throwing into the `lsError` dead-end and hanging activate().
-                for (let attempt = 1; attempt <= MAX_PROJECT_INFO_RETRIES; attempt++) {
-                    try {
+            return new Promise(async (resolve, reject) => {
+                try {
+                    const projectPath = context.workspacePath || context.projectPath;
+                    if (!projectPath) {
+                        resolve({ projectInfo: undefined });
+                    } else {
                         const projectInfo = await context.langClient.getProjectInfo({ projectPath });
                         resolve({ projectInfo });
-                        return;
-                    } catch (error) {
-                        console.error(`Error occurred while fetching project info (attempt ${attempt}/${MAX_PROJECT_INFO_RETRIES}).`, error);
-                        if (attempt < MAX_PROJECT_INFO_RETRIES) {
-                            await new Promise((r) => setTimeout(r, PROJECT_INFO_RETRY_DELAY_MS));
-                        }
                     }
+                } catch (error) {
+                    throw new Error("Error occurred while fetching project info.", error);
                 }
-                resolve({ projectInfo: undefined });
             });
         },
         registerProjectArtifactsStructure: (context, event) => {
@@ -859,13 +841,9 @@ const stateMachine = createMachine<MachineContext>(
 const stateService = interpret(stateMachine);
 
 function startMachine(): Promise<void> {
-    return new Promise<void>((resolve) => {
+    return new Promise<void>(async (resolve, reject) => {
         stateService.start().onTransition((state) => {
-            // Resolve on `lsError` as well so activate() never hangs when an init step fails on a
-            // path that can't be safely auto-retried (activateBallerina is not idempotent). The
-            // extension then activates in a degraded state (BI.status reflects the LS failure)
-            // rather than staying stuck "activating" forever.
-            if (state.value === "extensionReady" || state.value === "lsError") {
+            if (state.value === "extensionReady") {
                 resolve();
             }
         });
@@ -1042,36 +1020,10 @@ function getLastHistory() {
     return historyStack?.[historyStack?.length - 1];
 }
 
-/**
- * VS Code can call extension activation before `workspace.workspaceFolders` is populated
- * (e.g. on window reload). Reading it too early makes BI detection fall back to "not a BI
- * project", so wait (bounded) for the folders to appear before deciding.
- */
-async function waitForWorkspaceFolders(
-    timeoutMs = WORKSPACE_FOLDERS_WAIT_TIMEOUT_MS
-): Promise<readonly WorkspaceFolder[] | undefined> {
-    if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-        return workspace.workspaceFolders;
-    }
-    return new Promise((resolve) => {
-        const finish = () => {
-            clearTimeout(timer);
-            disposable.dispose();
-            resolve(workspace.workspaceFolders);
-        };
-        const disposable = workspace.onDidChangeWorkspaceFolders(() => {
-            if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-                finish();
-            }
-        });
-        const timer = setTimeout(finish, timeoutMs);
-    });
-}
-
 async function checkForProjects() {
-    const workspaceFolders = await waitForWorkspaceFolders();
+    const workspaceFolders = workspace.workspaceFolders;
 
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    if (!workspaceFolders) {
         return { isBI: false, projects: [] };
     }
 

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -103,6 +103,7 @@ public class SemanticDiffComputer {
             String docName = entry.getKey();
             if (!modifiedDocumentMap.containsKey(docName)) {
                 // Document removed in modified project
+                entry.getValue().syntaxTree().rootNode().accept(originalNodeRefExtractor);
                 continue;
             }
             Document originalDoc = entry.getValue();
@@ -305,9 +306,59 @@ public class SemanticDiffComputer {
                                        FunctionDefinitionNode modifiedFunction,
                                        NodeKind kind, Map<String, String> metadata) {
 
+        if (!functionHeaderKey(originalFunction).equals(functionHeaderKey(modifiedFunction))) {
+            LineRange lineRange = modifiedFunction.lineRange();
+            SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
+                    resolveUri(lineRange.fileName()), lineRange, metadata);
+            this.semanticDiffs.add(diff);
+            return;
+        }
+
         FunctionBodyNode originalFunctionBody = originalFunction.functionBody();
         FunctionBodyNode modifiedFunctionBody = modifiedFunction.functionBody();
         compareFunctionBodies(modifiedFunction, originalFunctionBody, modifiedFunctionBody, kind, metadata);
+    }
+
+    /**
+     * Builds a trivia-insensitive key for the complete function header. Comparing only function
+     * bodies made parameter, return type, qualifier and resource-path changes disappear from the
+     * review entirely.
+     */
+    private String functionHeaderKey(FunctionDefinitionNode function) {
+        StringBuilder header = new StringBuilder();
+        function.qualifierList().forEach(node -> header.append(node.toSourceCode()));
+        header.append(function.functionKeyword().toSourceCode());
+        header.append(function.functionName().toSourceCode());
+        function.relativeResourcePath().forEach(node -> header.append(node.toSourceCode()));
+        header.append(function.functionSignature().toSourceCode());
+        return normalizeTriviaOutsideLiterals(header.toString());
+    }
+
+    private String normalizeTriviaOutsideLiterals(String source) {
+        StringBuilder normalized = new StringBuilder();
+        char delimiter = 0;
+        boolean escaped = false;
+        for (int i = 0; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (delimiter != 0) {
+                normalized.append(current);
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == delimiter) {
+                    delimiter = 0;
+                }
+                continue;
+            }
+            if (current == '"' || current == '`') {
+                delimiter = current;
+                normalized.append(current);
+            } else if (!Character.isWhitespace(current)) {
+                normalized.append(current);
+            }
+        }
+        return normalized.toString();
     }
 
     /**

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/SemanticDiffComputer.java
@@ -240,10 +240,8 @@ public class SemanticDiffComputer {
             }
 
             // TODO: Need to use the semantic types and compare the types
-            LineRange lineRange = modifiedTypeDef.lineRange();
-            SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, NodeKind.TYPE_DEFINITION,
-                    resolveUri(lineRange.fileName()), lineRange, buildTypeMetadata(typeDefName));
-            this.semanticDiffs.add(diff);
+            addModificationDiff(NodeKind.TYPE_DEFINITION, modifiedTypeDef.lineRange(),
+                    originalTypeDef.lineRange(), buildTypeMetadata(typeDefName));
         }
 
         // Handle newly added type definitions in modified project
@@ -307,16 +305,14 @@ public class SemanticDiffComputer {
                                        NodeKind kind, Map<String, String> metadata) {
 
         if (!functionHeaderKey(originalFunction).equals(functionHeaderKey(modifiedFunction))) {
-            LineRange lineRange = modifiedFunction.lineRange();
-            SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
-                    resolveUri(lineRange.fileName()), lineRange, metadata);
-            this.semanticDiffs.add(diff);
+            addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
             return;
         }
 
         FunctionBodyNode originalFunctionBody = originalFunction.functionBody();
         FunctionBodyNode modifiedFunctionBody = modifiedFunction.functionBody();
-        compareFunctionBodies(modifiedFunction, originalFunctionBody, modifiedFunctionBody, kind, metadata);
+        compareFunctionBodies(originalFunction, modifiedFunction, originalFunctionBody, modifiedFunctionBody,
+                kind, metadata);
     }
 
     /**
@@ -365,13 +361,15 @@ public class SemanticDiffComputer {
      * Compares the bodies of two functions to identify modifications and update
      * semantic diffs accordingly.
      *
+     * @param originalFunction     original function node
      * @param modifiedFunction     modified function node
      * @param originalFunctionBody original function body node
      * @param modifiedFunctionBody modified function body node
      * @param kind                 the kind of node being compared
      * @param metadata             metadata about the function being compared
      */
-    private void compareFunctionBodies(NonTerminalNode modifiedFunction,
+    private void compareFunctionBodies(NonTerminalNode originalFunction,
+                                       NonTerminalNode modifiedFunction,
                                        FunctionBodyNode originalFunctionBody,
                                        FunctionBodyNode modifiedFunctionBody,
                                        NodeKind kind, Map<String, String> metadata) {
@@ -382,28 +380,20 @@ public class SemanticDiffComputer {
 
         if (originalFunctionBody instanceof ExpressionFunctionBodyNode &&
                 modifiedFunctionBody instanceof ExpressionFunctionBodyNode) {
-            LineRange lineRange = modifiedFunction.lineRange();
-            SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, NodeKind.DATA_MAPPING_FUNCTION,
-                    resolveUri(lineRange.fileName()), lineRange, metadata);
-            this.semanticDiffs.add(diff);
+            addModificationDiff(NodeKind.DATA_MAPPING_FUNCTION, modifiedFunction.lineRange(),
+                    originalFunction.lineRange(), metadata);
             return;
         }
 
         if (!originalFunctionBody.getClass().equals(modifiedFunctionBody.getClass())) {
-            LineRange lineRange = modifiedFunction.lineRange();
-            SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
-                    resolveUri(lineRange.fileName()), lineRange, metadata);
-            this.semanticDiffs.add(diff);
+            addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
             return;
         }
 
         if (originalFunctionBody instanceof FunctionBodyBlockNode originalBodyNode
                 && modifiedFunctionBody instanceof FunctionBodyBlockNode modifiedBodyNode) {
             if (originalBodyNode.statements().size() != modifiedBodyNode.statements().size()) {
-                LineRange lineRange = modifiedFunction.lineRange();
-                SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
-                        resolveUri(lineRange.fileName()), lineRange, metadata);
-                this.semanticDiffs.add(diff);
+                addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
                 return;
             }
 
@@ -421,10 +411,7 @@ public class SemanticDiffComputer {
                 extractStatementNodes(modifiedStmtNode, allModifiedStmtNodes);
 
                 if (allOriginalStmtNodes.size() != allModifiedStmtNodes.size()) {
-                    LineRange lineRange = modifiedFunction.lineRange();
-                    SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
-                            resolveUri(lineRange.fileName()), lineRange, metadata);
-                    this.semanticDiffs.add(diff);
+                    addModificationDiff(kind, modifiedFunction.lineRange(), originalFunction.lineRange(), metadata);
                     return;
                 }
 
@@ -433,22 +420,28 @@ public class SemanticDiffComputer {
                     Node modifiedNode = allModifiedStmtNodes.get(j);
                     // need to change whether both nodes have the same type
                     if (!originalNode.getClass().equals(modifiedNode.getClass())) {
-                        LineRange lineRange = modifiedNode.lineRange();
-                        SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
-                                resolveUri(lineRange.fileName()), lineRange, metadata);
-                        this.semanticDiffs.add(diff);
+                        addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
                         return;
                     }
                     if (!originalNode.toSourceCode().trim().equals(modifiedNode.toSourceCode().trim())) {
-                        LineRange lineRange = modifiedNode.lineRange();
-                        SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
-                                resolveUri(lineRange.fileName()), lineRange, metadata);
-                        this.semanticDiffs.add(diff);
+                        addModificationDiff(kind, modifiedNode.lineRange(), originalNode.lineRange(), metadata);
                         return;
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Adds a modification while retaining its original location.
+     * The review UI needs both locations because file:// resolves the original tree while ai:// resolves
+     * the modified tree.
+     */
+    private void addModificationDiff(NodeKind kind, LineRange modifiedLineRange, LineRange originalLineRange,
+                                     Map<String, String> metadata) {
+        SemanticDiff diff = new SemanticDiff(ChangeType.MODIFICATION, kind,
+                resolveUri(modifiedLineRange.fileName()), modifiedLineRange, originalLineRange, metadata);
+        this.semanticDiffs.add(diff);
     }
 
     private void extractStatementNodes(Node statementNode, List<Node> nodes) {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/SemanticDiff.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/copilotagent/core/models/SemanticDiff.java
@@ -29,10 +29,16 @@ import java.util.Map;
  * @param nodeKind node kind
  * @param uri file URI
  * @param lineRange line range of the change
+ * @param previousLineRange corresponding line range in the original source for modifications
  * @param metadata additional metadata about the changed node
  *
  * @since 1.5.0
  */
 public record SemanticDiff(ChangeType changeType, NodeKind nodeKind, String uri, LineRange lineRange,
-                           Map<String, String> metadata) {
+                           LineRange previousLineRange, Map<String, String> metadata) {
+
+    public SemanticDiff(ChangeType changeType, NodeKind nodeKind, String uri, LineRange lineRange,
+                        Map<String, String> metadata) {
+        this(changeType, nodeKind, uri, lineRange, null, metadata);
+    }
 }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config1.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config1.json
@@ -61,6 +61,17 @@
             "offset": 5
           }
         },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 13,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 19,
+            "offset": 5
+          }
+        },
         "metadata": {
           "accessor": "post",
           "servicePath": "/api/v1/petsstore",
@@ -100,6 +111,17 @@
           },
           "endLine": {
             "line": 46,
+            "offset": 5
+          }
+        },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 5,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 11,
             "offset": 5
           }
         },

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config12.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config12.json
@@ -19,6 +19,17 @@
             "offset": 1
           }
         },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 0,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 1
+          }
+        },
         "metadata": {
           "name": "greet"
         }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config12.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config12.json
@@ -1,0 +1,28 @@
+{
+  "description": "Get diff for a function signature-only change",
+  "projectPath": "function_signature_change",
+  "output": {
+    "loadDesignDiagrams": false,
+    "semanticDiffs": [
+      {
+        "changeType": "MODIFICATION",
+        "nodeKind": "MODULE_FUNCTION",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 0,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 2,
+            "offset": 1
+          }
+        },
+        "metadata": {
+          "name": "greet"
+        }
+      }
+    ]
+  }
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config2.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config2.json
@@ -6,6 +6,27 @@
     "semanticDiffs": [
       {
         "changeType": "MODIFICATION",
+        "nodeKind": "OBJECT_FUNCTION",
+        "uri": "ai:///main.bal",
+        "lineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 5,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 11,
+            "offset": 5
+          }
+        },
+        "metadata": {
+          "accessor": "post",
+          "servicePath": "/api",
+          "resourcePath": "patients"
+        }
+      },
+      {
+        "changeType": "MODIFICATION",
         "nodeKind": "TYPE_DEFINITION",
         "uri": "ai:///types.bal",
         "lineRange": {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config2.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config2.json
@@ -19,6 +19,17 @@
             "offset": 5
           }
         },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 5,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 11,
+            "offset": 5
+          }
+        },
         "metadata": {
           "accessor": "post",
           "servicePath": "/api",
@@ -37,6 +48,17 @@
           },
           "endLine": {
             "line": 25,
+            "offset": 3
+          }
+        },
+        "previousLineRange": {
+          "fileName": "types.bal",
+          "startLine": {
+            "line": 20,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 24,
             "offset": 3
           }
         },

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config3.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config3.json
@@ -76,6 +76,17 @@
             "offset": 1
           }
         },
+        "previousLineRange": {
+          "fileName": "functions.bal",
+          "startLine": {
+            "line": 12,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 17,
+            "offset": 1
+          }
+        },
         "metadata": {
           "name": "divide"
         }
@@ -95,6 +106,17 @@
             "offset": 5
           }
         },
+        "previousLineRange": {
+          "fileName": "functions.bal",
+          "startLine": {
+            "line": 33,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 35,
+            "offset": 5
+          }
+        },
         "metadata": {
           "name": "power"
         }
@@ -111,6 +133,17 @@
           },
           "endLine": {
             "line": 8,
+            "offset": 1
+          }
+        },
+        "previousLineRange": {
+          "fileName": "functions.bal",
+          "startLine": {
+            "line": 8,
+            "offset": 0
+          },
+          "endLine": {
+            "line": 10,
             "offset": 1
           }
         },

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config3.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config3.json
@@ -106,12 +106,12 @@
         "lineRange": {
           "fileName": "functions.bal",
           "startLine": {
-            "line": 7,
-            "offset": 4
+            "line": 6,
+            "offset": 0
           },
           "endLine": {
-            "line": 7,
-            "offset": 32
+            "line": 8,
+            "offset": 1
           }
         },
         "metadata": {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config4.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config4.json
@@ -103,6 +103,17 @@
             "offset": 5
           }
         },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 9,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 11,
+            "offset": 5
+          }
+        },
         "metadata": {
           "accessor": "get",
           "servicePath": "/api",
@@ -145,6 +156,17 @@
             "offset": 5
           }
         },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 33,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 35,
+            "offset": 5
+          }
+        },
         "metadata": {
           "accessor": "get",
           "servicePath": "/api",
@@ -163,6 +185,17 @@
           },
           "endLine": {
             "line": 8,
+            "offset": 5
+          }
+        },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 5,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 7,
             "offset": 5
           }
         },

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config8.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config8.json
@@ -19,6 +19,17 @@
             "offset": 5
           }
         },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 5,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 7,
+            "offset": 5
+          }
+        },
         "metadata": {
           "accessor": "get",
           "servicePath": "/api",

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config9.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/config/config9.json
@@ -19,6 +19,17 @@
             "offset": 5
           }
         },
+        "previousLineRange": {
+          "fileName": "main.bal",
+          "startLine": {
+            "line": 7,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 10,
+            "offset": 5
+          }
+        },
         "metadata": {
           "accessor": "get",
           "servicePath": "/api",

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/source/function_signature_change/modified/Ballerina.toml
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/source/function_signature_change/modified/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "wso2"
+name = "function_signature_change"
+version = "0.1.0"
+
+[build-options]
+sticky = true

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/source/function_signature_change/modified/main.bal
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/source/function_signature_change/modified/main.bal
@@ -1,0 +1,3 @@
+function greet(string name, boolean excited = false) returns string {
+    return "Hello " + name;
+}

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/source/function_signature_change/original/Ballerina.toml
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/source/function_signature_change/original/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "wso2"
+name = "function_signature_change"
+version = "0.1.0"
+
+[build-options]
+sticky = true

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/source/function_signature_change/original/main.bal
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_semantic_diff/source/function_signature_change/original/main.bal
@@ -1,0 +1,3 @@
+function greet(string name) returns string {
+    return "Hello " + name;
+}

--- a/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -76,6 +76,7 @@ import {
     getAIMachineSnapshot,
     getActiveTempDir,
     getChatMessages,
+    hasPendingReview,
     getCheckpoints,
     getDefaultPrompt,
     isScaffoldEnvActive,
@@ -337,6 +338,10 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     getActiveTempDir(): Promise<string> {
         return this._messenger.sendRequest(getActiveTempDir, HOST_EXTENSION);
+    }
+
+    hasPendingReview(): Promise<boolean> {
+        return this._messenger.sendRequest(hasPendingReview, HOST_EXTENSION);
     }
 
     getUsage(): Promise<UsageResponse | undefined> {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -597,6 +597,17 @@ const AIChat: React.FC = () => {
                 console.error('[AIChat] Failed to load initial chat history:', error);
                 // Continue with empty messages - don't block the UI
             }
+            // Re-derive the review flag: it is otherwise only set by the live stream
+            // event, so a webview reload would leave a pending review inactive
+            // (ReviewBar unclickable, auto-accept-on-send skipped).
+            try {
+                const pending = await rpcClient.getAiPanelRpcClient().hasPendingReview();
+                if (pending) {
+                    setHasActiveReview(true);
+                }
+            } catch (error) {
+                console.error('[AIChat] Failed to check pending review state:', error);
+            }
         };
 
         loadHistory();

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { ChangeTypeEnum, Flow, NodePosition, ParentMetadata } from "@wso2/ballerina-core";
+import { ChangeTypeEnum, Flow, NodePosition, ParentMetadata, SemanticDiff } from "@wso2/ballerina-core";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
@@ -35,6 +35,14 @@ const Container = styled.div`
     pointer-events: auto;
 `;
 
+const MessageContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    color: var(--vscode-descriptionForeground);
+`;
+
 interface ItemMetadata {
     type: string;
     name: string;
@@ -42,6 +50,10 @@ interface ItemMetadata {
 }
 
 export type ReviewViewMode = "diff" | "new" | "old";
+export type ExpectedFlowMetadata = Pick<SemanticDiff, "nodeKind" | "metadata">;
+
+const NODE_KIND_FUNCTION = 0;
+const NODE_KIND_RESOURCE = 1;
 
 /**
  * Which versions of a file structurally exist for a semantic-diff change type.
@@ -66,6 +78,7 @@ interface ReadonlyFlowDiagramProps {
     onModelLoaded?: (metadata: ItemMetadata) => void;
     viewMode: ReviewViewMode;
     changeType: number;
+    expectedMetadata?: ExpectedFlowMetadata;
     onDiffUnavailable?: () => void;
 }
 
@@ -74,31 +87,80 @@ function getEventStartData(flow: Flow): ParentMetadata | undefined {
     return eventStartNode?.metadata?.data as ParentMetadata | undefined;
 }
 
-// The old-version lookup reuses the new version's position, so line shifts in the old file
-// can land on a different function. Reject the pair when the resolved functions differ.
-function isSameFunction(oldFlow: Flow, newFlow: Flow): boolean {
+function normalizeResourcePath(path?: string): string {
+    const normalized = (path ?? "").trim().replace(/\s+/g, "");
+    return normalized === "/" || normalized.startsWith("/") ? normalized : `/${normalized}`;
+}
+
+function metadataMatchesExpected(flow: Flow, expected?: ExpectedFlowMetadata): boolean {
+    if (!expected?.metadata) {
+        return true;
+    }
+
+    const data = getEventStartData(flow);
+    if (!data) {
+        return false;
+    }
+
+    if (expected.nodeKind === NODE_KIND_RESOURCE) {
+        const metadata = expected.metadata as { accessor?: string; resourcePath?: string };
+        if (!metadata.accessor || !metadata.resourcePath) {
+            return true;
+        }
+        return data.isServiceFunction === true
+            && (data.accessor ?? "").toLowerCase() === (metadata.accessor ?? "").toLowerCase()
+            && normalizeResourcePath(data.label) === normalizeResourcePath(metadata.resourcePath);
+    }
+
+    if (expected.nodeKind === NODE_KIND_FUNCTION) {
+        const metadata = expected.metadata as { name?: string };
+        if (!metadata.name) {
+            return true;
+        }
+        return data.isServiceFunction !== true && data.label === metadata.name;
+    }
+
+    return true;
+}
+
+// The old-version lookup can reuse a modified-tree position. Reject the pair
+// when either side resolves to a different semantic item.
+function isSameExpectedFunction(oldFlow: Flow, newFlow: Flow, expected?: ExpectedFlowMetadata): boolean {
+    if (!metadataMatchesExpected(oldFlow, expected) || !metadataMatchesExpected(newFlow, expected)) {
+        return false;
+    }
+
     const oldData = getEventStartData(oldFlow);
     const newData = getEventStartData(newFlow);
     if (!oldData || !newData) {
-        return true; // cannot verify; let the merge proceed
+        return false;
     }
+
     return oldData.label === newData.label && oldData.accessor === newData.accessor;
 }
 
 export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Element {
-    const { filePath, position, onModelLoaded, viewMode, changeType, onDiffUnavailable } = props;
+    const { filePath, position, onModelLoaded, viewMode, changeType, expectedMetadata, onDiffUnavailable } = props;
     const { rpcClient } = useRpcContext();
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [unavailableMessage, setUnavailableMessage] = useState<string | null>(null);
     // Review content is frozen while the review is open, so fetched versions are cached
     // per view — toggling Diff/New/Old re-derives locally instead of re-querying the LS.
     const flowCache = useRef<{ key: string; versions: Map<boolean, Flow | null> }>({ key: "", versions: new Map() });
 
     useEffect(() => {
+        setIsLoading(true);
         setFlowModel(null);
+        setUnavailableMessage(null);
         let cancelled = false;
         loadFlowModel()
             .then((model) => {
-                if (cancelled || !model) {
+                if (cancelled) {
+                    return;
+                }
+                if (!model) {
+                    setUnavailableMessage("This diagram is unavailable for the selected version.");
                     return;
                 }
                 setFlowModel(model);
@@ -115,11 +177,19 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             })
             .catch((error) => {
                 console.error("[Reviewing Changes] Error loading flow model:", error);
+                if (!cancelled) {
+                    setUnavailableMessage("This diagram could not be loaded.");
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setIsLoading(false);
+                }
             });
         return () => {
             cancelled = true;
         };
-    }, [filePath, position, viewMode]);
+    }, [filePath, position, viewMode, expectedMetadata]);
 
     // Fetch one version of the enclosing function's flow model.
     // useFileSchema=true reads the frozen original (file://); false reads the modified temp content (ai://).
@@ -159,10 +229,19 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
 
     const loadFlowModel = async (): Promise<Flow | null> => {
         if (viewMode === "old") {
-            return fetchFlowModelVersion(true);
+            const oldFlow = await fetchFlowModelVersion(true);
+            if (oldFlow && !metadataMatchesExpected(oldFlow, expectedMetadata)) {
+                onDiffUnavailable?.();
+                return null;
+            }
+            return oldFlow;
         }
         if (viewMode === "new") {
-            return fetchFlowModelVersion(false);
+            const newFlow = await fetchFlowModelVersion(false);
+            if (newFlow && !metadataMatchesExpected(newFlow, expectedMetadata)) {
+                return null;
+            }
+            return newFlow;
         }
 
         // unified diff mode
@@ -177,20 +256,24 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         }
 
         // modification: merge old and new into a single diagram
-        const [oldFlow, newFlow] = await Promise.all([
-            fetchFlowModelVersion(true).catch((error): Flow | null => {
-                console.error("[Reviewing Changes] Error fetching old flow model:", error);
-                return null;
-            }),
-            fetchFlowModelVersion(false),
-        ]);
+        const newFlow = await fetchFlowModelVersion(false);
         if (!newFlow) {
-            return oldFlow;
+            return null;
         }
-        if (!oldFlow || !isSameFunction(oldFlow, newFlow)) {
+        if (!metadataMatchesExpected(newFlow, expectedMetadata)) {
             onDiffUnavailable?.();
             return newFlow;
         }
+
+        const oldFlow = await fetchFlowModelVersion(true).catch((error): Flow | null => {
+            console.error("[Reviewing Changes] Error fetching old flow model:", error);
+            return null;
+        });
+        if (!oldFlow || !isSameExpectedFunction(oldFlow, newFlow, expectedMetadata)) {
+            onDiffUnavailable?.();
+            return newFlow;
+        }
+
         try {
             return mergeFlowModelsForDiff(oldFlow, newFlow);
         } catch (error) {
@@ -200,12 +283,16 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         }
     };
 
-    if (!flowModel) {
+    if (isLoading) {
         return (
             <SpinnerContainer>
                 <ProgressRing color={ThemeColors.PRIMARY} />
             </SpinnerContainer>
         );
+    }
+
+    if (!flowModel) {
+        return <MessageContainer>{unavailableMessage ?? "This diagram is unavailable."}</MessageContainer>;
     }
 
     return (

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -22,6 +22,7 @@ import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
 import { Diagram, mergeFlowModelsForDiff, stampDiffState } from "@wso2/bi-diagram";
+import { getFlowLookupPosition } from "./position-utils";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -75,6 +76,7 @@ interface ReadonlyFlowDiagramProps {
     projectPath: string;
     filePath: string;
     position: NodePosition;
+    oldPosition?: NodePosition;
     onModelLoaded?: (metadata: ItemMetadata) => void;
     viewMode: ReviewViewMode;
     changeType: number;
@@ -140,7 +142,16 @@ function isSameExpectedFunction(oldFlow: Flow, newFlow: Flow, expected?: Expecte
 }
 
 export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Element {
-    const { filePath, position, onModelLoaded, viewMode, changeType, expectedMetadata, onDiffUnavailable } = props;
+    const {
+        filePath,
+        position,
+        oldPosition,
+        onModelLoaded,
+        viewMode,
+        changeType,
+        expectedMetadata,
+        onDiffUnavailable,
+    } = props;
     const { rpcClient } = useRpcContext();
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -196,12 +207,15 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         return () => {
             cancelled = true;
         };
-    }, [filePath, position, viewMode, expectedMetadata, changeType, rpcClient]);
+    }, [filePath, position, oldPosition, viewMode, expectedMetadata, changeType, rpcClient]);
 
     // Fetch one version of the enclosing function's flow model.
     // useFileSchema=true reads the frozen original (file://); false reads the modified temp content (ai://).
     const fetchFlowModelVersion = async (useFileSchema: boolean): Promise<Flow | null> => {
-        const cacheKey = `${filePath}:${position.startLine}:${position.startColumn}:${position.endLine}:${position.endColumn}`;
+        const lookupPosition = getFlowLookupPosition(position, oldPosition, useFileSchema);
+        const cacheKey = `${filePath}:${position.startLine}:${position.startColumn}:${position.endLine}:` +
+            `${position.endColumn}:${oldPosition?.startLine ?? ""}:${oldPosition?.startColumn ?? ""}:` +
+            `${oldPosition?.endLine ?? ""}:${oldPosition?.endColumn ?? ""}`;
         if (flowCache.current.key !== cacheKey) {
             flowCache.current = { key: cacheKey, versions: new Map() };
         }
@@ -215,11 +229,17 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         // since the position from semantic diff may only cover the changed statement
         const enclosedFn = await rpcClient.getBIDiagramRpcClient().getEnclosedFunction({
             filePath: filePath,
-            position: { line: position.startLine, offset: position.startColumn },
+            position: { line: lookupPosition.startLine, offset: lookupPosition.startColumn },
             useFileSchema,
         });
-        const startLine = enclosedFn?.startLine ?? { line: position.startLine, offset: position.startColumn };
-        const endLine = enclosedFn?.endLine ?? { line: position.endLine, offset: position.endColumn };
+        const startLine = enclosedFn?.startLine ?? {
+            line: lookupPosition.startLine,
+            offset: lookupPosition.startColumn,
+        };
+        const endLine = enclosedFn?.endLine ?? {
+            line: lookupPosition.endLine,
+            offset: lookupPosition.endColumn,
+        };
 
         const response = await rpcClient.getBIDiagramRpcClient().getFlowModel({
             filePath: filePath,

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -145,6 +145,13 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [unavailableMessage, setUnavailableMessage] = useState<string | null>(null);
+    // Latest callbacks held in refs so the load effect can call them without listing them
+    // as dependencies — the parent re-creates onModelLoaded on every render, which would
+    // otherwise retrigger a full refetch each render.
+    const onModelLoadedRef = useRef(onModelLoaded);
+    const onDiffUnavailableRef = useRef(onDiffUnavailable);
+    onModelLoadedRef.current = onModelLoaded;
+    onDiffUnavailableRef.current = onDiffUnavailable;
     // Review content is frozen while the review is open, so fetched versions are cached
     // per view — toggling Diff/New/Old re-derives locally instead of re-querying the LS.
     const flowCache = useRef<{ key: string; versions: Map<boolean, Flow | null> }>({ key: "", versions: new Map() });
@@ -167,8 +174,8 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
 
                 // Extract metadata from EVENT_START node
                 const data = getEventStartData(model);
-                if (onModelLoaded && data) {
-                    onModelLoaded({
+                if (data) {
+                    onModelLoadedRef.current?.({
                         type: (data as any).kind || "Function",
                         name: data.label || "Unknown",
                         accessor: data.accessor,
@@ -189,7 +196,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         return () => {
             cancelled = true;
         };
-    }, [filePath, position, viewMode, expectedMetadata]);
+    }, [filePath, position, viewMode, expectedMetadata, changeType, rpcClient]);
 
     // Fetch one version of the enclosing function's flow model.
     // useFileSchema=true reads the frozen original (file://); false reads the modified temp content (ai://).
@@ -231,7 +238,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         if (viewMode === "old") {
             const oldFlow = await fetchFlowModelVersion(true);
             if (oldFlow && !metadataMatchesExpected(oldFlow, expectedMetadata)) {
-                onDiffUnavailable?.();
+                onDiffUnavailableRef.current?.();
                 return null;
             }
             return oldFlow;
@@ -239,6 +246,9 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         if (viewMode === "new") {
             const newFlow = await fetchFlowModelVersion(false);
             if (newFlow && !metadataMatchesExpected(newFlow, expectedMetadata)) {
+                // Match the "old" branch: disable the diff toggle up front instead of
+                // waiting for the user to click Diff and discover it later.
+                onDiffUnavailableRef.current?.();
                 return null;
             }
             return newFlow;
@@ -261,7 +271,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             return null;
         }
         if (!metadataMatchesExpected(newFlow, expectedMetadata)) {
-            onDiffUnavailable?.();
+            onDiffUnavailableRef.current?.();
             return newFlow;
         }
 
@@ -270,7 +280,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             return null;
         });
         if (!oldFlow || !isSameExpectedFunction(oldFlow, newFlow, expectedMetadata)) {
-            onDiffUnavailable?.();
+            onDiffUnavailableRef.current?.();
             return newFlow;
         }
 
@@ -278,7 +288,7 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             return mergeFlowModelsForDiff(oldFlow, newFlow);
         } catch (error) {
             console.error("[Reviewing Changes] Error merging flow models for diff:", error);
-            onDiffUnavailable?.();
+            onDiffUnavailableRef.current?.();
             return newFlow;
         }
     };

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -17,11 +17,11 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { Flow, NodePosition } from "@wso2/ballerina-core";
+import { ChangeTypeEnum, Flow, NodePosition, ParentMetadata } from "@wso2/ballerina-core";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ProgressRing, ThemeColors } from "@wso2/ui-toolkit";
-import { Diagram } from "@wso2/bi-diagram";
+import { Diagram, mergeFlowModelsForDiff, stampDiffState } from "@wso2/bi-diagram";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -41,68 +41,129 @@ interface ItemMetadata {
     accessor?: string;
 }
 
+export type ReviewViewMode = "diff" | "new" | "old";
+
 interface ReadonlyFlowDiagramProps {
     projectPath: string;
     filePath: string;
     position: NodePosition;
     onModelLoaded?: (metadata: ItemMetadata) => void;
-    useFileSchema?: boolean;
+    viewMode: ReviewViewMode;
+    changeType: number;
+    onDiffUnavailable?: () => void;
+}
+
+function getEventStartData(flow: Flow): ParentMetadata | undefined {
+    const eventStartNode = flow?.nodes?.find((node) => node.codedata?.node === "EVENT_START");
+    return eventStartNode?.metadata?.data as ParentMetadata | undefined;
+}
+
+// The old-version lookup reuses the new version's position, so line shifts in the old file
+// can land on a different function. Reject the pair when the resolved functions differ.
+function isSameFunction(oldFlow: Flow, newFlow: Flow): boolean {
+    const oldData = getEventStartData(oldFlow);
+    const newData = getEventStartData(newFlow);
+    if (!oldData || !newData) {
+        return true; // cannot verify; let the merge proceed
+    }
+    return oldData.label === newData.label && oldData.accessor === newData.accessor;
 }
 
 export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Element {
-    const { filePath, position, onModelLoaded, useFileSchema } = props;
+    const { filePath, position, onModelLoaded, viewMode, changeType, onDiffUnavailable } = props;
     const { rpcClient } = useRpcContext();
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
 
     useEffect(() => {
         setFlowModel(null);
-        fetchFlowModel();
-    }, [filePath, position, useFileSchema]);
+        let cancelled = false;
+        loadFlowModel()
+            .then((model) => {
+                if (cancelled || !model) {
+                    return;
+                }
+                setFlowModel(model);
 
-    const fetchFlowModel = () => {
+                // Extract metadata from EVENT_START node
+                const data = getEventStartData(model);
+                if (onModelLoaded && data) {
+                    onModelLoaded({
+                        type: (data as any).kind || "Function",
+                        name: data.label || "Unknown",
+                        accessor: data.accessor,
+                    });
+                }
+            })
+            .catch((error) => {
+                console.error("[Reviewing Changes] Error loading flow model:", error);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [filePath, position, viewMode]);
+
+    // Fetch one version of the enclosing function's flow model.
+    // useFileSchema=true reads the frozen original (file://); false reads the modified temp content (ai://).
+    const fetchFlowModelVersion = async (useFileSchema: boolean): Promise<Flow | null> => {
         // First resolve the full function range using getEnclosedFunction,
         // since the position from semantic diff may only cover the changed statement
-        rpcClient
-            .getBIDiagramRpcClient()
-            .getEnclosedFunction({
-                filePath: filePath,
-                position: { line: position.startLine, offset: position.startColumn },
-                useFileSchema,
-            })
-            .then((enclosedFn) => {
-                const startLine = enclosedFn?.startLine ?? { line: position.startLine, offset: position.startColumn };
-                const endLine = enclosedFn?.endLine ?? { line: position.endLine, offset: position.endColumn };
+        const enclosedFn = await rpcClient.getBIDiagramRpcClient().getEnclosedFunction({
+            filePath: filePath,
+            position: { line: position.startLine, offset: position.startColumn },
+            useFileSchema,
+        });
+        const startLine = enclosedFn?.startLine ?? { line: position.startLine, offset: position.startColumn };
+        const endLine = enclosedFn?.endLine ?? { line: position.endLine, offset: position.endColumn };
 
-                return rpcClient
-                    .getBIDiagramRpcClient()
-                    .getFlowModel({
-                        filePath: filePath,
-                        startLine,
-                        endLine,
-                        useFileSchema,
-                    });
-            })
-            .then((response) => {
-                if (response?.flowModel) {
-                    setFlowModel(response.flowModel);
+        const response = await rpcClient.getBIDiagramRpcClient().getFlowModel({
+            filePath: filePath,
+            startLine,
+            endLine,
+            useFileSchema,
+        });
+        return response?.flowModel ?? null;
+    };
 
-                    // Extract metadata from EVENT_START node
-                    if (onModelLoaded && response.flowModel.nodes) {
-                        const eventStartNode = response.flowModel.nodes.find(
-                            (node: any) => node.codedata?.node === 'EVENT_START'
-                        );
+    const loadFlowModel = async (): Promise<Flow | null> => {
+        if (viewMode === "old") {
+            return fetchFlowModelVersion(true);
+        }
+        if (viewMode === "new") {
+            return fetchFlowModelVersion(false);
+        }
 
-                        if (eventStartNode?.metadata?.data) {
-                            const data = eventStartNode.metadata.data as any;
-                            onModelLoaded({
-                                type: data.kind || 'Function',
-                                name: data.label || 'Unknown',
-                                accessor: data.accessor
-                            });
-                        }
-                    }
-                }
-            });
+        // unified diff mode
+        if (changeType === ChangeTypeEnum.ADDITION) {
+            const newFlow = await fetchFlowModelVersion(false);
+            return newFlow ? stampDiffState(newFlow, "added") : null;
+        }
+        if (changeType === ChangeTypeEnum.DELETION) {
+            const oldFlow = await fetchFlowModelVersion(true);
+            return oldFlow ? stampDiffState(oldFlow, "removed") : null;
+        }
+
+        // modification: merge old and new into a single diagram
+        const [oldFlow, newFlow] = await Promise.all([
+            fetchFlowModelVersion(true).catch((error): Flow | null => {
+                console.error("[Reviewing Changes] Error fetching old flow model:", error);
+                return null;
+            }),
+            fetchFlowModelVersion(false),
+        ]);
+        if (!newFlow) {
+            return oldFlow;
+        }
+        if (!oldFlow || !isSameFunction(oldFlow, newFlow)) {
+            onDiffUnavailable?.();
+            return newFlow;
+        }
+        try {
+            return mergeFlowModelsForDiff(oldFlow, newFlow);
+        } catch (error) {
+            console.error("[Reviewing Changes] Error merging flow models for diff:", error);
+            onDiffUnavailable?.();
+            return newFlow;
+        }
     };
 
     if (!flowModel) {

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ChangeTypeEnum, Flow, NodePosition, ParentMetadata } from "@wso2/ballerina-core";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -42,6 +42,22 @@ interface ItemMetadata {
 }
 
 export type ReviewViewMode = "diff" | "new" | "old";
+
+/**
+ * Which versions of a file structurally exist for a semantic-diff change type.
+ * Single source of truth for the toggle availability (ReviewMode) and the
+ * diff-mode fetch branching below.
+ */
+export function getVersionsForChangeType(changeType: number): { old: boolean; new: boolean } {
+    switch (changeType) {
+        case ChangeTypeEnum.ADDITION:
+            return { old: false, new: true };
+        case ChangeTypeEnum.DELETION:
+            return { old: true, new: false };
+        default:
+            return { old: true, new: true };
+    }
+}
 
 interface ReadonlyFlowDiagramProps {
     projectPath: string;
@@ -73,6 +89,9 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
     const { filePath, position, onModelLoaded, viewMode, changeType, onDiffUnavailable } = props;
     const { rpcClient } = useRpcContext();
     const [flowModel, setFlowModel] = useState<Flow | null>(null);
+    // Review content is frozen while the review is open, so fetched versions are cached
+    // per view — toggling Diff/New/Old re-derives locally instead of re-querying the LS.
+    const flowCache = useRef<{ key: string; versions: Map<boolean, Flow | null> }>({ key: "", versions: new Map() });
 
     useEffect(() => {
         setFlowModel(null);
@@ -105,6 +124,16 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
     // Fetch one version of the enclosing function's flow model.
     // useFileSchema=true reads the frozen original (file://); false reads the modified temp content (ai://).
     const fetchFlowModelVersion = async (useFileSchema: boolean): Promise<Flow | null> => {
+        const cacheKey = `${filePath}:${position.startLine}:${position.startColumn}:${position.endLine}:${position.endColumn}`;
+        if (flowCache.current.key !== cacheKey) {
+            flowCache.current = { key: cacheKey, versions: new Map() };
+        }
+        // capture the entry so a late response can't poison a newer view's cache
+        const cacheEntry = flowCache.current;
+        if (cacheEntry.versions.has(useFileSchema)) {
+            return cacheEntry.versions.get(useFileSchema);
+        }
+
         // First resolve the full function range using getEnclosedFunction,
         // since the position from semantic diff may only cover the changed statement
         const enclosedFn = await rpcClient.getBIDiagramRpcClient().getEnclosedFunction({
@@ -121,7 +150,11 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             endLine,
             useFileSchema,
         });
-        return response?.flowModel ?? null;
+        const flow = response?.flowModel ?? null;
+        if (flowCache.current === cacheEntry) {
+            cacheEntry.versions.set(useFileSchema, flow);
+        }
+        return flow;
     };
 
     const loadFlowModel = async (): Promise<Flow | null> => {
@@ -133,11 +166,12 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
         }
 
         // unified diff mode
-        if (changeType === ChangeTypeEnum.ADDITION) {
+        const versions = getVersionsForChangeType(changeType);
+        if (!versions.old) {
             const newFlow = await fetchFlowModelVersion(false);
             return newFlow ? stampDiffState(newFlow, "added") : null;
         }
-        if (changeType === ChangeTypeEnum.DELETION) {
+        if (!versions.new) {
             const oldFlow = await fetchFlowModelVersion(true);
             return oldFlow ? stampDiffState(oldFlow, "removed") : null;
         }

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -265,8 +265,18 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             return oldFlow ? stampDiffState(oldFlow, "removed") : null;
         }
 
-        // modification: merge old and new into a single diagram
-        const newFlow = await fetchFlowModelVersion(false);
+        // modification: merge old and new into a single diagram.
+        // Fetch both versions concurrently — they're independent LS lookups, so doing
+        // them sequentially doubled the time-to-first-render for diff mode. Results are
+        // cached per version, so the extra fetch on a metadata-mismatch fallback is free
+        // if the user then toggles to New/Old.
+        const [newFlow, oldFlow] = await Promise.all([
+            fetchFlowModelVersion(false),
+            fetchFlowModelVersion(true).catch((error): Flow | null => {
+                console.error("[Reviewing Changes] Error fetching old flow model:", error);
+                return null;
+            }),
+        ]);
         if (!newFlow) {
             return null;
         }
@@ -274,11 +284,6 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             onDiffUnavailableRef.current?.();
             return newFlow;
         }
-
-        const oldFlow = await fetchFlowModelVersion(true).catch((error): Flow | null => {
-            console.error("[Reviewing Changes] Error fetching old flow model:", error);
-            return null;
-        });
         if (!oldFlow || !isSameExpectedFunction(oldFlow, newFlow, expectedMetadata)) {
             onDiffUnavailableRef.current?.();
             return newFlow;

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReviewNavigation.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReviewNavigation.tsx
@@ -116,6 +116,33 @@ const ActionButtons = styled.div`
     min-width: 158px;
 `;
 
+const Legend = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding-left: 12px;
+`;
+
+const LegendItem = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+`;
+
+const LegendSwatch = styled.span<{ color: string }>`
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: ${(props: { color: string }) => props.color};
+`;
+
+const DIFF_REMOVED_LEGEND_COLOR = "var(--vscode-gitDecoration-deletedResourceForeground, #f85149)";
+const DIFF_ADDED_LEGEND_COLOR = "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)";
+
+export type ReviewViewMode = "diff" | "new" | "old";
+
 interface ReviewNavigationProps {
     currentIndex: number;
     totalViews: number;
@@ -126,9 +153,9 @@ interface ReviewNavigationProps {
     onReject: () => void;
     canGoPrevious: boolean;
     canGoNext: boolean;
-    showOldVersion: boolean;
-    onToggleVersion: () => void;
-    canToggleVersion: boolean;
+    viewMode: ReviewViewMode;
+    onViewModeChange: (mode: ReviewViewMode) => void;
+    availableModes: Record<ReviewViewMode, boolean>;
 }
 
 export function ReviewNavigation(props: ReviewNavigationProps): JSX.Element {
@@ -142,9 +169,9 @@ export function ReviewNavigation(props: ReviewNavigationProps): JSX.Element {
         onReject,
         canGoPrevious,
         canGoNext,
-        showOldVersion,
-        onToggleVersion,
-        canToggleVersion
+        viewMode,
+        onViewModeChange,
+        availableModes,
     } = props;
 
     const handlePreviousClick = () => {
@@ -199,22 +226,43 @@ export function ReviewNavigation(props: ReviewNavigationProps): JSX.Element {
 
             <VersionToggle>
                 <ToggleSegment
-                    active={!showOldVersion}
-                    disabled={!canToggleVersion}
-                    onClick={() => { if (canToggleVersion && showOldVersion) { onToggleVersion(); } }}
+                    active={viewMode === "diff"}
+                    disabled={!availableModes.diff}
+                    onClick={() => { if (availableModes.diff && viewMode !== "diff") { onViewModeChange("diff"); } }}
+                    title="Show old and new versions in one diagram"
+                >
+                    Diff
+                </ToggleSegment>
+                <ToggleSegment
+                    active={viewMode === "new"}
+                    disabled={!availableModes.new}
+                    onClick={() => { if (availableModes.new && viewMode !== "new") { onViewModeChange("new"); } }}
                     title="Show new version"
                 >
                     New
                 </ToggleSegment>
                 <ToggleSegment
-                    active={showOldVersion}
-                    disabled={!canToggleVersion}
-                    onClick={() => { if (canToggleVersion && !showOldVersion) { onToggleVersion(); } }}
+                    active={viewMode === "old"}
+                    disabled={!availableModes.old}
+                    onClick={() => { if (availableModes.old && viewMode !== "old") { onViewModeChange("old"); } }}
                     title="Show old version"
                 >
                     Old
                 </ToggleSegment>
             </VersionToggle>
+
+            {viewMode === "diff" && (
+                <Legend>
+                    <LegendItem>
+                        <LegendSwatch color={DIFF_REMOVED_LEGEND_COLOR} />
+                        Removed
+                    </LegendItem>
+                    <LegendItem>
+                        <LegendSwatch color={DIFF_ADDED_LEGEND_COLOR} />
+                        Added
+                    </LegendItem>
+                </Legend>
+            )}
 
         </NavigationContainer>
     );

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReviewNavigation.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReviewNavigation.tsx
@@ -19,6 +19,8 @@
 import React from "react";
 import styled from "@emotion/styled";
 import { Button } from "@wso2/ui-toolkit";
+import { DIFF_ADDED_COLOR, DIFF_MODIFIED_COLOR, DIFF_REMOVED_COLOR } from "@wso2/bi-diagram";
+import { ReviewViewMode } from "./ReadonlyFlowDiagram";
 
 const NavigationContainer = styled.div`
     position: fixed;
@@ -138,10 +140,6 @@ const LegendSwatch = styled.span<{ color: string }>`
     background: ${(props: { color: string }) => props.color};
 `;
 
-const DIFF_REMOVED_LEGEND_COLOR = "var(--vscode-gitDecoration-deletedResourceForeground, #f85149)";
-const DIFF_ADDED_LEGEND_COLOR = "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)";
-
-export type ReviewViewMode = "diff" | "new" | "old";
 
 interface ReviewNavigationProps {
     currentIndex: number;
@@ -254,12 +252,16 @@ export function ReviewNavigation(props: ReviewNavigationProps): JSX.Element {
             {viewMode === "diff" && (
                 <Legend>
                     <LegendItem>
-                        <LegendSwatch color={DIFF_REMOVED_LEGEND_COLOR} />
+                        <LegendSwatch color={DIFF_REMOVED_COLOR} />
                         Removed
                     </LegendItem>
                     <LegendItem>
-                        <LegendSwatch color={DIFF_ADDED_LEGEND_COLOR} />
+                        <LegendSwatch color={DIFF_ADDED_COLOR} />
                         Added
+                    </LegendItem>
+                    <LegendItem>
+                        <LegendSwatch color={DIFF_MODIFIED_COLOR} />
+                        Modified
                     </LegendItem>
                 </Legend>
             )}

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useEffect, useState, useCallback, useRef } from "react";
-import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum } from "@wso2/ballerina-core";
+import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum, NodePosition } from "@wso2/ballerina-core";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
@@ -125,12 +125,8 @@ enum DiagramType {
 interface ReviewView {
     type: DiagramType;
     filePath: string;
-    position: {
-        startLine: number;
-        endLine: number;
-        startColumn: number;
-        endColumn: number;
-    };
+    position: NodePosition;
+    oldPosition?: NodePosition;
     projectPath: string;
     label?: string;
     changeType: number;
@@ -198,6 +194,14 @@ function convertToReviewView(diff: SemanticDiff, projectPath: string, packageNam
             startColumn: diff.lineRange.startLine.offset,
             endColumn: diff.lineRange.endLine.offset,
         },
+        oldPosition: diff.previousLineRange
+            ? {
+                  startLine: diff.previousLineRange.startLine.line,
+                  endLine: diff.previousLineRange.endLine.line,
+                  startColumn: diff.previousLineRange.startLine.offset,
+                  endColumn: diff.previousLineRange.endLine.offset,
+              }
+            : undefined,
         projectPath,
         label: changeLabel,
         changeType: diff.changeType,
@@ -475,6 +479,7 @@ export function ReviewMode(): JSX.Element {
                         projectPath={currentView.projectPath || projectPath}
                         filePath={currentView.filePath}
                         position={currentView.position}
+                        oldPosition={currentView.oldPosition}
                         onModelLoaded={handleModelLoaded}
                         viewMode={effectiveViewMode}
                         changeType={currentView.changeType}

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -21,7 +21,7 @@ import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum } from "@wso2/baller
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
-import { ReadonlyFlowDiagram, ReviewViewMode } from "./ReadonlyFlowDiagram";
+import { ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
@@ -427,25 +427,9 @@ export function ReviewMode(): JSX.Element {
         if (!currentView) {
             return { diff: false, new: true, old: false };
         }
-        if (currentView.type !== DiagramType.FLOW) {
-            switch (currentView.changeType) {
-                case ChangeTypeEnum.DELETION:
-                    return { diff: false, new: false, old: true };
-                case ChangeTypeEnum.MODIFICATION:
-                    return { diff: false, new: true, old: true };
-                default:
-                    return { diff: false, new: true, old: false };
-            }
-        }
-        const diffAvailable = !diffUnavailableViews.has(currentIndex);
-        switch (currentView.changeType) {
-            case ChangeTypeEnum.ADDITION:
-                return { diff: diffAvailable, new: true, old: false };
-            case ChangeTypeEnum.DELETION:
-                return { diff: diffAvailable, new: false, old: true };
-            default:
-                return { diff: diffAvailable, new: true, old: true };
-        }
+        const versions = getVersionsForChangeType(currentView.changeType);
+        const diff = currentView.type === DiagramType.FLOW && !diffUnavailableViews.has(currentIndex);
+        return { diff, new: versions.new, old: versions.old };
     };
 
     const availableModes = getAvailableModes();

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -21,7 +21,7 @@ import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum } from "@wso2/baller
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
-import { ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
+import { ExpectedFlowMetadata, ReadonlyFlowDiagram, ReviewViewMode, getVersionsForChangeType } from "./ReadonlyFlowDiagram";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
@@ -134,6 +134,7 @@ interface ReviewView {
     projectPath: string;
     label?: string;
     changeType: number;
+    expectedMetadata?: ExpectedFlowMetadata;
 }
 
 enum NodeKindEnum {
@@ -200,6 +201,10 @@ function convertToReviewView(diff: SemanticDiff, projectPath: string, packageNam
         projectPath,
         label: changeLabel,
         changeType: diff.changeType,
+        expectedMetadata: {
+            nodeKind: diff.nodeKind,
+            metadata: diff.metadata,
+        },
     };
 }
 
@@ -345,6 +350,7 @@ export function ReviewMode(): JSX.Element {
                 pendingIndexRef.current = index;
             } else {
                 setCurrentIndex(index >= 0 && index < viewsLengthRef.current ? index : 0);
+                setCurrentItemMetadata(null);
                 setViewMode("diff");
             }
         });
@@ -472,6 +478,7 @@ export function ReviewMode(): JSX.Element {
                         onModelLoaded={handleModelLoaded}
                         viewMode={effectiveViewMode}
                         changeType={currentView.changeType}
+                        expectedMetadata={currentView.expectedMetadata}
                         onDiffUnavailable={handleDiffUnavailable}
                     />
                 );

--- a/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -21,7 +21,7 @@ import { SemanticDiffResponse, SemanticDiff, ChangeTypeEnum } from "@wso2/baller
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ReadonlyComponentDiagram } from "./ReadonlyComponentDiagram";
-import { ReadonlyFlowDiagram } from "./ReadonlyFlowDiagram";
+import { ReadonlyFlowDiagram, ReviewViewMode } from "./ReadonlyFlowDiagram";
 import { ReadonlyTypeDiagram } from "./ReadonlyTypeDiagram";
 import { ReviewNavigation } from "./ReviewNavigation";
 import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
@@ -234,7 +234,9 @@ export function ReviewMode(): JSX.Element {
     const [isLoading, setIsLoading] = useState(true);
     const [currentItemMetadata, setCurrentItemMetadata] = useState<ItemMetadata | null>(null);
     const [isWorkspace, setIsWorkspace] = useState(false);
-    const [showOldVersion, setShowOldVersion] = useState(false);
+    const [viewMode, setViewMode] = useState<ReviewViewMode>("diff");
+    // View indices where the unified diff could not be built (old version missing/mismatched)
+    const [diffUnavailableViews, setDiffUnavailableViews] = useState<Set<number>>(new Set());
     const pendingIndexRef = useRef<number | null>(null);
     const viewsLengthRef = useRef<number>(0);
 
@@ -343,7 +345,7 @@ export function ReviewMode(): JSX.Element {
                 pendingIndexRef.current = index;
             } else {
                 setCurrentIndex(index >= 0 && index < viewsLengthRef.current ? index : 0);
-                setShowOldVersion(false);
+                setViewMode("diff");
             }
         });
     }, [rpcClient]);
@@ -363,7 +365,7 @@ export function ReviewMode(): JSX.Element {
             const newIndex = currentIndex - 1;
             setCurrentIndex(newIndex);
             setCurrentItemMetadata(null); // Clear metadata when navigating
-            setShowOldVersion(false); // Reset toggle when navigating
+            setViewMode("diff"); // Reset toggle when navigating
         } else {
             console.log("[Reviewing Changes] Already at first view");
         }
@@ -374,11 +376,22 @@ export function ReviewMode(): JSX.Element {
             const newIndex = currentIndex + 1;
             setCurrentIndex(newIndex);
             setCurrentItemMetadata(null); // Clear metadata when navigating
-            setShowOldVersion(false); // Reset toggle when navigating
+            setViewMode("diff"); // Reset toggle when navigating
         } else {
             console.log("[Reviewing Changes] Already at last view");
         }
     };
+
+    const handleDiffUnavailable = useCallback(() => {
+        setDiffUnavailableViews((prev) => {
+            if (prev.has(currentIndex)) {
+                return prev;
+            }
+            const next = new Set(prev);
+            next.add(currentIndex);
+            return next;
+        });
+    }, [currentIndex]);
 
     const handleClose = () => {
         rpcClient.getVisualizerRpcClient().goBack();
@@ -408,6 +421,43 @@ export function ReviewMode(): JSX.Element {
         }
     };
 
+    // Which toggle segments are available for the current view.
+    // Only flow diagrams support the unified diff; type/design diagrams keep old/new behavior.
+    const getAvailableModes = (): Record<ReviewViewMode, boolean> => {
+        if (!currentView) {
+            return { diff: false, new: true, old: false };
+        }
+        if (currentView.type !== DiagramType.FLOW) {
+            switch (currentView.changeType) {
+                case ChangeTypeEnum.DELETION:
+                    return { diff: false, new: false, old: true };
+                case ChangeTypeEnum.MODIFICATION:
+                    return { diff: false, new: true, old: true };
+                default:
+                    return { diff: false, new: true, old: false };
+            }
+        }
+        const diffAvailable = !diffUnavailableViews.has(currentIndex);
+        switch (currentView.changeType) {
+            case ChangeTypeEnum.ADDITION:
+                return { diff: diffAvailable, new: true, old: false };
+            case ChangeTypeEnum.DELETION:
+                return { diff: diffAvailable, new: false, old: true };
+            default:
+                return { diff: diffAvailable, new: true, old: true };
+        }
+    };
+
+    const availableModes = getAvailableModes();
+    // Clamp the selected mode to what the current view supports (diff → new → old)
+    const effectiveViewMode: ReviewViewMode = availableModes[viewMode]
+        ? viewMode
+        : availableModes.diff
+        ? "diff"
+        : availableModes.new
+        ? "new"
+        : "old";
+
     const renderDiagram = () => {
         if (!currentView) {
             return <div>No view to display</div>;
@@ -415,8 +465,6 @@ export function ReviewMode(): JSX.Element {
 
         // Create a unique key for each diagram to force re-mount when switching views
         const diagramKey = `${currentView.type}-${currentIndex}-${currentView.filePath}`;
-
-        const effectiveShowOld = currentView.changeType === ChangeTypeEnum.DELETION ? true : showOldVersion;
 
         switch (currentView.type) {
             case "component":
@@ -427,7 +475,7 @@ export function ReviewMode(): JSX.Element {
                         projectPath={currentView.projectPath || projectPath}
                         filePath={currentView.filePath}
                         position={currentView.position}
-                        useFileSchema={effectiveShowOld}
+                        useFileSchema={effectiveViewMode === "old"}
                     />
                 );
             case "flow":
@@ -438,7 +486,9 @@ export function ReviewMode(): JSX.Element {
                         filePath={currentView.filePath}
                         position={currentView.position}
                         onModelLoaded={handleModelLoaded}
-                        useFileSchema={effectiveShowOld}
+                        viewMode={effectiveViewMode}
+                        changeType={currentView.changeType}
+                        onDiffUnavailable={handleDiffUnavailable}
                     />
                 );
             case "type":
@@ -448,7 +498,7 @@ export function ReviewMode(): JSX.Element {
                         projectPath={currentView.projectPath || projectPath}
                         filePath={currentView.filePath}
                         onModelLoaded={handleModelLoaded}
-                        useFileSchema={effectiveShowOld}
+                        useFileSchema={effectiveViewMode === "old"}
                     />
                 );
             default:
@@ -497,7 +547,6 @@ export function ReviewMode(): JSX.Element {
 
     const canGoPrevious = currentIndex > 0;
     const canGoNext = currentIndex < views.length - 1;
-    const canToggleVersion = currentView?.changeType === ChangeTypeEnum.MODIFICATION;
     const isAutomation = currentItemMetadata?.type === "Function" && currentItemMetadata?.name === "main";
     const isResource = currentItemMetadata?.type === "Resource";
     const isType = currentItemMetadata?.type === "Type";
@@ -574,9 +623,9 @@ export function ReviewMode(): JSX.Element {
                 onReject={handleReject}
                 canGoPrevious={canGoPrevious}
                 canGoNext={canGoNext}
-                showOldVersion={currentView?.changeType === ChangeTypeEnum.DELETION ? true : showOldVersion}
-                onToggleVersion={() => setShowOldVersion((prev) => !prev)}
-                canToggleVersion={canToggleVersion}
+                viewMode={effectiveViewMode}
+                onViewModeChange={setViewMode}
+                availableModes={availableModes}
             />
         </ReviewContainer>
     );

--- a/packages/ballerina-visualizer/src/views/ReviewMode/position-utils.test.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/position-utils.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { NodePosition } from "@wso2/ballerina-core";
+import { getFlowLookupPosition } from "./position-utils";
+
+describe("getFlowLookupPosition", () => {
+    const modifiedPosition: NodePosition = {
+        startLine: 38,
+        startColumn: 4,
+        endLine: 40,
+        endColumn: 5,
+    };
+    const originalPosition: NodePosition = {
+        startLine: 32,
+        startColumn: 4,
+        endLine: 34,
+        endColumn: 5,
+    };
+
+    it("uses the original range for file-schema lookups after earlier edits shift a function", () => {
+        expect(getFlowLookupPosition(modifiedPosition, originalPosition, true)).toBe(originalPosition);
+    });
+
+    it("uses the modified range for ai-schema lookups", () => {
+        expect(getFlowLookupPosition(modifiedPosition, originalPosition, false)).toBe(modifiedPosition);
+    });
+
+    it("falls back to the modified range for older semantic-diff responses", () => {
+        expect(getFlowLookupPosition(modifiedPosition, undefined, true)).toBe(modifiedPosition);
+    });
+});

--- a/packages/ballerina-visualizer/src/views/ReviewMode/position-utils.ts
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/position-utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { NodePosition } from "@wso2/ballerina-core";
+
+/** Selects a position from the same syntax-tree version that the flow-model request reads. */
+export function getFlowLookupPosition(
+    position: NodePosition,
+    oldPosition: NodePosition | undefined,
+    useFileSchema: boolean
+): NodePosition {
+    return useFileSchema && oldPosition ? oldPosition : position;
+}

--- a/packages/bi-diagram/.storybook/preview.js
+++ b/packages/bi-diagram/.storybook/preview.js
@@ -1,3 +1,29 @@
+import "./reviewDiffThemes.css";
+
+const REVIEW_THEME_CLASSES = [
+    "review-theme-light-2026",
+    "review-theme-dark-2026",
+    "review-theme-light-vs",
+    "review-theme-dark-vs",
+    "review-theme-light-modern",
+    "review-theme-dark-modern",
+    "review-theme-hc-light",
+    "review-theme-hc-dark",
+];
+
+const THEME_CLASS_BY_NAME = {
+    Light_Theme: "review-theme-light-vs",
+    Dark_Theme: "review-theme-dark-vs",
+    Light_2026: "review-theme-light-2026",
+    Dark_2026: "review-theme-dark-2026",
+    Light_Visual_Studio: "review-theme-light-vs",
+    Dark_Visual_Studio: "review-theme-dark-vs",
+    Light_Modern: "review-theme-light-modern",
+    Dark_Modern: "review-theme-dark-modern",
+    Light_High_Contrast: "review-theme-hc-light",
+    Dark_High_Contrast: "review-theme-hc-dark",
+};
+
 export const parameters = {
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {
@@ -10,12 +36,23 @@ export const parameters = {
 
 export const decorators = [
     (Story, context) => {
-        if (context.globals.theme === "Dark_Theme") {
-            import("../.storybook/darkTheme.css");
-        } else if (context.globals.theme === "Light_Theme") {
+        const theme = context.globals.theme || "Light_2026";
+        const themeClass = THEME_CLASS_BY_NAME[theme] || THEME_CLASS_BY_NAME.Light_2026;
+        const isLight = themeClass.includes("light");
+        const isHighContrast = themeClass.includes("hc-");
+        const themeKind = isHighContrast ? (isLight ? "4" : "3") : (isLight ? "1" : "2");
+
+        if (isLight) {
             import("../.storybook/lightTheme.css");
+        } else {
+            import("../.storybook/darkTheme.css");
         }
         import("@vscode/codicons/dist/codicon.css");
+
+        document.body.classList.remove("review-diff-theme", ...REVIEW_THEME_CLASSES);
+        document.body.classList.add("review-diff-theme", themeClass);
+        document.documentElement.style.setProperty("--vscode-theme-kind", themeKind);
+
         return <Story />;
     },
 ];
@@ -24,10 +61,19 @@ export const globalTypes = {
     theme: {
         name: "Theme",
         description: "Global theme for components",
-        defaultValue: "Light_Theme",
+        defaultValue: "Light_2026",
         toolbar: {
             icon: "circlehollow",
-            items: ["Light_Theme", "Dark_Theme"],
+            items: [
+                { value: "Light_2026", title: "Light 2026" },
+                { value: "Dark_2026", title: "Dark 2026" },
+                { value: "Light_Visual_Studio", title: "Light (Visual Studio)" },
+                { value: "Dark_Visual_Studio", title: "Dark (Visual Studio)" },
+                { value: "Light_Modern", title: "Light Modern" },
+                { value: "Dark_Modern", title: "Dark Modern" },
+                { value: "Light_High_Contrast", title: "Light High Contrast" },
+                { value: "Dark_High_Contrast", title: "Dark High Contrast" },
+            ],
         },
     },
 };

--- a/packages/bi-diagram/.storybook/reviewDiffThemes.css
+++ b/packages/bi-diagram/.storybook/reviewDiffThemes.css
@@ -1,0 +1,120 @@
+/*
+ * Focused VS Code theme fixtures for the review-diff Storybook POC. Production
+ * webviews receive these variables from VS Code itself; these classes let us
+ * exercise the same token paths without copying entire built-in theme files.
+ */
+body.review-diff-theme {
+    color: var(--vscode-editor-foreground);
+    background: var(--vscode-editor-background);
+    --vscode-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --vscode-contrastBorder: transparent;
+    --vscode-gitDecoration-addedResourceForeground: #2ea043;
+    --vscode-gitDecoration-deletedResourceForeground: #c74e39;
+}
+
+body.review-diff-theme.review-theme-light-2026,
+body.review-diff-theme.review-theme-light-vs,
+body.review-diff-theme.review-theme-light-modern,
+body.review-diff-theme.review-theme-hc-light {
+    --vscode-foreground: #202020;
+    --vscode-descriptionForeground: #606060;
+    --vscode-editor-background: #ffffff;
+    --vscode-editor-foreground: #202020;
+    --vscode-editorWidget-background: #f3f3f3;
+    --vscode-editorWidget-foreground: #202020;
+    --vscode-editorWidget-border: #c8c8c8;
+    --vscode-editorHoverWidget-background: #f3f3f3;
+    --vscode-editorHoverWidget-foreground: #202020;
+    --vscode-editorHoverWidget-border: #c8c8c8;
+    --vscode-editorInfo-foreground: #0063d3;
+    --vscode-gitDecoration-modifiedResourceForeground: #895503;
+    --vscode-diffEditor-insertedTextBackground: rgba(156, 204, 44, 0.25);
+    --vscode-diffEditor-removedTextBackground: rgba(255, 0, 0, 0.2);
+    --vscode-gitDecoration-addedResourceForeground: #2ea043;
+    --vscode-gitDecoration-deletedResourceForeground: #c74e39;
+}
+
+body.review-diff-theme.review-theme-dark-2026,
+body.review-diff-theme.review-theme-dark-vs,
+body.review-diff-theme.review-theme-dark-modern,
+body.review-diff-theme.review-theme-hc-dark {
+    --vscode-foreground: #cccccc;
+    --vscode-descriptionForeground: rgba(204, 204, 204, 0.72);
+    --vscode-editor-background: #1e1e1e;
+    --vscode-editor-foreground: #d4d4d4;
+    --vscode-editorWidget-background: #252526;
+    --vscode-editorWidget-foreground: #cccccc;
+    --vscode-editorWidget-border: #454545;
+    --vscode-editorHoverWidget-background: #252526;
+    --vscode-editorHoverWidget-foreground: #cccccc;
+    --vscode-editorHoverWidget-border: #454545;
+    --vscode-editorInfo-foreground: #59a4f9;
+    --vscode-gitDecoration-modifiedResourceForeground: #e2c08d;
+    --vscode-diffEditor-insertedTextBackground: rgba(156, 204, 44, 0.2);
+    --vscode-diffEditor-removedTextBackground: rgba(255, 0, 0, 0.2);
+    --vscode-gitDecoration-addedResourceForeground: #73c991;
+    --vscode-gitDecoration-deletedResourceForeground: #f48771;
+}
+
+body.review-diff-theme.review-theme-light-2026 {
+    --vscode-editor-foreground: #202020;
+    --vscode-editorWidget-background: #fafafd;
+    --vscode-gitDecoration-modifiedResourceForeground: #667309;
+}
+
+body.review-diff-theme.review-theme-dark-2026 {
+    --vscode-foreground: #bbbebf;
+    --vscode-editor-background: #121314;
+    --vscode-editor-foreground: #bbbebf;
+    --vscode-editorWidget-background: #202122;
+    --vscode-editorWidget-foreground: #bbbebf;
+    --vscode-editorWidget-border: #2a2b2c;
+    --vscode-editorHoverWidget-background: #202122;
+    --vscode-editorHoverWidget-foreground: #bbbebf;
+    --vscode-editorHoverWidget-border: #2a2b2c;
+    --vscode-gitDecoration-modifiedResourceForeground: #e5ba7d;
+    --vscode-diffEditor-insertedTextBackground: rgba(87, 171, 90, 0.3);
+    --vscode-diffEditor-removedTextBackground: rgba(244, 112, 103, 0.3);
+}
+
+body.review-diff-theme.review-theme-light-modern {
+    --vscode-editorWidget-background: #f8f8f8;
+}
+
+body.review-diff-theme.review-theme-dark-modern {
+    --vscode-editor-background: #181818;
+    --vscode-editorWidget-background: #1f1f1f;
+    --vscode-editorHoverWidget-background: #1f1f1f;
+}
+
+body.review-diff-theme.review-theme-hc-light {
+    --vscode-contrastBorder: #0f4a85;
+    --vscode-editor-background: #ffffff;
+    --vscode-editor-foreground: #292929;
+    --vscode-editorWidget-background: #ffffff;
+    --vscode-editorWidget-foreground: #292929;
+    --vscode-editorWidget-border: #0f4a85;
+    --vscode-editorHoverWidget-background: #ffffff;
+    --vscode-editorHoverWidget-foreground: #292929;
+    --vscode-editorHoverWidget-border: #0f4a85;
+    --vscode-diffEditor-insertedTextBackground: transparent;
+    --vscode-diffEditor-removedTextBackground: transparent;
+    --vscode-diffEditor-insertedTextBorder: #374e06;
+    --vscode-diffEditor-removedTextBorder: #ad0707;
+}
+
+body.review-diff-theme.review-theme-hc-dark {
+    --vscode-contrastBorder: #6fc3df;
+    --vscode-editor-background: #000000;
+    --vscode-editor-foreground: #ffffff;
+    --vscode-editorWidget-background: #0c141f;
+    --vscode-editorWidget-foreground: #ffffff;
+    --vscode-editorWidget-border: #6fc3df;
+    --vscode-editorHoverWidget-background: #0c141f;
+    --vscode-editorHoverWidget-foreground: #ffffff;
+    --vscode-editorHoverWidget-border: #6fc3df;
+    --vscode-diffEditor-insertedTextBackground: transparent;
+    --vscode-diffEditor-removedTextBackground: transparent;
+    --vscode-diffEditor-insertedTextBorder: #33ff2e;
+    --vscode-diffEditor-removedTextBorder: #ff008f;
+}

--- a/packages/bi-diagram/src/components/Diagram.tsx
+++ b/packages/bi-diagram/src/components/Diagram.tsx
@@ -132,7 +132,7 @@ export function Diagram(props: DiagramProps) {
     } = props;
 
     const [showErrorFlow, setShowErrorFlow] = useState(false);
-    const [nodeComments, setNodeComments] = useState<Map<string, FlowNode>>(new Map());
+    const [nodeComments, setNodeComments] = useState<Map<string, FlowNode[]>>(new Map());
     const [diagramEngine] = useState<DiagramEngine>(generateEngine());
     const [diagramModel, setDiagramModel] = useState<DiagramModel | null>(null);
     const [showComponentPanel, setShowComponentPanel] = useState(false);

--- a/packages/bi-diagram/src/components/DiagramContext.tsx
+++ b/packages/bi-diagram/src/components/DiagramContext.tsx
@@ -128,7 +128,7 @@ export interface DiagramContextState {
     setLockCanvas?: (lock: boolean) => void;
     isUserAuthenticated?: boolean;
     expressionContext: ExpressionContextProps;
-    nodeComments?: Map<string, FlowNode>;
+    nodeComments?: Map<string, FlowNode[]>;
     entrypointContext?: {
         serviceName?: string;
         functionName?: string;

--- a/packages/bi-diagram/src/components/DiffTooltip/index.tsx
+++ b/packages/bi-diagram/src/components/DiffTooltip/index.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import styled from "@emotion/styled";
+import { Tooltip } from "@wso2/ui-toolkit";
+import { FlowNode } from "../../utils/types";
+import { getDiffDisplaySource } from "../../utils/diff";
+import { DIFF_ADDED_COLOR, DIFF_REMOVED_COLOR } from "../../resources/constants";
+
+const Content = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-width: 360px;
+    font-family: monospace;
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+`;
+
+const OldText = styled.span`
+    color: ${DIFF_REMOVED_COLOR};
+    text-decoration: line-through;
+`;
+
+const NewText = styled.span`
+    color: ${DIFF_ADDED_COLOR};
+`;
+
+interface DiffTooltipProps {
+    node: FlowNode;
+    children: React.ReactNode;
+}
+
+/**
+ * Hover card for nodes marked "modified" by the review-diff merge: the old source
+ * struck through above the new source. Renders children untouched for any other node.
+ */
+export function DiffTooltip({ node, children }: DiffTooltipProps) {
+    if (node?.diffState !== "modified" || !node.diffPreviousText) {
+        return <>{children}</>;
+    }
+    const newText = getDiffDisplaySource(node);
+    return (
+        <Tooltip
+            content={
+                <Content>
+                    <OldText>{node.diffPreviousText}</OldText>
+                    {newText && <NewText>{newText}</NewText>}
+                </Content>
+            }
+            containerSx={{ cursor: "inherit" }}
+        >
+            {children}
+        </Tooltip>
+    );
+}

--- a/packages/bi-diagram/src/components/DiffTooltip/index.tsx
+++ b/packages/bi-diagram/src/components/DiffTooltip/index.tsx
@@ -21,17 +21,53 @@ import styled from "@emotion/styled";
 import { Tooltip } from "@wso2/ui-toolkit";
 import { FlowNode } from "../../utils/types";
 import { getDiffDisplaySource } from "../../utils/diff";
+import { getDiffColors, getDiffStatePresentation } from "../../utils/node";
 import { DIFF_ADDED_COLOR, DIFF_REMOVED_COLOR } from "../../resources/constants";
 
+const DiffNodeContainer = styled.div`
+    position: relative;
+    display: inline-block;
+`;
+
+const DiffStateBadge = styled.span<{ accent: string }>`
+    position: absolute;
+    top: -8px;
+    right: 4px;
+    z-index: 10;
+    display: inline-flex;
+    align-items: center;
+    min-height: 16px;
+    padding: 1px 5px;
+    border: 1px solid ${(props) => props.accent};
+    border-radius: 8px;
+    background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+    color: var(--vscode-editorWidget-foreground, var(--vscode-editor-foreground));
+    box-shadow: 0 0 0 1px var(--vscode-contrastBorder, transparent);
+    font-family: var(--vscode-font-family);
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    pointer-events: none;
+`;
+
 const Content = styled.div`
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
     gap: 4px;
     max-width: 360px;
     font-family: monospace;
     font-size: 12px;
     white-space: pre-wrap;
     word-break: break-word;
+`;
+
+const VersionLabel = styled.span<{ accent: string }>`
+    color: ${(props) => props.accent};
+    font-family: var(--vscode-font-family);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
 `;
 
 const OldText = styled.span`
@@ -49,25 +85,47 @@ interface DiffTooltipProps {
 }
 
 /**
- * Hover card for nodes marked "modified" by the review-diff merge: the old source
- * struck through above the new source. Renders children untouched for any other node.
+ * Adds a visible, accessible state marker to review-diff nodes. Modified nodes
+ * also show their labeled old and new source on hover when both are available.
  */
 export function DiffTooltip({ node, children }: DiffTooltipProps) {
-    if (node?.diffState !== "modified" || !node.diffPreviousText) {
+    const presentation = getDiffStatePresentation(node?.diffState);
+    const colors = getDiffColors(node);
+    if (!presentation || !colors) {
         return <>{children}</>;
     }
+
+    const markedNode = (
+        <DiffNodeContainer role="group" aria-label={`${presentation.label} diagram node`}>
+            {children}
+            <DiffStateBadge accent={colors.border} aria-hidden="true">
+                {presentation.symbol} {presentation.label}
+            </DiffStateBadge>
+        </DiffNodeContainer>
+    );
+
+    if (node.diffState !== "modified" || !node.diffPreviousText) {
+        return markedNode;
+    }
+
     const newText = getDiffDisplaySource(node);
     return (
         <Tooltip
             content={
                 <Content>
+                    <VersionLabel accent={DIFF_REMOVED_COLOR}>Old</VersionLabel>
                     <OldText>{node.diffPreviousText}</OldText>
-                    {newText && <NewText>{newText}</NewText>}
+                    {newText && (
+                        <>
+                            <VersionLabel accent={DIFF_ADDED_COLOR}>New</VersionLabel>
+                            <NewText>{newText}</NewText>
+                        </>
+                    )}
                 </Content>
             }
             containerSx={{ cursor: "inherit" }}
         >
-            {children}
+            {markedNode}
         </Tooltip>
     );
 }

--- a/packages/bi-diagram/src/components/NodeLink/NodeLinkModel.ts
+++ b/packages/bi-diagram/src/components/NodeLink/NodeLinkModel.ts
@@ -18,7 +18,7 @@
 
 import { DefaultLinkModel } from "@projectstorm/react-diagrams";
 import { LINK_COLOR, LINK_HOVERED_COLOR, NODE_GAP_Y, NODE_LINK, NodeTypes } from "../../resources/constants";
-import { Branch, FlowNode, LinePosition, NodeModel } from "../../utils/types";
+import { Branch, FlowNode, FlowNodeDiffState, LinePosition, NodeModel } from "../../utils/types";
 
 export const LINK_BOTTOM_OFFSET = 30;
 
@@ -31,6 +31,7 @@ export interface NodeLinkModelOptions {
     brokenLine?: boolean; // default false
     disabled?: boolean; // default false
     alignBottom?: boolean; // default false
+    diffState?: FlowNodeDiffState; // review diff lane the link belongs to
     linkCounter?: number;
     onAddClick?: () => void;
 }
@@ -49,6 +50,7 @@ export class NodeLinkModel extends DefaultLinkModel {
     brokenLine = false;
     disabled = false;
     alignBottom = false;
+    diffState: FlowNodeDiffState | undefined = undefined;
     linkBottomOffset = LINK_BOTTOM_OFFSET;
     linkCounter?: number;
     onAddClick?: () => void;
@@ -91,6 +93,9 @@ export class NodeLinkModel extends DefaultLinkModel {
                 }
                 if ((options as NodeLinkModelOptions).alignBottom === true) {
                     this.alignBottom = (options as NodeLinkModelOptions).alignBottom;
+                }
+                if ((options as NodeLinkModelOptions).diffState) {
+                    this.diffState = (options as NodeLinkModelOptions).diffState;
                 }
                 if ((options as NodeLinkModelOptions).linkCounter) {
                     this.linkCounter = (options as NodeLinkModelOptions).linkCounter;

--- a/packages/bi-diagram/src/components/NodeLink/NodeLinkWidget.tsx
+++ b/packages/bi-diagram/src/components/NodeLink/NodeLinkWidget.tsx
@@ -27,6 +27,8 @@ import {
     ADD_BUTTON_DISABLED_COLOR,
     ADD_BUTTON_HOVERED_COLOR,
     CANVAS_BG_COLOR,
+    DIFF_ADDED_COLOR,
+    DIFF_REMOVED_COLOR,
     LINK_COLOR,
     LINK_DISABLED_COLOR,
     LINK_HOVERED_COLOR,
@@ -69,7 +71,11 @@ export const NodeLinkWidget: React.FC<NodeLinkWidgetProps> = ({ link, engine }) 
     const showAddButton = link.showAddButton && !link.disabled;
     const shouldHighlight =
         showAddButton && (isHovered || link.showButtonAlways || isCommentBoxOpen);
-    const linkColor = link.disabled
+    const linkColor = link.diffState
+        ? link.diffState === "removed"
+            ? DIFF_REMOVED_COLOR
+            : DIFF_ADDED_COLOR
+        : link.disabled
         ? LINK_DISABLED_COLOR
         : isHovered && !readOnly
         ? LINK_HOVERED_COLOR
@@ -144,7 +150,7 @@ export const NodeLinkWidget: React.FC<NodeLinkWidgetProps> = ({ link, engine }) 
                 fill={"none"}
                 stroke={linkColor}
                 strokeWidth={1.5}
-                strokeDasharray={link.brokenLine ? "5,5" : "0"}
+                strokeDasharray={link.brokenLine || link.diffState === "removed" ? "5,5" : "0"}
                 markerEnd={link.showArrowToNode() ? `url(#${link.getID()}-arrow-head)` : ""}
                 style={{
                     filter: isHovered && !readOnly ? `drop-shadow(0 0 3px ${LINK_HOVERED_COLOR})` : 'none',

--- a/packages/bi-diagram/src/components/NodeNoteChip/index.tsx
+++ b/packages/bi-diagram/src/components/NodeNoteChip/index.tsx
@@ -23,6 +23,7 @@ import { Button, Item, Menu, MenuItem } from "@wso2/ui-toolkit";
 import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { FlowNode } from "../../utils/types";
 import { getCommentText } from "../../utils/diff";
+import { getDiffStatePresentation } from "../../utils/node";
 import { useDiagramContext } from "../DiagramContext";
 import { MoreVertIcon } from "../../resources";
 import {
@@ -96,6 +97,14 @@ const RemovedNoteText = styled(NoteText)`
     text-decoration: line-through;
 `;
 
+const NoteVersionLabel = styled.span<{ accent: string }>`
+    color: ${(props) => props.accent};
+    font-family: var(--vscode-font-family);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+`;
+
 const MenuButton = styled(Button)`
     border-radius: 5px;
     flex-shrink: 0;
@@ -167,22 +176,43 @@ export function NodeNoteChip({ commentNode, engine, onOpen, onClose }: NodeNoteC
     }, [isMenuOpen]);
 
     const commentText = getCommentText(commentNode);
+    const diffTextColor = "var(--vscode-editorWidget-foreground, var(--vscode-editor-foreground))";
 
-    // Review-diff styling: added note green, removed note red, edited note amber.
+    // Review-diff styling combines themed colors with a non-color label and border pattern.
     let chipDiffStyle: React.CSSProperties | undefined;
     let noteTextStyle: React.CSSProperties | undefined;
+    const diffPresentation = getDiffStatePresentation(commentNode.diffState);
     switch (commentNode.diffState) {
         case "removed":
-            chipDiffStyle = { backgroundColor: DIFF_REMOVED_BG_COLOR, color: DIFF_REMOVED_COLOR, textDecoration: "line-through" };
-            noteTextStyle = { color: DIFF_REMOVED_COLOR, textDecoration: "line-through" };
+            chipDiffStyle = {
+                backgroundColor: DIFF_REMOVED_BG_COLOR,
+                borderColor: DIFF_REMOVED_COLOR,
+                borderStyle: diffPresentation?.borderStyle,
+                borderWidth: 1,
+                color: diffTextColor,
+                textDecoration: "line-through",
+            };
+            noteTextStyle = { color: diffTextColor, textDecoration: "line-through" };
             break;
         case "added":
-            chipDiffStyle = { backgroundColor: DIFF_ADDED_BG_COLOR, color: DIFF_ADDED_COLOR };
-            noteTextStyle = { color: DIFF_ADDED_COLOR };
+            chipDiffStyle = {
+                backgroundColor: DIFF_ADDED_BG_COLOR,
+                borderColor: DIFF_ADDED_COLOR,
+                borderStyle: diffPresentation?.borderStyle,
+                borderWidth: 1,
+                color: diffTextColor,
+            };
+            noteTextStyle = { color: diffTextColor };
             break;
         case "modified":
-            chipDiffStyle = { backgroundColor: DIFF_MODIFIED_BG_COLOR, color: DIFF_MODIFIED_COLOR };
-            noteTextStyle = { color: DIFF_MODIFIED_COLOR };
+            chipDiffStyle = {
+                backgroundColor: DIFF_MODIFIED_BG_COLOR,
+                borderColor: DIFF_MODIFIED_COLOR,
+                borderStyle: diffPresentation?.borderStyle,
+                borderWidth: 1,
+                color: diffTextColor,
+            };
+            noteTextStyle = { color: diffTextColor };
             break;
     }
 
@@ -237,11 +267,17 @@ export function NodeNoteChip({ commentNode, engine, onOpen, onClose }: NodeNoteC
 
     return (
         <>
-            <ChipButton style={chipDiffStyle} onClick={handleChipClick}>
+            <ChipButton
+                style={chipDiffStyle}
+                aria-label={diffPresentation ? `${diffPresentation.label} note` : "Note"}
+                onClick={handleChipClick}
+            >
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24">
                     <path d="m6 18l-2.3 2.3q-.475.475-1.088.213T2 19.575V4q0-.825.588-1.412T4 2h16q.825 0 1.413.588T22 4v12q0 .825-.587 1.413T20 18zm-.85-2H20V4H4v13.125zM4 16V4zm3-2h6q.425 0 .713-.288T14 13t-.288-.712T13 12H7q-.425 0-.712.288T6 13t.288.713T7 14m0-3h10q.425 0 .713-.288T18 10t-.288-.712T17 9H7q-.425 0-.712.288T6 10t.288.713T7 11m0-3h10q.425 0 .713-.288T18 7t-.288-.712T17 6H7q-.425 0-.712.288T6 7t.288.713T7 8" />
                 </svg>
-                <ChipLabel>Note</ChipLabel>
+                <ChipLabel>
+                    {diffPresentation ? `${diffPresentation.symbol} ${diffPresentation.label}` : "Note"}
+                </ChipLabel>
             </ChipButton>
 
             {/* Note content popup */}
@@ -261,9 +297,17 @@ export function NodeNoteChip({ commentNode, engine, onOpen, onClose }: NodeNoteC
                     <NotePopoverContent>
                         <NoteTextColumn>
                             {commentNode.diffPreviousText && (
-                                <RemovedNoteText>{commentNode.diffPreviousText}</RemovedNoteText>
+                                <>
+                                    <NoteVersionLabel accent={DIFF_REMOVED_COLOR}>Old</NoteVersionLabel>
+                                    <RemovedNoteText>{commentNode.diffPreviousText}</RemovedNoteText>
+                                    <NoteVersionLabel accent={DIFF_ADDED_COLOR}>New</NoteVersionLabel>
+                                </>
                             )}
-                            <NoteText style={noteTextStyle}>{commentText || "..."}</NoteText>
+                            <NoteText
+                                style={commentNode.diffPreviousText ? { ...noteTextStyle, color: DIFF_ADDED_COLOR } : noteTextStyle}
+                            >
+                                {commentText || "..."}
+                            </NoteText>
                         </NoteTextColumn>
                         {!readOnly && (
                             <MenuButton appearance="icon" onClick={handleMenuOpen}>

--- a/packages/bi-diagram/src/components/NodeNoteChip/index.tsx
+++ b/packages/bi-diagram/src/components/NodeNoteChip/index.tsx
@@ -22,8 +22,17 @@ import styled from "@emotion/styled";
 import { Button, Item, Menu, MenuItem } from "@wso2/ui-toolkit";
 import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { FlowNode } from "../../utils/types";
+import { getCommentText } from "../../utils/diff";
 import { useDiagramContext } from "../DiagramContext";
 import { MoreVertIcon } from "../../resources";
+import {
+    DIFF_ADDED_BG_COLOR,
+    DIFF_ADDED_COLOR,
+    DIFF_MODIFIED_BG_COLOR,
+    DIFF_MODIFIED_COLOR,
+    DIFF_REMOVED_BG_COLOR,
+    DIFF_REMOVED_COLOR,
+} from "../../resources/constants";
 
 const ChipButton = styled.button`
     display: inline-flex;
@@ -65,6 +74,13 @@ const NotePopoverContent = styled.div`
     gap: 6px;
 `;
 
+const NoteTextColumn = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+`;
+
 const NoteText = styled.p`
     font-size: 13px;
     font-family: monospace;
@@ -72,8 +88,12 @@ const NoteText = styled.p`
     white-space: pre-wrap;
     word-break: break-word;
     opacity: 0.85;
-    flex: 1;
     padding-top: 2px;
+`;
+
+const RemovedNoteText = styled(NoteText)`
+    color: ${DIFF_REMOVED_COLOR};
+    text-decoration: line-through;
 `;
 
 const MenuButton = styled(Button)`
@@ -146,10 +166,25 @@ export function NodeNoteChip({ commentNode, engine, onOpen, onClose }: NodeNoteC
         };
     }, [isMenuOpen]);
 
-    const commentText =
-        commentNode.metadata?.description ||
-        (commentNode.properties as any)?.comment?.value ||
-        "";
+    const commentText = getCommentText(commentNode);
+
+    // Review-diff styling: added note green, removed note red, edited note amber.
+    let chipDiffStyle: React.CSSProperties | undefined;
+    let noteTextStyle: React.CSSProperties | undefined;
+    switch (commentNode.diffState) {
+        case "removed":
+            chipDiffStyle = { backgroundColor: DIFF_REMOVED_BG_COLOR, color: DIFF_REMOVED_COLOR, textDecoration: "line-through" };
+            noteTextStyle = { color: DIFF_REMOVED_COLOR, textDecoration: "line-through" };
+            break;
+        case "added":
+            chipDiffStyle = { backgroundColor: DIFF_ADDED_BG_COLOR, color: DIFF_ADDED_COLOR };
+            noteTextStyle = { color: DIFF_ADDED_COLOR };
+            break;
+        case "modified":
+            chipDiffStyle = { backgroundColor: DIFF_MODIFIED_BG_COLOR, color: DIFF_MODIFIED_COLOR };
+            noteTextStyle = { color: DIFF_MODIFIED_COLOR };
+            break;
+    }
 
     const handleChipClick = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.stopPropagation();
@@ -202,7 +237,7 @@ export function NodeNoteChip({ commentNode, engine, onOpen, onClose }: NodeNoteC
 
     return (
         <>
-            <ChipButton onClick={handleChipClick}>
+            <ChipButton style={chipDiffStyle} onClick={handleChipClick}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24">
                     <path d="m6 18l-2.3 2.3q-.475.475-1.088.213T2 19.575V4q0-.825.588-1.412T4 2h16q.825 0 1.413.588T22 4v12q0 .825-.587 1.413T20 18zm-.85-2H20V4H4v13.125zM4 16V4zm3-2h6q.425 0 .713-.288T14 13t-.288-.712T13 12H7q-.425 0-.712.288T6 13t.288.713T7 14m0-3h10q.425 0 .713-.288T18 10t-.288-.712T17 9H7q-.425 0-.712.288T6 10t.288.713T7 11m0-3h10q.425 0 .713-.288T18 7t-.288-.712T17 6H7q-.425 0-.712.288T6 7t.288.713T7 8" />
                 </svg>
@@ -224,7 +259,12 @@ export function NodeNoteChip({ commentNode, engine, onOpen, onClose }: NodeNoteC
                     onMouseDown={(e) => e.stopPropagation()}
                 >
                     <NotePopoverContent>
-                        <NoteText>{commentText || "..."}</NoteText>
+                        <NoteTextColumn>
+                            {commentNode.diffPreviousText && (
+                                <RemovedNoteText>{commentNode.diffPreviousText}</RemovedNoteText>
+                            )}
+                            <NoteText style={noteTextStyle}>{commentText || "..."}</NoteText>
+                        </NoteTextColumn>
                         {!readOnly && (
                             <MenuButton appearance="icon" onClick={handleMenuOpen}>
                                 <MoreVertIcon />

--- a/packages/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeFactory.tsx
@@ -22,6 +22,7 @@ import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { AgentCallNodeModel } from "./AgentCallNodeModel";
 import { AgentCallNodeWidget } from "./AgentCallNodeWidget";
 import { NodeTypes } from "../../../resources/constants";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class AgentCallNodeFactory extends AbstractReactFactory<AgentCallNodeModel, DiagramEngine> {
     constructor() {
@@ -33,6 +34,10 @@ export class AgentCallNodeFactory extends AbstractReactFactory<AgentCallNodeMode
     }
 
     generateReactWidget(event: GenerateWidgetEvent<AgentCallNodeModel>) {
-        return <AgentCallNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <AgentCallNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
@@ -52,7 +52,7 @@ import NodeIcon, { CHART_COLORS, getAIColor, isDarkTheme, ThemeListener } from "
 import ConnectorIcon from "../../ConnectorIcon";
 import { useDiagramContext, useTraceAnimation } from "../../DiagramContext";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { css, keyframes } from "@emotion/react";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeMetadata } from "@wso2/ballerina-core";
@@ -864,6 +864,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                 readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
                 isSelected={isSelected}
+                style={getDiffContainerStyles(model.node)}
                 onMouseEnter={() => setIsBoxHovered(true)}
                 onMouseLeave={() => setIsBoxHovered(false)}
                 onContextMenu={!readOnly ? handleOnContextMenu : undefined}
@@ -907,7 +908,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                         <NodeStyles.Row readOnly={readOnly}>
                             <NodeStyles.Header onClick={handleOnClick}>
                                 <div style={{ display: "flex", alignItems: "center", gap: "6px", lineHeight: 1, maxWidth: `${NODE_WIDTH - 80}px` }}>
-                                    <NodeStyles.Title>{nodeTitle}</NodeStyles.Title>
+                                    <NodeStyles.Title style={getDiffTitleStyles(model.node)}>{nodeTitle}</NodeStyles.Title>
                                     {model.node.properties?.credential?.value && (
                                         <NodeStyles.AgentIdBadge
                                             title=""

--- a/packages/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeFactory.tsx
@@ -23,6 +23,7 @@ import { ApiCallNodeModel } from "./ApiCallNodeModel";
 import { ApiCallNodeWidget } from "./ApiCallNodeWidget";
 import { NodeTypes } from "../../../resources/constants";
 import { NodeKind } from "../../../utils/types";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class ApiCallNodeFactory extends AbstractReactFactory<ApiCallNodeModel, DiagramEngine> {
     constructor() {
@@ -34,6 +35,10 @@ export class ApiCallNodeFactory extends AbstractReactFactory<ApiCallNodeModel, D
     }
 
     generateReactWidget(event: GenerateWidgetEvent<ApiCallNodeModel>) {
-        return <ApiCallNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <ApiCallNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
@@ -46,7 +46,7 @@ import NodeIcon from "../../NodeIcon";
 import ConnectorIcon from "../../ConnectorIcon";
 import { useDiagramContext } from "../../DiagramContext";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { getNodeTitle, nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, getNodeTitle, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeMetadata } from "@wso2/ballerina-core";
 
@@ -372,6 +372,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                 readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
                 isSelected={isSelected}
+                style={getDiffContainerStyles(model.node)}
                 onMouseEnter={() => setIsBoxHovered(true)}
                 onMouseLeave={() => setIsBoxHovered(false)}
                 onContextMenu={!readOnly ? handleOnContextMenu : undefined}
@@ -401,7 +402,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                     </NodeStyles.Icon>
                     <NodeStyles.Row>
                         <NodeStyles.Header onClick={handleOnClick}>
-                            <NodeStyles.Title>{nodeTitle}</NodeStyles.Title>
+                            <NodeStyles.Title style={getDiffTitleStyles(model.node)}>{nodeTitle}</NodeStyles.Title>
                             <NodeStyles.Description>
                                 {model.node.properties.variable?.value as ReactNode}
                             </NodeStyles.Description>

--- a/packages/bi-diagram/src/components/nodes/BaseNode/BaseNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/BaseNode/BaseNodeFactory.tsx
@@ -22,6 +22,7 @@ import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { BaseNodeModel } from "./BaseNodeModel";
 import { NodeTypes } from "../../../resources/constants";
 import { BaseNodeWidget } from "./BaseNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class BaseNodeFactory extends AbstractReactFactory<BaseNodeModel, DiagramEngine> {
 
@@ -34,6 +35,10 @@ export class BaseNodeFactory extends AbstractReactFactory<BaseNodeModel, Diagram
     }
 
     generateReactWidget(event: GenerateWidgetEvent<BaseNodeModel>) {
-        return <BaseNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <BaseNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
@@ -213,7 +213,7 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
         nodeComments,
     } = useDiagramContext();
 
-    const noteComment = nodeComments?.get(model.node.id);
+    const noteComments = nodeComments?.get(model.node.id) ?? [];
 
     const isSelected = selectedNodeId === model.node.id;
 
@@ -488,7 +488,15 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
                         <NodeStyles.Description>{nodeDescription as ReactNode}</NodeStyles.Description>
                     </NodeStyles.Header>
                     <NodeStyles.ActionButtonGroup>
-                        {noteComment && <NodeNoteChip commentNode={noteComment} engine={engine} onOpen={() => setIsNoteActive(true)} onClose={() => { setIsNoteActive(false); setIsHovered(false); }} />}
+                        {noteComments.map((noteComment) => (
+                            <NodeNoteChip
+                                key={noteComment.id}
+                                commentNode={noteComment}
+                                engine={engine}
+                                onOpen={() => setIsNoteActive(true)}
+                                onClose={() => { setIsNoteActive(false); setIsHovered(false); }}
+                            />
+                        ))}
                         {hasError && <DiagnosticsPopUp node={model.node} engine={engine} />}
                         {canViewFunction && (
                             <Tooltip content="View function flow">

--- a/packages/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
@@ -45,7 +45,7 @@ import { useDiagramContext } from "../../DiagramContext";
 import { BaseNodeModel } from "./BaseNodeModel";
 import { ELineRange, FlowNode } from "@wso2/ballerina-core";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { getNodeTitle, isWorkflowNode, nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, getNodeTitle, isWorkflowNode, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeNoteChip } from "../../NodeNoteChip";
 
@@ -456,6 +456,7 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
             isActiveBreakpoint={isActiveBreakpoint}
             isSelected={isSelected}
             isWorkflowNode={isWorkflowStyledNode}
+            style={getDiffContainerStyles(model.node)}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => { setIsHovered(false); setIsNoteActive(false); }}
             onContextMenu={!readOnly ? handleOnContextMenu : undefined}
@@ -483,7 +484,7 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
                 </NodeStyles.Icon>
                 <NodeStyles.Row style={{ flex: 1, minWidth: 0, width: "auto" }}>
                     <NodeStyles.Header onClick={handleOnClick}>
-                        <NodeStyles.Title>{nodeTitle}</NodeStyles.Title>
+                        <NodeStyles.Title style={getDiffTitleStyles(model.node)}>{nodeTitle}</NodeStyles.Title>
                         <NodeStyles.Description>{nodeDescription as ReactNode}</NodeStyles.Description>
                     </NodeStyles.Header>
                     <NodeStyles.ActionButtonGroup>

--- a/packages/bi-diagram/src/components/nodes/CallActivityNode/CallActivityNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/CallActivityNode/CallActivityNodeFactory.tsx
@@ -22,6 +22,7 @@ import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { NodeTypes } from "../../../resources/constants";
 import { CallActivityNodeModel } from "./CallActivityNodeModel";
 import { CallActivityNodeWidget } from "./CallActivityNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class CallActivityNodeFactory extends AbstractReactFactory<CallActivityNodeModel, DiagramEngine> {
     constructor() {
@@ -33,6 +34,10 @@ export class CallActivityNodeFactory extends AbstractReactFactory<CallActivityNo
     }
 
     generateReactWidget(event: GenerateWidgetEvent<CallActivityNodeModel>) {
-        return <CallActivityNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <CallActivityNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/CallActivityNode/CallActivityNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/CallActivityNode/CallActivityNodeWidget.tsx
@@ -43,7 +43,7 @@ import { useDiagramContext } from "../../DiagramContext";
 import { CallActivityNodeModel } from "./CallActivityNodeModel";
 import { ELineRange, FlowNode } from "@wso2/ballerina-core";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { getNodeTitle, nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, getNodeTitle, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 
 const SIDE_FILL_WIDTH = 2;
@@ -377,6 +377,7 @@ export function CallActivityNodeWidget(props: CallActivityNodeWidgetProps) {
                 readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
                 isSelected={isSelected}
+                style={getDiffContainerStyles(model.node)}
                 onContextMenu={!readOnly ? handleOnContextMenu : undefined}
             >
                 {hasBreakpoint && (
@@ -398,7 +399,7 @@ export function CallActivityNodeWidget(props: CallActivityNodeWidgetProps) {
                     </S.NodeIcon>
                     <S.Row style={{ flex: 1, minWidth: 0, width: "auto" }}>
                         <S.Header onClick={handleOnClick}>
-                            <S.Title>{nodeTitle}</S.Title>
+                            <S.Title style={getDiffTitleStyles(model.node)}>{nodeTitle}</S.Title>
                             <S.Description>{nodeDescription as ReactNode}</S.Description>
                         </S.Header>
                         <S.ActionButtonGroup>

--- a/packages/bi-diagram/src/components/nodes/CommentNode/CommentNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/CommentNode/CommentNodeFactory.tsx
@@ -23,6 +23,7 @@ import { CommentNodeModel } from "./CommentNodeModel";
 import { CommentNodeWidget } from "./CommentNodeWidget";
 import { NodeTypes } from "../../../resources/constants";
 import { NodeKind } from "../../../utils/types";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class CommentNodeFactory extends AbstractReactFactory<CommentNodeModel, DiagramEngine> {
     constructor() {
@@ -34,6 +35,10 @@ export class CommentNodeFactory extends AbstractReactFactory<CommentNodeModel, D
     }
 
     generateReactWidget(event: GenerateWidgetEvent<CommentNodeModel>) {
-        return <CommentNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <CommentNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/CommentNode/CommentNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/CommentNode/CommentNodeWidget.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../../resources/constants";
 import { Button, Item, Menu, MenuItem, Popover, Tooltip } from "@wso2/ui-toolkit";
 import { MoreVertIcon } from "../../../resources";
+import { getDiffContainerStyles, getDiffTitleStyles } from "../../../utils/node";
 import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 
@@ -238,6 +239,7 @@ export function CommentNodeWidget(props: CommentNodeWidgetProps) {
                 disabled={model.node.suggested}
                 isSelected={isSelected}
                 readOnly={readOnly}
+                style={getDiffContainerStyles(model.node)}
             >
                 <NodeStyles.Row>
                     <NodeStyles.Header onClick={handleOnClick}>
@@ -245,7 +247,7 @@ export function CommentNodeWidget(props: CommentNodeWidgetProps) {
                             content={model.node.metadata.description}
                             sx={{ maxWidth: COMMENT_NODE_WIDTH, textWrap: "wrap" }}
                         >
-                            <NodeStyles.Description>{model.node.metadata.description || "..."}</NodeStyles.Description>
+                            <NodeStyles.Description style={getDiffTitleStyles(model.node)}>{model.node.metadata.description || "..."}</NodeStyles.Description>
                         </Tooltip>
                     </NodeStyles.Header>
                     <NodeStyles.StyledButton disabled={readOnly} appearance="icon" onClick={handleOnMenuClick}>

--- a/packages/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeFactory.tsx
@@ -23,6 +23,7 @@ import { NodeTypes } from "../../../resources/constants";
 import { NodeKind } from "../../../utils/types";
 import { ErrorNodeModel } from "./ErrorNodeModel";
 import { ErrorNodeWidget } from "./ErrorNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class ErrorNodeFactory extends AbstractReactFactory<ErrorNodeModel, DiagramEngine> {
     constructor() {
@@ -37,7 +38,9 @@ export class ErrorNodeFactory extends AbstractReactFactory<ErrorNodeModel, Diagr
         switch (event.model.node.codedata.node as NodeKind) {
             default:
                 return (
-                    <ErrorNodeWidget engine={this.engine} model={event.model} />
+                    <DiffTooltip node={event.model.node}>
+                        <ErrorNodeWidget engine={this.engine} model={event.model} />
+                    </DiffTooltip>
                 );
         }
     }

--- a/packages/bi-diagram/src/components/nodes/IfNode/IfNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/IfNodeFactory.tsx
@@ -23,6 +23,7 @@ import { NodeTypes } from "../../../resources/constants";
 import { IfNodeModel } from "./IfNodeModel";
 import { IfNodeWidget } from "./IfNodeWidget";
 import { MatchNodeWidget } from "./MatchNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class IfNodeFactory extends AbstractReactFactory<IfNodeModel, DiagramEngine> {
     constructor() {
@@ -35,8 +36,16 @@ export class IfNodeFactory extends AbstractReactFactory<IfNodeModel, DiagramEngi
 
     generateReactWidget(event: GenerateWidgetEvent<IfNodeModel>) {
         if (event.model.node.codedata.node === "MATCH") {
-            return <MatchNodeWidget engine={this.engine} model={event.model} />;
+            return (
+                <DiffTooltip node={event.model.node}>
+                    <MatchNodeWidget engine={this.engine} model={event.model} />
+                </DiffTooltip>
+            );
         }
-        return <IfNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <IfNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
@@ -39,7 +39,7 @@ import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
+import { getDiffColors, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import NodeIcon from "../../NodeIcon";
 import { NodeNoteChip } from "../../NodeNoteChip";
@@ -268,11 +268,7 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
 
     const disabled = model.node.suggested;
     const hasError = nodeHasError(model.node);
-    // Cast to a plain shape here: this package's CSSProperties type resolution doesn't
-    // expose named members for direct reads (only works when passed whole to a `style` prop).
-    const diffStyles = getDiffContainerStyles(model.node) as
-        | { backgroundColor?: string; borderColor?: string }
-        | undefined;
+    const diffColors = getDiffColors(model.node);
 
     return (
         <NodeStyles.Node
@@ -316,8 +312,8 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                             rx="5"
                             ry="5"
                             fill={
-                                diffStyles?.backgroundColor
-                                    ? (diffStyles.backgroundColor as string)
+                                diffColors
+                                    ? diffColors.background
                                     : isActiveBreakpoint
                                     ? NODE_BG_BREAKPOINT_COLOR
                                     : (isHovered || isNoteActive) && !disabled && !readOnly
@@ -325,8 +321,8 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                                     : NODE_BG_COLOR
                             }
                             stroke={
-                                diffStyles?.borderColor
-                                    ? (diffStyles.borderColor as string)
+                                diffColors
+                                    ? diffColors.border
                                     : hasError
                                     ? NODE_BORDER_ERROR_COLOR
                                     : isSelected && !disabled

--- a/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
@@ -39,7 +39,7 @@ import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import NodeIcon from "../../NodeIcon";
 import { NodeNoteChip } from "../../NodeNoteChip";
@@ -268,6 +268,11 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
 
     const disabled = model.node.suggested;
     const hasError = nodeHasError(model.node);
+    // Cast to a plain shape here: this package's CSSProperties type resolution doesn't
+    // expose named members for direct reads (only works when passed whole to a `style` prop).
+    const diffStyles = getDiffContainerStyles(model.node) as
+        | { backgroundColor?: string; borderColor?: string }
+        | undefined;
 
     return (
         <NodeStyles.Node
@@ -311,14 +316,18 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                             rx="5"
                             ry="5"
                             fill={
-                                isActiveBreakpoint
+                                diffStyles?.backgroundColor
+                                    ? (diffStyles.backgroundColor as string)
+                                    : isActiveBreakpoint
                                     ? NODE_BG_BREAKPOINT_COLOR
                                     : (isHovered || isNoteActive) && !disabled && !readOnly
                                     ? NODE_BG_HOVER_COLOR
                                     : NODE_BG_COLOR
                             }
                             stroke={
-                                hasError
+                                diffStyles?.borderColor
+                                    ? (diffStyles.borderColor as string)
+                                    : hasError
                                     ? NODE_BORDER_ERROR_COLOR
                                     : isSelected && !disabled
                                         ? ThemeColors.SECONDARY
@@ -338,7 +347,7 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                     <NodeStyles.BottomPortWidget port={model.getPort("out")!} engine={engine} />
                 </NodeStyles.Column>
                 <NodeStyles.Header onClick={handleOnClick}>
-                    <NodeStyles.Title>{model.node.metadata.label || model.node.codedata.node}</NodeStyles.Title>
+                    <NodeStyles.Title style={getDiffTitleStyles(model.node)}>{model.node.metadata.label || model.node.codedata.node}</NodeStyles.Title>
                     {/* <NodeStyles.Description>
                         {model.node.branches.at(0).properties.condition.value}
                     </NodeStyles.Description> */}

--- a/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
@@ -39,7 +39,7 @@ import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { getDiffColors, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
+import { getDiffColors, getDiffStrokeDasharray, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import NodeIcon from "../../NodeIcon";
 import { NodeNoteChip } from "../../NodeNoteChip";
@@ -334,7 +334,7 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                                             : ThemeColors.OUTLINE_VARIANT
                             }
                             strokeWidth={NODE_BORDER_WIDTH}
-                            strokeDasharray={disabled ? "5 5" : "none"}
+                            strokeDasharray={disabled ? "5 5" : getDiffStrokeDasharray(model.node)}
                             opacity={disabled ? 0.7 : 1}
                             transform="rotate(45 28 28)"
                         />

--- a/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
@@ -79,6 +79,8 @@ export namespace NodeStyles {
         position: absolute;
         top: -14px;
         right: -50px;
+        display: flex;
+        gap: 2px;
     `;
 
     export const ErrorIcon = styled.div`
@@ -158,7 +160,7 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
     const { onNodeSelect, goToSource, onDeleteNode, addBreakpoint, removeBreakpoint, readOnly, selectedNodeId, nodeComments } =
         useDiagramContext();
 
-    const noteComment = nodeComments?.get(model.node.id);
+    const noteComments = nodeComments?.get(model.node.id) ?? [];
 
     const isSelected = selectedNodeId === model.node.id;
 
@@ -353,9 +355,17 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                         <DiagnosticsPopUp node={model.node} engine={engine} />
                     </NodeStyles.ErrorIcon>
                 )}
-                {noteComment && (
+                {noteComments.length > 0 && (
                     <NodeStyles.NoteChipWrapper>
-                        <NodeNoteChip commentNode={noteComment} engine={engine} onOpen={() => setIsNoteActive(true)} onClose={() => { setIsNoteActive(false); setIsHovered(false); }} />
+                        {noteComments.map((noteComment) => (
+                            <NodeNoteChip
+                                key={noteComment.id}
+                                commentNode={noteComment}
+                                engine={engine}
+                                onOpen={() => setIsNoteActive(true)}
+                                onClose={() => { setIsNoteActive(false); setIsHovered(false); }}
+                            />
+                        ))}
                     </NodeStyles.NoteChipWrapper>
                 )}
                 <NodeStyles.StyledButton

--- a/packages/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
@@ -36,7 +36,7 @@ import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeStyles } from "./IfNodeWidget";
 import NodeIcon from "../../NodeIcon";
@@ -160,6 +160,11 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
 
     const disabled = model.node.suggested;
     const hasError = nodeHasError(model.node);
+    // Cast to a plain shape here: this package's CSSProperties type resolution doesn't
+    // expose named members for direct reads (only works when passed whole to a `style` prop).
+    const diffStyles = getDiffContainerStyles(model.node) as
+        | { backgroundColor?: string; borderColor?: string }
+        | undefined;
     const condition = (
         model.node.properties.condition?.value ||
         model.node.properties.matchTarget?.value ||
@@ -208,14 +213,18 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                             rx="5"
                             ry="5"
                             fill={
-                                isActiveBreakpoint
+                                diffStyles?.backgroundColor
+                                    ? (diffStyles.backgroundColor as string)
+                                    : isActiveBreakpoint
                                     ? NODE_BG_BREAKPOINT_COLOR
                                     : isHovered && !disabled && !readOnly
                                     ? NODE_BG_HOVER_COLOR
                                     : NODE_BG_COLOR
                             }
                             stroke={
-                                hasError
+                                diffStyles?.borderColor
+                                    ? (diffStyles.borderColor as string)
+                                    : hasError
                                     ? NODE_BORDER_ERROR_COLOR
                                     : isSelected && !disabled
                                         ? ThemeColors.SECONDARY
@@ -235,7 +244,7 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                     <NodeStyles.BottomPortWidget port={model.getPort("out")!} engine={engine} />
                 </NodeStyles.Column>
                 <NodeStyles.Header onClick={handleOnClick}>
-                    <NodeStyles.Title>{model.node.metadata.label || model.node.codedata.node}</NodeStyles.Title>
+                    <NodeStyles.Title style={getDiffTitleStyles(model.node)}>{model.node.metadata.label || model.node.codedata.node}</NodeStyles.Title>
                     <NodeStyles.Description>{condition}</NodeStyles.Description>
                 </NodeStyles.Header>
                 {hasError && (

--- a/packages/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
@@ -36,7 +36,7 @@ import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { getDiffColors, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
+import { getDiffColors, getDiffStrokeDasharray, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeStyles } from "./IfNodeWidget";
 import NodeIcon from "../../NodeIcon";
@@ -229,7 +229,7 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                                             : ThemeColors.OUTLINE_VARIANT
                             }
                             strokeWidth={NODE_BORDER_WIDTH}
-                            strokeDasharray={disabled ? "5 5" : "none"}
+                            strokeDasharray={disabled ? "5 5" : getDiffStrokeDasharray(model.node)}
                             opacity={disabled ? 0.7 : 1}
                             transform="rotate(45 28 28)"
                         />

--- a/packages/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
@@ -36,7 +36,7 @@ import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
+import { getDiffColors, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeStyles } from "./IfNodeWidget";
 import NodeIcon from "../../NodeIcon";
@@ -160,11 +160,7 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
 
     const disabled = model.node.suggested;
     const hasError = nodeHasError(model.node);
-    // Cast to a plain shape here: this package's CSSProperties type resolution doesn't
-    // expose named members for direct reads (only works when passed whole to a `style` prop).
-    const diffStyles = getDiffContainerStyles(model.node) as
-        | { backgroundColor?: string; borderColor?: string }
-        | undefined;
+    const diffColors = getDiffColors(model.node);
     const condition = (
         model.node.properties.condition?.value ||
         model.node.properties.matchTarget?.value ||
@@ -213,8 +209,8 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                             rx="5"
                             ry="5"
                             fill={
-                                diffStyles?.backgroundColor
-                                    ? (diffStyles.backgroundColor as string)
+                                diffColors
+                                    ? diffColors.background
                                     : isActiveBreakpoint
                                     ? NODE_BG_BREAKPOINT_COLOR
                                     : isHovered && !disabled && !readOnly
@@ -222,8 +218,8 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                                     : NODE_BG_COLOR
                             }
                             stroke={
-                                diffStyles?.borderColor
-                                    ? (diffStyles.borderColor as string)
+                                diffColors
+                                    ? diffColors.border
                                     : hasError
                                     ? NODE_BORDER_ERROR_COLOR
                                     : isSelected && !disabled

--- a/packages/bi-diagram/src/components/nodes/PromptNode/PromptNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/PromptNode/PromptNodeFactory.tsx
@@ -22,6 +22,7 @@ import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { NodeTypes } from "../../../resources/constants";
 import { PromptNodeModel } from "./PromptNodeModel";
 import { PromptNodeWidget } from "./PromptNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class PromptNodeFactory extends AbstractReactFactory<PromptNodeModel, DiagramEngine> {
 
@@ -34,6 +35,10 @@ export class PromptNodeFactory extends AbstractReactFactory<PromptNodeModel, Dia
     }
 
     generateReactWidget(event: GenerateWidgetEvent<PromptNodeModel>) {
-        return <PromptNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <PromptNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/PromptNode/PromptNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/PromptNode/PromptNodeWidget.tsx
@@ -48,7 +48,7 @@ import { useDiagramContext } from "../../DiagramContext";
 import { PromptNodeModel } from "./PromptNodeModel";
 import { ELineRange, ExpressionProperty, NodeMetadata } from "@wso2/ballerina-core";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { cloneDeep } from "lodash";
 
 export namespace NodeStyles {
@@ -423,6 +423,7 @@ export function PromptNodeWidget(props: PromptNodeWidgetProps) {
                 hasError={hasError}
                 isActiveBreakpoint={isActiveBreakpoint}
                 isSelected={isSelected}
+                style={getDiffContainerStyles(model.node)}
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}
             >
@@ -446,7 +447,7 @@ export function PromptNodeWidget(props: PromptNodeWidgetProps) {
                     </NodeStyles.Icon>
                     <NodeStyles.Row>
                         <NodeStyles.Header onClick={handleOnClick}>
-                            <NodeStyles.Title>Prompt</NodeStyles.Title>
+                            <NodeStyles.Title style={getDiffTitleStyles(model.node)}>Prompt</NodeStyles.Title>
                         </NodeStyles.Header>
                         <NodeStyles.ActionButtonGroup>
                             {hasError && <DiagnosticsPopUp node={model.node} engine={engine} />}

--- a/packages/bi-diagram/src/components/nodes/SendDataNode/SendDataNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/SendDataNode/SendDataNodeFactory.tsx
@@ -22,6 +22,7 @@ import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { NodeTypes } from "../../../resources/constants";
 import { SendDataNodeModel } from "./SendDataNodeModel";
 import { SendDataNodeWidget } from "./SendDataNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class SendDataNodeFactory extends AbstractReactFactory<SendDataNodeModel, DiagramEngine> {
     constructor() {
@@ -33,6 +34,10 @@ export class SendDataNodeFactory extends AbstractReactFactory<SendDataNodeModel,
     }
 
     generateReactWidget(event: GenerateWidgetEvent<SendDataNodeModel>) {
-        return <SendDataNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <SendDataNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/SendDataNode/SendDataNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/SendDataNode/SendDataNodeWidget.tsx
@@ -27,7 +27,7 @@ import { MoreVertIcon } from "../../../resources";
 import NodeIcon from "../../NodeIcon";
 import { useDiagramContext } from "../../DiagramContext";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import {
     DRAFT_NODE_BORDER_WIDTH,
@@ -376,6 +376,7 @@ export function SendDataNodeWidget(props: SendDataNodeWidgetProps) {
                 readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
                 isSelected={isSelected}
+                style={getDiffContainerStyles(model.node)}
                 onMouseEnter={() => setIsBoxHovered(true)}
                 onMouseLeave={() => setIsBoxHovered(false)}
                 onContextMenu={!readOnly ? handleOnContextMenu : undefined}
@@ -399,7 +400,7 @@ export function SendDataNodeWidget(props: SendDataNodeWidgetProps) {
                     </NodeStyles.NodeIconWrapper>
                     <NodeStyles.Row>
                         <NodeStyles.Header onClick={handleOnClick}>
-                            <NodeStyles.Title>{nodeTitle}</NodeStyles.Title>
+                            <NodeStyles.Title style={getDiffTitleStyles(model.node)}>{nodeTitle}</NodeStyles.Title>
                         </NodeStyles.Header>
                         <NodeStyles.ActionButtonGroup>
                             {hasError && <DiagnosticsPopUp node={model.node} engine={engine} />}

--- a/packages/bi-diagram/src/components/nodes/StartNode/StartNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/StartNode/StartNodeFactory.tsx
@@ -23,6 +23,7 @@ import { StartNodeModel } from "./StartNodeModel";
 import { StartNodeWidget } from "./StartNodeWidget";
 import { NodeTypes } from "../../../resources/constants";
 import { NodeKind } from "../../../utils/types";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class StartNodeFactory extends AbstractReactFactory<StartNodeModel, DiagramEngine> {
     constructor() {
@@ -34,6 +35,10 @@ export class StartNodeFactory extends AbstractReactFactory<StartNodeModel, Diagr
     }
 
     generateReactWidget(event: GenerateWidgetEvent<StartNodeModel>) {
-        return <StartNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <StartNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/StartNode/StartNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/StartNode/StartNodeWidget.tsx
@@ -31,6 +31,9 @@ import {
 } from "../../../resources/constants";
 import { FlowNode } from "../../../utils/types";
 import { Tooltip } from "@wso2/ui-toolkit";
+import { getDiffContainerStyles, getDiffTitleStyles } from "../../../utils/node";
+import { useDiagramContext } from "../../DiagramContext";
+import { NodeNoteChip } from "../../NodeNoteChip";
 
 export namespace NodeStyles {
     export type NodeStyleProp = {
@@ -50,6 +53,7 @@ export namespace NodeStyles {
         background-color: ${NODE_BG_COLOR};
         color: ${NODE_TEXT_COLOR};
         cursor: default;
+        position: relative;
     `;
 
     export const TopPortWidget = styled(PortWidget)`
@@ -71,6 +75,14 @@ export namespace NodeStyles {
         text-overflow: ellipsis;
         font-family: "GilmerMedium";
     `;
+
+    export const NoteChipWrapper = styled.div`
+        position: absolute;
+        top: -16px;
+        right: -48px;
+        display: flex;
+        gap: 2px;
+    `;
 }
 
 interface StartNodeWidgetProps {
@@ -84,18 +96,30 @@ export interface NodeWidgetProps extends Omit<StartNodeWidgetProps, "children"> 
 export function StartNodeWidget(props: StartNodeWidgetProps) {
     const { model, engine, onClick } = props;
     const [isHovered, setIsHovered] = React.useState(false);
+    const { nodeComments } = useDiagramContext();
+    const noteComments = nodeComments?.get(model.node.id) ?? [];
 
     return (
         <NodeStyles.Node
             selected={model.isSelected()}
             hovered={isHovered}
+            style={getDiffContainerStyles(model.node)}
         // onMouseEnter={() => setIsHovered(true)}
         // onMouseLeave={() => setIsHovered(false)}
         >
             <NodeStyles.TopPortWidget port={model.getPort("in")!} engine={engine} />
             <Tooltip content={model.node.metadata.label || "Start"} containerSx={{ cursor: "default" }}>
-                <NodeStyles.Title data-testid="start-node">{model.node.metadata.label || "Start"}</NodeStyles.Title>
+                <NodeStyles.Title data-testid="start-node" style={getDiffTitleStyles(model.node)}>
+                    {model.node.metadata.label || "Start"}
+                </NodeStyles.Title>
             </Tooltip>
+            {noteComments.length > 0 && (
+                <NodeStyles.NoteChipWrapper>
+                    {noteComments.map((comment) => (
+                        <NodeNoteChip key={comment.id} commentNode={comment} engine={engine} />
+                    ))}
+                </NodeStyles.NoteChipWrapper>
+            )}
             <NodeStyles.BottomPortWidget port={model.getPort("out")!} engine={engine} />
         </NodeStyles.Node>
     );

--- a/packages/bi-diagram/src/components/nodes/WaitDataNode/WaitDataNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/WaitDataNode/WaitDataNodeFactory.tsx
@@ -22,6 +22,7 @@ import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { NodeTypes } from "../../../resources/constants";
 import { WaitDataNodeModel } from "./WaitDataNodeModel";
 import { WaitDataNodeWidget } from "./WaitDataNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class WaitDataNodeFactory extends AbstractReactFactory<WaitDataNodeModel, DiagramEngine> {
     constructor() {
@@ -33,6 +34,10 @@ export class WaitDataNodeFactory extends AbstractReactFactory<WaitDataNodeModel,
     }
 
     generateReactWidget(event: GenerateWidgetEvent<WaitDataNodeModel>) {
-        return <WaitDataNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <WaitDataNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/components/nodes/WaitDataNode/WaitDataNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/WaitDataNode/WaitDataNodeWidget.tsx
@@ -26,7 +26,7 @@ import { MoreVertIcon } from "../../../resources";
 import { useDiagramContext } from "../../DiagramContext";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { WaitDataNodeModel } from "./WaitDataNodeModel";
 import {
     HIGHLIGHT_NODE_BORDER_COLOR,
@@ -403,6 +403,7 @@ export function WaitDataNodeWidget(props: WaitDataNodeWidgetProps) {
                         readOnly={readOnly}
                         isSelected={isSelected}
                         isActiveBreakpoint={isActiveBreakpoint}
+                        style={getDiffContainerStyles(model.node)}
                         onClick={handleOnClick}
                     >
                         <Icon name="bi-pause" sx={{ fontSize: 32, width: 32, height: 32, color: NODE_TEXT_COLOR }} />
@@ -414,7 +415,7 @@ export function WaitDataNodeWidget(props: WaitDataNodeWidgetProps) {
             {/* Right: Title, subtitle, and action buttons */}
             <NodeStyles.Details onClick={handleOnClick}>
                 <NodeStyles.TextGroup>
-                    <NodeStyles.Title>{nodeTitle}</NodeStyles.Title>
+                    <NodeStyles.Title style={getDiffTitleStyles(model.node)}>{nodeTitle}</NodeStyles.Title>
                     <NodeStyles.Subtitle>{nodeSubtitle}</NodeStyles.Subtitle>
                 </NodeStyles.TextGroup>
                 <NodeStyles.ActionButtonGroup>

--- a/packages/bi-diagram/src/components/nodes/WhileNode/WhileNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/WhileNode/WhileNodeFactory.tsx
@@ -23,6 +23,7 @@ import { NodeTypes } from "../../../resources/constants";
 import { NodeKind } from "../../../utils/types";
 import { WhileNodeModel } from "./WhileNodeModel";
 import { WhileNodeWidget } from "./WhileNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class WhileNodeFactory extends AbstractReactFactory<WhileNodeModel, DiagramEngine> {
     constructor() {
@@ -37,7 +38,9 @@ export class WhileNodeFactory extends AbstractReactFactory<WhileNodeModel, Diagr
         switch (event.model.node.codedata.node as NodeKind) {
             default:
                 return (
-                    <WhileNodeWidget engine={this.engine} model={event.model} />
+                    <DiffTooltip node={event.model.node}>
+                        <WhileNodeWidget engine={this.engine} model={event.model} />
+                    </DiffTooltip>
                 );
         }
     }

--- a/packages/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
+++ b/packages/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
@@ -43,7 +43,7 @@ import { FlowNode } from "../../../utils/types";
 import { useDiagramContext } from "../../DiagramContext";
 import { MoreVertIcon } from "../../../resources";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
-import { nodeHasError } from "../../../utils/node";
+import { getDiffContainerStyles, getDiffTitleStyles, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeIcon } from "../../NodeIcon";
 
@@ -366,6 +366,7 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
                         isActiveBreakpoint={isActiveBreakpoint}
                         disabled={disabled}
                         isSelected={isSelected}
+                        style={getDiffContainerStyles(model.node)}
                     >
                         {hasBreakpoint && (
                             <div
@@ -391,7 +392,7 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
                     <div style={{ display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between", width: "100%" }}>
                         <div style={{}}>
                             <div style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "4px" }}>
-                                <NodeStyles.Title>{model.node.metadata.label || model.node.codedata.node}</NodeStyles.Title>
+                                <NodeStyles.Title style={getDiffTitleStyles(model.node)}>{model.node.metadata.label || model.node.codedata.node}</NodeStyles.Title>
                                 <NodeStyles.StyledButton
                                     ref={setMenuButtonElement}
                                     buttonSx={readOnly ? { cursor: "not-allowed" } : {}}

--- a/packages/bi-diagram/src/components/nodes/WorkflowRunNode/WorkflowRunNodeFactory.tsx
+++ b/packages/bi-diagram/src/components/nodes/WorkflowRunNode/WorkflowRunNodeFactory.tsx
@@ -22,6 +22,7 @@ import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { NodeTypes } from "../../../resources/constants";
 import { WorkflowRunNodeModel } from "./WorkflowRunNodeModel";
 import { WorkflowRunNodeWidget } from "./WorkflowRunNodeWidget";
+import { DiffTooltip } from "../../DiffTooltip";
 
 export class WorkflowRunNodeFactory extends AbstractReactFactory<WorkflowRunNodeModel, DiagramEngine> {
     constructor() {
@@ -33,6 +34,10 @@ export class WorkflowRunNodeFactory extends AbstractReactFactory<WorkflowRunNode
     }
 
     generateReactWidget(event: GenerateWidgetEvent<WorkflowRunNodeModel>) {
-        return <WorkflowRunNodeWidget engine={this.engine} model={event.model} />;
+        return (
+            <DiffTooltip node={event.model.node}>
+                <WorkflowRunNodeWidget engine={this.engine} model={event.model} />
+            </DiffTooltip>
+        );
     }
 }

--- a/packages/bi-diagram/src/index.tsx
+++ b/packages/bi-diagram/src/index.tsx
@@ -32,6 +32,7 @@ export { setTraceAnimationActive, setTraceAnimationInactive, useTraceAnimation }
 
 // diff utils
 export { mergeFlowModelsForDiff, stampDiffState } from "./utils/diff";
+export { DIFF_ADDED_COLOR, DIFF_MODIFIED_COLOR, DIFF_REMOVED_COLOR } from "./resources/constants";
 
 // traversing utils
 export { traverseFlow, traverseNode } from "@wso2/ballerina-core";

--- a/packages/bi-diagram/src/index.tsx
+++ b/packages/bi-diagram/src/index.tsx
@@ -30,6 +30,9 @@ export type { GetHelperPaneFunction, TraceAnimationState, TraceAnimationEntry, A
 
 export { setTraceAnimationActive, setTraceAnimationInactive, useTraceAnimation } from "./components/DiagramContext";
 
+// diff utils
+export { mergeFlowModelsForDiff, stampDiffState } from "./utils/diff";
+
 // traversing utils
 export { traverseFlow, traverseNode } from "@wso2/ballerina-core";
 export { AddNodeVisitor } from "./visitors/AddNodeVisitor";

--- a/packages/bi-diagram/src/resources/constants.ts
+++ b/packages/bi-diagram/src/resources/constants.ts
@@ -82,6 +82,9 @@ export const DIFF_REMOVED_COLOR = "var(--vscode-gitDecoration-deletedResourceFor
 export const DIFF_REMOVED_BG_COLOR = "var(--vscode-diffEditor-removedTextBackground, rgba(255, 0, 0, 0.2))";
 export const DIFF_ADDED_COLOR = "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)";
 export const DIFF_ADDED_BG_COLOR = "var(--vscode-diffEditor-insertedTextBackground, rgba(0, 255, 0, 0.2))";
+export const DIFF_MODIFIED_COLOR = "var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d)";
+export const DIFF_MODIFIED_BG_COLOR =
+    "color-mix(in srgb, var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d) 12%, transparent)";
 
 // ─── Link Colors ─────────────────────────────────────────────────────────────
 export const LINK_COLOR = ThemeColors.ON_SURFACE_VARIANT;

--- a/packages/bi-diagram/src/resources/constants.ts
+++ b/packages/bi-diagram/src/resources/constants.ts
@@ -77,6 +77,12 @@ export const END_NODE_BG_COLOR = ThemeColors.ON_SURFACE;
 export const EMPTY_NODE_ACTIVE_BORDER_COLOR = ThemeColors.ON_SURFACE;
 export const EMPTY_NODE_ACTIVE_BG_COLOR = ThemeColors.PRIMARY_CONTAINER;
 
+// ─── Review Diff Colors (unified old/new diagram) ────────────────────────────
+export const DIFF_REMOVED_COLOR = "var(--vscode-gitDecoration-deletedResourceForeground, #f85149)";
+export const DIFF_REMOVED_BG_COLOR = "var(--vscode-diffEditor-removedTextBackground, rgba(255, 0, 0, 0.2))";
+export const DIFF_ADDED_COLOR = "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)";
+export const DIFF_ADDED_BG_COLOR = "var(--vscode-diffEditor-insertedTextBackground, rgba(0, 255, 0, 0.2))";
+
 // ─── Link Colors ─────────────────────────────────────────────────────────────
 export const LINK_COLOR = ThemeColors.ON_SURFACE_VARIANT;
 export const LINK_HOVERED_COLOR = ThemeColors.PRIMARY;

--- a/packages/bi-diagram/src/resources/constants.ts
+++ b/packages/bi-diagram/src/resources/constants.ts
@@ -78,13 +78,20 @@ export const EMPTY_NODE_ACTIVE_BORDER_COLOR = ThemeColors.ON_SURFACE;
 export const EMPTY_NODE_ACTIVE_BG_COLOR = ThemeColors.PRIMARY_CONTAINER;
 
 // ─── Review Diff Colors (unified old/new diagram) ────────────────────────────
-export const DIFF_REMOVED_COLOR = "var(--vscode-gitDecoration-deletedResourceForeground, #f85149)";
-export const DIFF_REMOVED_BG_COLOR = "var(--vscode-diffEditor-removedTextBackground, rgba(255, 0, 0, 0.2))";
-export const DIFF_ADDED_COLOR = "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)";
-export const DIFF_ADDED_BG_COLOR = "var(--vscode-diffEditor-insertedTextBackground, rgba(0, 255, 0, 0.2))";
-export const DIFF_MODIFIED_COLOR = "var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d)";
-export const DIFF_MODIFIED_BG_COLOR =
-    "color-mix(in srgb, var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d) 12%, transparent)";
+// Prefer the diff-editor borders because VS Code defines dedicated variants for
+// both high-contrast themes. Standard themes fall back to their Git decoration.
+export const DIFF_REMOVED_COLOR =
+    "var(--vscode-diffEditor-removedTextBorder, var(--vscode-gitDecoration-deletedResourceForeground, #c74e39))";
+export const DIFF_REMOVED_BG_COLOR = "var(--vscode-diffEditor-removedTextBackground, transparent)";
+export const DIFF_ADDED_COLOR =
+    "var(--vscode-diffEditor-insertedTextBorder, var(--vscode-gitDecoration-addedResourceForeground, #2ea043))";
+export const DIFF_ADDED_BG_COLOR = "var(--vscode-diffEditor-insertedTextBackground, transparent)";
+
+// Use VS Code's familiar SCM modified color. The explicit "~ Modified" marker
+// and dotted border keep the state identifiable without relying on amber alone.
+export const DIFF_MODIFIED_COLOR =
+    "var(--vscode-gitDecoration-modifiedResourceForeground, var(--vscode-editorInfo-foreground, #e2c08d))";
+export const DIFF_MODIFIED_BG_COLOR = "transparent";
 
 // ─── Link Colors ─────────────────────────────────────────────────────────────
 export const LINK_COLOR = ThemeColors.ON_SURFACE_VARIANT;

--- a/packages/bi-diagram/src/stories/8-diff-new.json
+++ b/packages/bi-diagram/src/stories/8-diff-new.json
@@ -40,7 +40,7 @@
                     "startLine": { "line": 11, "offset": 8 },
                     "endLine": { "line": 11, "offset": 52 }
                 },
-                "sourceCode": "string orderStatus = orderValue.status;"
+                "sourceCode": "string orderStatus = orderValue.status.toUpperAscii();"
             },
             "properties": {
                 "variable": {
@@ -53,7 +53,7 @@
                 },
                 "expression": {
                     "metadata": { "label": "Expression", "description": "Expression of the variable" },
-                    "value": "orderValue.status",
+                    "value": "orderValue.status.toUpperAscii()",
                     "optional": false,
                     "editable": true,
                     "advanced": false,

--- a/packages/bi-diagram/src/stories/8-diff-new.json
+++ b/packages/bi-diagram/src/stories/8-diff-new.json
@@ -1,0 +1,116 @@
+{
+    "fileName": "/tmp/sample/main.bal",
+    "nodes": [
+        {
+            "id": "50001",
+            "metadata": {
+                "label": "Start",
+                "description": "",
+                "data": {
+                    "kind": "Resource",
+                    "label": "orderStatus",
+                    "accessor": "get",
+                    "isServiceFunction": true,
+                    "return": "string"
+                }
+            },
+            "codedata": {
+                "node": "EVENT_START",
+                "lineRange": {
+                    "fileName": "main.bal",
+                    "startLine": { "line": 10, "offset": 4 },
+                    "endLine": { "line": 16, "offset": 5 }
+                },
+                "sourceCode": "resource function get orderStatus() returns string {"
+            },
+            "returning": false,
+            "flags": 0
+        },
+        {
+            "id": "50002",
+            "metadata": {
+                "label": "Declare Variable",
+                "description": "New variable with type"
+            },
+            "codedata": {
+                "node": "VARIABLE",
+                "lineRange": {
+                    "fileName": "main.bal",
+                    "startLine": { "line": 11, "offset": 8 },
+                    "endLine": { "line": 11, "offset": 52 }
+                },
+                "sourceCode": "string orderStatus = orderValue.status;"
+            },
+            "properties": {
+                "variable": {
+                    "metadata": { "label": "Name", "description": "Name of the variable" },
+                    "value": "orderStatus",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                },
+                "expression": {
+                    "metadata": { "label": "Expression", "description": "Expression of the variable" },
+                    "value": "orderValue.status",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                }
+            },
+            "returning": false,
+            "flags": 0
+        },
+        {
+            "id": "50003",
+            "metadata": {
+                "label": "Print",
+                "description": "Print the order status"
+            },
+            "codedata": {
+                "node": "FUNCTION_CALL",
+                "org": "ballerina",
+                "module": "io",
+                "symbol": "println",
+                "lineRange": {
+                    "fileName": "main.bal",
+                    "startLine": { "line": 13, "offset": 8 },
+                    "endLine": { "line": 13, "offset": 36 }
+                },
+                "sourceCode": "io:println(orderStatus);"
+            },
+            "returning": false,
+            "flags": 0
+        },
+        {
+            "id": "50004",
+            "metadata": {
+                "label": "Return",
+                "description": "Return a value"
+            },
+            "codedata": {
+                "node": "RETURN",
+                "lineRange": {
+                    "fileName": "main.bal",
+                    "startLine": { "line": 15, "offset": 8 },
+                    "endLine": { "line": 15, "offset": 27 }
+                },
+                "sourceCode": "return orderStatus;"
+            },
+            "properties": {
+                "expression": {
+                    "metadata": { "label": "Expression", "description": "Return value" },
+                    "value": "orderStatus",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                }
+            },
+            "returning": true,
+            "flags": 0
+        }
+    ],
+    "connections": []
+}

--- a/packages/bi-diagram/src/stories/8-diff-new.json
+++ b/packages/bi-diagram/src/stories/8-diff-new.json
@@ -23,6 +23,7 @@
                 },
                 "sourceCode": "resource function get orderStatus() returns string {"
             },
+            "branches": [],
             "returning": false,
             "flags": 0
         },
@@ -59,6 +60,7 @@
                     "hidden": false
                 }
             },
+            "branches": [],
             "returning": false,
             "flags": 0
         },
@@ -80,6 +82,7 @@
                 },
                 "sourceCode": "io:println(orderStatus);"
             },
+            "branches": [],
             "returning": false,
             "flags": 0
         },
@@ -108,6 +111,7 @@
                     "hidden": false
                 }
             },
+            "branches": [],
             "returning": true,
             "flags": 0
         }

--- a/packages/bi-diagram/src/stories/8-diff-old.json
+++ b/packages/bi-diagram/src/stories/8-diff-old.json
@@ -23,6 +23,7 @@
                 },
                 "sourceCode": "resource function get orderStatus() returns string {"
             },
+            "branches": [],
             "returning": false,
             "flags": 0
         },
@@ -59,6 +60,7 @@
                     "hidden": false
                 }
             },
+            "branches": [],
             "returning": false,
             "flags": 0
         },
@@ -78,6 +80,7 @@
                 },
                 "sourceCode": "logOrderStatusRetrieved(orderStatus);"
             },
+            "branches": [],
             "returning": false,
             "flags": 0
         },
@@ -106,6 +109,7 @@
                     "hidden": false
                 }
             },
+            "branches": [],
             "returning": true,
             "flags": 0
         }

--- a/packages/bi-diagram/src/stories/8-diff-old.json
+++ b/packages/bi-diagram/src/stories/8-diff-old.json
@@ -1,0 +1,114 @@
+{
+    "fileName": "/tmp/sample/main.bal",
+    "nodes": [
+        {
+            "id": "40001",
+            "metadata": {
+                "label": "Start",
+                "description": "",
+                "data": {
+                    "kind": "Resource",
+                    "label": "orderStatus",
+                    "accessor": "get",
+                    "isServiceFunction": true,
+                    "return": "string"
+                }
+            },
+            "codedata": {
+                "node": "EVENT_START",
+                "lineRange": {
+                    "fileName": "main.bal",
+                    "startLine": { "line": 10, "offset": 4 },
+                    "endLine": { "line": 16, "offset": 5 }
+                },
+                "sourceCode": "resource function get orderStatus() returns string {"
+            },
+            "returning": false,
+            "flags": 0
+        },
+        {
+            "id": "40002",
+            "metadata": {
+                "label": "Declare Variable",
+                "description": "New variable with type"
+            },
+            "codedata": {
+                "node": "VARIABLE",
+                "lineRange": {
+                    "fileName": "main.bal",
+                    "startLine": { "line": 11, "offset": 8 },
+                    "endLine": { "line": 11, "offset": 52 }
+                },
+                "sourceCode": "string orderStatus = orderValue.status;"
+            },
+            "properties": {
+                "variable": {
+                    "metadata": { "label": "Name", "description": "Name of the variable" },
+                    "value": "orderStatus",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                },
+                "expression": {
+                    "metadata": { "label": "Expression", "description": "Expression of the variable" },
+                    "value": "orderValue.status",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                }
+            },
+            "returning": false,
+            "flags": 0
+        },
+        {
+            "id": "40003",
+            "metadata": {
+                "label": "Call Function",
+                "description": "Call the logOrderStatusRetrieved function"
+            },
+            "codedata": {
+                "node": "FUNCTION_CALL",
+                "symbol": "logOrderStatusRetrieved",
+                "lineRange": {
+                    "fileName": "main.bal",
+                    "startLine": { "line": 13, "offset": 8 },
+                    "endLine": { "line": 13, "offset": 48 }
+                },
+                "sourceCode": "logOrderStatusRetrieved(orderStatus);"
+            },
+            "returning": false,
+            "flags": 0
+        },
+        {
+            "id": "40004",
+            "metadata": {
+                "label": "Return",
+                "description": "Return a value"
+            },
+            "codedata": {
+                "node": "RETURN",
+                "lineRange": {
+                    "fileName": "main.bal",
+                    "startLine": { "line": 15, "offset": 8 },
+                    "endLine": { "line": 15, "offset": 27 }
+                },
+                "sourceCode": "return orderStatus;"
+            },
+            "properties": {
+                "expression": {
+                    "metadata": { "label": "Expression", "description": "Return value" },
+                    "value": "orderStatus",
+                    "optional": false,
+                    "editable": true,
+                    "advanced": false,
+                    "hidden": false
+                }
+            },
+            "returning": true,
+            "flags": 0
+        }
+    ],
+    "connections": []
+}

--- a/packages/bi-diagram/src/stories/Diagram.stories.tsx
+++ b/packages/bi-diagram/src/stories/Diagram.stories.tsx
@@ -20,8 +20,8 @@ Start.args = {
     model: model1,
 };
 
-// Unified review-diff diagram: old and new versions of the same function merged into one
-// flow, with removed nodes in a red lane and added nodes in a green lane.
+// Unified review-diff diagram with an edited variable and replaced function call,
+// covering modified, removed and added state presentations in one visual fixture.
 export const ReviewDiff = Template.bind({});
 ReviewDiff.args = {
     model: mergeFlowModelsForDiff(diffOldModel as unknown as Flow, diffNewModel as unknown as Flow),

--- a/packages/bi-diagram/src/stories/Diagram.stories.tsx
+++ b/packages/bi-diagram/src/stories/Diagram.stories.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react/types-6-0";
 import { Diagram, DiagramProps } from "../components/Diagram";
+import { mergeFlowModelsForDiff } from "../utils/diff";
+import { Flow } from "../utils/types";
 
 import model1 from "./1-start.json";
+import diffOldModel from "./8-diff-old.json";
+import diffNewModel from "./8-diff-new.json";
 
 export default {
     title: "BI/Diagram",
@@ -14,4 +18,12 @@ const Template: Story<DiagramProps> = (args: JSX.IntrinsicAttributes & DiagramPr
 export const Start = Template.bind({});
 Start.args = {
     model: model1,
+};
+
+// Unified review-diff diagram: old and new versions of the same function merged into one
+// flow, with removed nodes in a red lane and added nodes in a green lane.
+export const ReviewDiff = Template.bind({});
+ReviewDiff.args = {
+    model: mergeFlowModelsForDiff(diffOldModel as unknown as Flow, diffNewModel as unknown as Flow),
+    readOnly: true,
 };

--- a/packages/bi-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
+++ b/packages/bi-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
 .css-10 {cursor: not-allowed; visibility: hidden;}
 .css-76 svg {fill: var(--vscode-terminal-ansiGreen);}
 .css-79 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 16px; height: 16px; cursor: pointer;}
+.css-25 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default; position: relative;}
 .css-26 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-23 {border-radius: 5px;}
 .css-64 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; color: var(--vscode-foreground); cursor: pointer;}
@@ -146,7 +147,6 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
 .css-18 svg {fill: var(--vscode-terminal-ansiYellow);}
 .css-59 {pointer-events: none; opacity: 0; -webkit-transition: opacity 0.4s ease-out; transition: opacity 0.4s ease-out; -webkit-animation: animation-zkuskm 1s linear infinite; animation: animation-zkuskm 1s linear infinite;}
 .css-67 {font-size: 14px; max-width: 230px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground);}
-.css-25 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default;}
 .css-63 {background-color: var(--vscode-editor-background); color: var(--vscode-foreground); padding: 4px 8px; border-radius: 4px; font-size: 12px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); opacity: 0; visibility: hidden; -webkit-transition: opacity 0.2s ease-in-out; transition: opacity 0.2s ease-in-out; pointer-events: none; white-space: nowrap; font-family: "GilmerRegular";}
 .css-13 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; color: var(--vscode-foreground); cursor: pointer;}
 .css-57 {opacity: 0; visibility: hidden; -webkit-transition: opacity 0.2s ease-in-out; transition: opacity 0.2s ease-in-out; pointer-events: all;}
@@ -1909,7 +1909,6 @@ exports[`BI Diagram - Snapshot Tests renders AI agent flow correctly: ai-agent-f
                     rx="5"
                     ry="5"
                     stroke="var(--vscode-dropdown-border)"
-                    stroke-dasharray="none"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -2287,6 +2286,7 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
 .css-10 {cursor: not-allowed; visibility: hidden;}
 .css-27 svg {fill: var(--vscode-terminal-ansiGreen);}
 .css-97 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 16px; height: 16px; cursor: pointer;}
+.css-34 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default; position: relative;}
 .css-35 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-23 {border-radius: 5px;}
 .css-37 svg {fill: var(--vscode-terminal-ansiMagenta);}
@@ -2392,7 +2392,6 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
 .css-18 svg {fill: var(--vscode-terminal-ansiYellow);}
 .css-88 {pointer-events: none; opacity: 0; -webkit-transition: opacity 0.4s ease-out; transition: opacity 0.4s ease-out; -webkit-animation: animation-zkuskm 1s linear infinite; animation: animation-zkuskm 1s linear infinite;}
 .css-47 {font-size: 14px; max-width: 230px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground);}
-.css-34 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default;}
 .css-81 {background-color: var(--vscode-editor-background); color: var(--vscode-foreground); padding: 4px 8px; border-radius: 4px; font-size: 12px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); opacity: 0; visibility: hidden; -webkit-transition: opacity 0.2s ease-in-out; transition: opacity 0.2s ease-in-out; pointer-events: none; white-space: nowrap; font-family: "GilmerRegular";}
 .css-13 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; color: var(--vscode-foreground); cursor: pointer;}
 .css-86 {opacity: 0; visibility: hidden; -webkit-transition: opacity 0.2s ease-in-out; transition: opacity 0.2s ease-in-out; pointer-events: all;}
@@ -7245,7 +7244,6 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                     rx="5"
                     ry="5"
                     stroke="var(--vscode-dropdown-border)"
-                    stroke-dasharray="none"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -7542,7 +7540,6 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                     rx="5"
                     ry="5"
                     stroke="var(--vscode-dropdown-border)"
-                    stroke-dasharray="none"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -9283,7 +9280,6 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                     rx="5"
                     ry="5"
                     stroke="var(--vscode-dropdown-border)"
-                    stroke-dasharray="none"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -9547,7 +9543,6 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                     rx="5"
                     ry="5"
                     stroke="var(--vscode-dropdown-border)"
-                    stroke-dasharray="none"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -10309,6 +10304,7 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
 .css-10 {cursor: not-allowed; visibility: hidden;}
 .css-38 svg {fill: var(--vscode-terminal-ansiGreen);}
 .css-56 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 16px; height: 16px; cursor: pointer;}
+.css-25 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default; position: relative;}
 .css-26 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-23 {border-radius: 5px;}
 .css-30 svg {fill: var(--vscode-terminal-ansiMagenta);}
@@ -10344,7 +10340,6 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
 .css-35 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-align-items: flex-start; -webkit-box-align: flex-start; -ms-flex-align: flex-start; align-items: flex-start; cursor: pointer;}
 .css-18 svg {fill: var(--vscode-terminal-ansiYellow);}
 .css-44 {font-size: 14px; max-width: 230px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-family: "GilmerMedium"; color: var(--vscode-foreground);}
-.css-25 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default;}
 .css-13 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; color: var(--vscode-foreground); cursor: pointer;}
 
 /* DOM */
@@ -12527,7 +12522,6 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                     rx="5"
                     ry="5"
                     stroke="var(--vscode-dropdown-border)"
-                    stroke-dasharray="none"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -12711,7 +12705,6 @@ exports[`BI Diagram - Snapshot Tests renders complex flow correctly: complex-flo
                     rx="5"
                     ry="5"
                     stroke="var(--vscode-dropdown-border)"
-                    stroke-dasharray="none"
                     stroke-width="1.8"
                     transform="rotate(45 28 28)"
                     width="50"
@@ -13592,6 +13585,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with diagnostics correctly: fl
 .css-9 {cursor: pointer;}
 .css-10 {cursor: not-allowed; visibility: hidden;}
 .css-34 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 16px; height: 16px; cursor: pointer;}
+.css-31 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default; position: relative;}
 .css-32 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-22 {border-radius: 5px;}
 .css-26 svg {fill: var(--vscode-terminal-ansiMagenta);}
@@ -13614,7 +13608,6 @@ exports[`BI Diagram - Snapshot Tests renders flow with diagnostics correctly: fl
 .css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 280px; min-height: 50px; padding: 0 8px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); opacity: 0.7; border: 2px; border-style: dashed; border-color: var(--vscode-foreground); border-radius: 10px; cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-17 svg {fill: var(--vscode-terminal-ansiYellow);}
 .css-38 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: space-around; -ms-flex-pack: space-around; -webkit-justify-content: space-around; justify-content: space-around; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 4px; width: 100%;}
-.css-31 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default;}
 .css-12 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; color: var(--vscode-foreground); cursor: pointer;}
 .css-39 {font-size: 12px;}
 
@@ -14291,6 +14284,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with error handler correctly: 
 .css-9 {cursor: pointer;}
 .css-10 {cursor: not-allowed; visibility: hidden;}
 .css-27 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 16px; height: 16px; cursor: pointer;}
+.css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default; position: relative;}
 .css-25 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-22 {border-radius: 5px;}
 .css-15 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; border: 1.8px; border-style: solid; border-color: var(--vscode-dropdown-border); border-radius: 8px; background-color: var(--vscode-menu-background); width: 52px; height: 52px; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
@@ -14307,7 +14301,6 @@ exports[`BI Diagram - Snapshot Tests renders flow with error handler correctly: 
 .css-4 >* {height: 100%; min-height: 100%; width: 100%;}
 .css-4 {height: 100%; -webkit-background-size: 16px 16px; background-size: 16px 16px; display: flex; pointer-events: auto; background-image: radial-gradient(var(--vscode-editor-inactiveSelectionBackground) 10%, transparent 0px); background-color: var(--vscode-editor-background); font-family: "GilmerRegular";}
 .css-17 svg {fill: var(--vscode-terminal-ansiYellow);}
-.css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default;}
 .css-12 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; color: var(--vscode-foreground); cursor: pointer;}
 
 /* DOM */
@@ -14799,6 +14792,7 @@ exports[`BI Diagram - Snapshot Tests renders flow with suggestions correctly: fl
 .css-9 {cursor: pointer;}
 .css-10 {cursor: not-allowed; visibility: hidden;}
 .css-34 {display: flex; -webkit-box-pack: center; -ms-flex-pack: center; -webkit-justify-content: center; justify-content: center; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 16px; height: 16px; cursor: pointer;}
+.css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default; position: relative;}
 .css-25 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-22 {border-radius: 5px;}
 .css-29 svg {fill: var(--vscode-terminal-ansiMagenta);}
@@ -14821,7 +14815,6 @@ exports[`BI Diagram - Snapshot Tests renders flow with suggestions correctly: fl
 .css-27 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 280px; min-height: 50px; padding: 0 8px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); opacity: 0.7; border: 2px; border-style: dashed; border-color: var(--vscode-foreground); border-radius: 10px; cursor: pointer; box-shadow: none; -webkit-transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease; transition: box-shadow 0.1s ease,background-color 0.1s ease,border-color 0.1s ease;}
 .css-17 svg {fill: var(--vscode-terminal-ansiYellow);}
 .css-38 {display: flex; -webkit-flex-direction: row; -ms-flex-direction: row; flex-direction: row; -webkit-box-pack: space-around; -ms-flex-pack: space-around; -webkit-justify-content: space-around; justify-content: space-around; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; gap: 4px; width: 100%;}
-.css-24 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default;}
 .css-12 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; color: var(--vscode-foreground); cursor: pointer;}
 .css-39 {font-size: 12px;}
 
@@ -15486,6 +15479,7 @@ exports[`BI Diagram - Snapshot Tests renders start flow correctly: start-flow 1`
 .css-19 {margin-top: -2px;}
 .css-18 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: start; -ms-flex-pack: start; -webkit-justify-content: flex-start; justify-content: flex-start; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 20px; height: 20px; background-color: var(--vscode-foreground); border-radius: 50%;}
 .css-9 {cursor: pointer;}
+.css-12 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default; position: relative;}
 .css-14 {position: relative; display: inline-block; cursor: default; pointer-events: auto;}
 .css-13 {margin-top: -3px;}
 .css-8 {cursor: pointer; visibility: visible;}
@@ -15499,7 +15493,6 @@ exports[`BI Diagram - Snapshot Tests renders start flow correctly: start-flow 1`
 .css-6 {top: 0; left: 0; right: 0; bottom: 0; position: absolute; pointer-events: none; transform-origin: 0 0; width: 100%; height: 100%; overflow: visible;}
 .css-4 >* {height: 100%; min-height: 100%; width: 100%;}
 .css-4 {height: 100%; -webkit-background-size: 16px 16px; background-size: 16px 16px; display: flex; pointer-events: auto; background-image: radial-gradient(var(--vscode-editor-inactiveSelectionBackground) 10%, transparent 0px); background-color: var(--vscode-editor-background); font-family: "GilmerRegular";}
-.css-12 {display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-box-pack: justify; -webkit-justify-content: space-between; justify-content: space-between; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center; width: 93.33333333333333px; min-height: 33.333333333333336px; padding: 0 8px; border: 1.8px solid var(--vscode-foreground); border-radius: 40px; background-color: var(--vscode-menu-background); color: var(--vscode-foreground); cursor: default;}
 
 /* DOM */
 <div>

--- a/packages/bi-diagram/src/test/diff-presentation.test.tsx
+++ b/packages/bi-diagram/src/test/diff-presentation.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { DiffTooltip } from "../components/DiffTooltip";
+import { DIFF_ADDED_COLOR, DIFF_MODIFIED_COLOR, DIFF_REMOVED_COLOR } from "../resources/constants";
+import { getDiffContainerStyles, getDiffStatePresentation, getDiffStrokeDasharray } from "../utils/node";
+import { FlowNode, FlowNodeDiffState, NodeKind } from "../utils/types";
+
+function makeNode(diffState: FlowNodeDiffState, sourceCode = "doWork();"): FlowNode {
+    return {
+        id: `node-${diffState}`,
+        metadata: { label: "Test", description: "Test node" },
+        codedata: { node: "EXPRESSION" as NodeKind, sourceCode },
+        branches: [],
+        returning: false,
+        diffState,
+    };
+}
+
+describe("review diff presentation", () => {
+    it.each([
+        ["added", "+", "Added", "solid", undefined, DIFF_ADDED_COLOR],
+        ["removed", "−", "Removed", "dashed", "6 4", DIFF_REMOVED_COLOR],
+        ["modified", "~", "Modified", "dotted", "2 2", DIFF_MODIFIED_COLOR],
+    ] as const)("presents %s without relying on color", (state, symbol, label, borderStyle, dasharray, color) => {
+        const node = makeNode(state);
+
+        expect(getDiffStatePresentation(state)).toEqual({ symbol, label, borderStyle, strokeDasharray: dasharray });
+        expect(getDiffContainerStyles(node)).toMatchObject({
+            borderColor: color,
+            borderStyle,
+            outline: "1px solid var(--vscode-contrastBorder, transparent)",
+        });
+        expect(getDiffStrokeDasharray(node)).toBe(dasharray);
+    });
+
+    it("keeps the modified fill transparent", () => {
+        expect(getDiffContainerStyles(makeNode("modified"))).toMatchObject({ backgroundColor: "transparent" });
+    });
+
+    it.each([
+        ["added", "Added", "+ Added"],
+        ["removed", "Removed", "− Removed"],
+        ["modified", "Modified", "~ Modified"],
+    ] as const)("adds a visible and accessible %s marker", (state, label, marker) => {
+        render(
+            <DiffTooltip node={makeNode(state)}>
+                <div>Diagram content</div>
+            </DiffTooltip>
+        );
+
+        expect(screen.getByRole("group", { name: `${label} diagram node` })).toBeInTheDocument();
+        expect(screen.getByText(marker)).toBeInTheDocument();
+    });
+
+    it("labels the old and new source in a modified-node tooltip", () => {
+        const node = makeNode("modified", "doNewWork();");
+        node.diffPreviousText = "doOldWork();";
+
+        render(
+            <DiffTooltip node={node}>
+                <div>Diagram content</div>
+            </DiffTooltip>
+        );
+
+        expect(screen.getByText("Old")).toBeInTheDocument();
+        expect(screen.getByText("doOldWork();")).toBeInTheDocument();
+        expect(screen.getByText("New")).toBeInTheDocument();
+        expect(screen.getByText("doNewWork();")).toBeInTheDocument();
+    });
+});

--- a/packages/bi-diagram/src/test/diff.test.ts
+++ b/packages/bi-diagram/src/test/diff.test.ts
@@ -143,6 +143,35 @@ describe("mergeFlowModelsForDiff", () => {
         expect(hunk.branches[1].children[0].diffState).toBe("added");
     });
 
+    it("re-keys old and new nodes that have the same LS line-range id", () => {
+        const oldCall = makeNode("IF", "if oldCondition {\n  nestedOld();\n}", [
+            makeBranch("Body", [makeNode("FUNCTION_CALL", "nestedOld();")]),
+        ]);
+        const newCall = makeNode("WHILE", "while newCondition {\n  nestedNew();\n}", [
+            makeBranch("Body", [makeNode("FUNCTION_CALL", "nestedNew();")]),
+        ]);
+        oldCall.id = "same-line-range-id";
+        newCall.id = "same-line-range-id";
+        oldCall.branches[0].children[0].id = "same-nested-id";
+        newCall.branches[0].children[0].id = "same-nested-id";
+        oldCall.branches[0].children[0].viewState = { startNodeId: "same-line-range-id" } as any;
+        newCall.branches[0].children[0].viewState = { startNodeId: "same-line-range-id" } as any;
+
+        const merged = mergeFlowModelsForDiff(
+            makeFlow([makeNode("EVENT_START", "start"), oldCall]),
+            makeFlow([makeNode("EVENT_START", "start"), newCall])
+        );
+
+        const hunk = merged.nodes[1];
+        const removed = hunk.branches[0].children[0];
+        const added = hunk.branches[1].children[0];
+        expect(removed.id).not.toBe(added.id);
+        expect(removed.branches[0].children[0].id).not.toBe(added.branches[0].children[0].id);
+        expect(removed.branches[0].children[0].viewState?.startNodeId).toBe(removed.id);
+        expect(added.branches[0].children[0].viewState?.startNodeId).toBe(added.id);
+        expect([removed.id, added.id]).not.toContain("same-line-range-id");
+    });
+
     it("marks a call to the same function with changed content as one modified node", () => {
         const oldFlow = makeFlow([
             makeNode("EVENT_START", "start"),
@@ -215,6 +244,44 @@ describe("mergeFlowModelsForDiff", () => {
         const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
 
         expect(kinds(merged.nodes)).toEqual(["EVENT_START", "RETURN"]);
+    });
+
+    it("preserves semantic whitespace inside string and template literals", () => {
+        const stringDiff = mergeFlowModelsForDiff(makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("RETURN", 'return "a b";'),
+        ]), makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("RETURN", 'return "ab";'),
+        ]));
+        const templateDiff = mergeFlowModelsForDiff(makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("EXPRESSION", "string value = string `line one\n// literal content`;"),
+        ]), makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("EXPRESSION", "string value = string `line one\n// changed literal content`;"),
+        ]));
+
+        expect(stringDiff.nodes[1].diffState).toBe("modified");
+        expect(stringDiff.nodes[1].diffPreviousText).toBe('return "a b";');
+        expect(templateDiff.nodes[1].diffState).toBe("modified");
+    });
+
+    it("finds a container body brace after braces inside literals", () => {
+        const oldIf = makeNode("IF", 'if value == "{" && enabled {\n  run();\n}', [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "run();", undefined, { symbol: "run" })]),
+        ]);
+        const newIf = makeNode("IF", 'if value == "{" && ready {\n  run();\n}', [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "run();", undefined, { symbol: "run" })]),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(
+            makeFlow([makeNode("EVENT_START", "start"), oldIf]),
+            makeFlow([makeNode("EVENT_START", "start"), newIf])
+        );
+
+        expect(merged.nodes[1].diffState).toBe("modified");
+        expect(merged.nodes[1].diffPreviousText).toBe('if value == "{" && enabled');
     });
 
     it("recurses into a container whose header is unchanged", () => {
@@ -442,7 +509,7 @@ describe("mergeFlowModelsForDiff", () => {
         expect(hunk.branches[1].children.every((n) => n.diffState === "added")).toBe(true);
     });
 
-    it("always pairs EVENT_START even when its source changed", () => {
+    it("pairs EVENT_START and marks a changed function signature as modified", () => {
         const oldFlow = makeFlow([makeNode("EVENT_START", "get resource()"), makeNode("RETURN", "return x;")]);
         const newFlow = makeFlow([makeNode("EVENT_START", "get resource(int y)"), makeNode("RETURN", "return x;")]);
 
@@ -450,6 +517,33 @@ describe("mergeFlowModelsForDiff", () => {
 
         expect(kinds(merged.nodes)).toEqual(["EVENT_START", "RETURN"]);
         expect(merged.nodes[0].codedata.sourceCode).toBe("get resource(int y)");
+        expect(merged.nodes[0].diffState).toBe("modified");
+        expect(merged.nodes[0].diffPreviousText).toBe("get resource()");
+    });
+
+    it("uses a bounded coarse diff for very large node lists", () => {
+        const oldMiddle = Array.from({ length: 500 }, (_, index) =>
+            makeNode("FUNCTION_CALL", `old${index}();`, undefined, { symbol: `old${index}` })
+        );
+        const newMiddle = Array.from({ length: 500 }, (_, index) =>
+            makeNode("FUNCTION_CALL", `new${index}();`, undefined, { symbol: `new${index}` })
+        );
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            ...oldMiddle,
+            makeNode("RETURN", "return result;"),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            ...newMiddle,
+            makeNode("RETURN", "return result;"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", DIFF_HUNK_NODE, "RETURN"]);
+        expect(merged.nodes[1].branches[0].children).toHaveLength(500);
+        expect(merged.nodes[1].branches[1].children).toHaveLength(500);
     });
 
     it("does not mutate its inputs", () => {

--- a/packages/bi-diagram/src/test/diff.test.ts
+++ b/packages/bi-diagram/src/test/diff.test.ts
@@ -24,12 +24,20 @@ import { Branch, Flow, FlowNode, NodeKind } from "../utils/types";
 
 let idCounter = 0;
 
-function makeNode(kind: NodeKind, sourceCode: string, branches?: Branch[]): FlowNode {
+interface NodeIdentity {
+    symbol?: string;
+    module?: string;
+    org?: string;
+    varName?: string;
+}
+
+function makeNode(kind: NodeKind, sourceCode: string, branches?: Branch[], identity?: NodeIdentity): FlowNode {
     idCounter += 1;
     return {
         id: `node-${idCounter}`,
         metadata: { label: kind, description: "" },
-        codedata: { node: kind, sourceCode },
+        codedata: { node: kind, sourceCode, symbol: identity?.symbol, module: identity?.module, org: identity?.org },
+        properties: identity?.varName ? ({ variable: { value: identity.varName } } as any) : undefined,
         branches: branches ?? [],
         returning: kind === "RETURN",
     };
@@ -107,17 +115,17 @@ describe("mergeFlowModelsForDiff", () => {
         expect(hunk.branches[0].children[0].codedata.sourceCode).toBe("log(x);");
     });
 
-    it("pairs a replaced statement into a removed+added hunk", () => {
+    it("pairs a statement replaced by a different call into a removed+added hunk", () => {
         const oldFlow = makeFlow([
             makeNode("EVENT_START", "start"),
             makeNode("VARIABLE", "string s = orderValue.status;"),
-            makeNode("FUNCTION_CALL", "logOrderStatusRetrieved(s);"),
+            makeNode("FUNCTION_CALL", "logOrderStatusRetrieved(s);", undefined, { symbol: "logOrderStatusRetrieved" }),
             makeNode("RETURN", "return s;"),
         ]);
         const newFlow = makeFlow([
             makeNode("EVENT_START", "start"),
             makeNode("VARIABLE", "string s = orderValue.status;"),
-            makeNode("FUNCTION_CALL", "io:println(s);"),
+            makeNode("FUNCTION_CALL", "io:println(s);", undefined, { symbol: "println", module: "io", org: "ballerina" }),
             makeNode("RETURN", "return s;"),
         ]);
 
@@ -135,6 +143,71 @@ describe("mergeFlowModelsForDiff", () => {
         expect(hunk.branches[1].children[0].diffState).toBe("added");
     });
 
+    it("marks a call to the same function with changed content as one modified node", () => {
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("FUNCTION_CALL", `io:println("hello");`, undefined, { symbol: "println", module: "io" }),
+            makeNode("RETURN", "return x;"),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("FUNCTION_CALL", `io:println("hello world");`, undefined, { symbol: "println", module: "io" }),
+            makeNode("RETURN", "return x;"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "FUNCTION_CALL", "RETURN"]);
+        expect(merged.nodes[1].diffState).toBe("modified");
+        expect(merged.nodes[1].codedata.sourceCode).toBe(`io:println("hello world");`);
+        expect(merged.nodes[1].diffPreviousText).toBe(`io:println("hello");`);
+        expect(merged.nodes[2].diffState).toBeUndefined();
+    });
+
+    it("marks a variable assigned a different value as one modified node", () => {
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("VARIABLE", "int total = 5;", undefined, { varName: "total" }),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("VARIABLE", "int total = 10;", undefined, { varName: "total" }),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "VARIABLE"]);
+        expect(merged.nodes[1].diffState).toBe("modified");
+        expect(merged.nodes[1].diffPreviousText).toBe("int total = 5;");
+    });
+
+    it("treats a variable replaced by a differently-named one as a removed+added hunk", () => {
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("VARIABLE", "int total = 5;", undefined, { varName: "total" }),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("VARIABLE", `string name = "x";`, undefined, { varName: "name" }),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", DIFF_HUNK_NODE]);
+        expect(hunkBranchLabels(merged.nodes[1])).toEqual(["Removed", "Added"]);
+    });
+
+    it("marks a one-for-one edit of an identity-less node (RETURN) as modified", () => {
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return a;")]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return a + b;")]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "RETURN"]);
+        expect(merged.nodes[1].diffState).toBe("modified");
+        expect(merged.nodes[1].diffPreviousText).toBe("return a;");
+    });
+
     it("ignores whitespace-only differences", () => {
         const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return  x ;")]);
         const newFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return x;")]);
@@ -146,10 +219,10 @@ describe("mergeFlowModelsForDiff", () => {
 
     it("recurses into a container whose header is unchanged", () => {
         const oldIf = makeNode("IF", "if x > 5 {\n  log(x);\n}", [
-            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);")]),
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);", undefined, { symbol: "log" })]),
         ]);
         const newIf = makeNode("IF", "if x > 5 {\n  io:println(x);\n}", [
-            makeBranch("Then", [makeNode("FUNCTION_CALL", "io:println(x);")]),
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "io:println(x);", undefined, { symbol: "println", module: "io" })]),
         ]);
         const oldFlow = makeFlow([makeNode("EVENT_START", "start"), oldIf]);
         const newFlow = makeFlow([makeNode("EVENT_START", "start"), newIf]);
@@ -164,15 +237,39 @@ describe("mergeFlowModelsForDiff", () => {
         expect(hunkBranchLabels(hunk)).toEqual(["Removed", "Added"]);
     });
 
-    it("treats a container with a changed header as removed+added pair", () => {
+    it("marks a container with a changed header as modified and still recurses into its body", () => {
         const oldIf = makeNode("IF", "if x > 5 {\n  log(x);\n}", [
-            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);")]),
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);", undefined, { symbol: "log" })]),
         ]);
         const newIf = makeNode("IF", "if x > 10 {\n  log(x);\n}", [
-            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);")]),
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);", undefined, { symbol: "log" })]),
         ]);
         const oldFlow = makeFlow([makeNode("EVENT_START", "start"), oldIf]);
         const newFlow = makeFlow([makeNode("EVENT_START", "start"), newIf]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "IF"]);
+        const ifNode = merged.nodes[1];
+        expect(ifNode.diffState).toBe("modified");
+        // the old header (not the whole body) is carried for the hover card
+        expect(ifNode.diffPreviousText).toBe("if x > 5");
+        // unchanged body is left alone — no hunks, no stamps
+        expect(kinds(ifNode.branches[0].children)).toEqual(["FUNCTION_CALL"]);
+        expect(ifNode.branches[0].children[0].diffState).toBeUndefined();
+    });
+
+    it("replaces a container by a different kind of node as a removed+added hunk", () => {
+        const oldIf = makeNode("IF", "if x > 5 {\n  log(x);\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);", undefined, { symbol: "log" })]),
+        ]);
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), oldIf]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("WHILE", "while x > 5 {\n  log(x);\n}", [
+                makeBranch("Body", [makeNode("FUNCTION_CALL", "log(x);", undefined, { symbol: "log" })]),
+            ]),
+        ]);
 
         const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
 
@@ -223,7 +320,7 @@ describe("mergeFlowModelsForDiff", () => {
         expect(ifNode.branches[1].children[0].diffState).toBe("added");
     });
 
-    it("treats a note (comment) text change as unchanged", () => {
+    it("stamps an edited note (comment) without hunking the following statement", () => {
         // Statement sourceCode from the LS includes the leading comment line,
         // so both the COMMENT node and the following statement differ textually.
         const oldFlow = makeFlow([
@@ -240,12 +337,33 @@ describe("mergeFlowModelsForDiff", () => {
         const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
 
         expect(kinds(merged.nodes)).toEqual(["EVENT_START", "COMMENT", "FUNCTION_CALL"]);
-        expect(merged.nodes.every((n) => n.diffState === undefined)).toBe(true);
-        // the new note text is kept
+        // the statement itself is unchanged — no hunk, no stamp
+        expect(merged.nodes[2].diffState).toBeUndefined();
+        // the edited note keeps the new text and carries the old one for the chip
         expect(merged.nodes[1].codedata.sourceCode).toBe("// new note");
+        expect(merged.nodes[1].diffState).toBe("modified");
+        expect(merged.nodes[1].diffPreviousText).toBe("// old note");
     });
 
-    it("emits an added-only comment inline without a hunk", () => {
+    it("leaves an unchanged note unstamped", () => {
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// same note"),
+            makeNode("RETURN", "return x;"),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// same note"),
+            makeNode("RETURN", "return x;"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "COMMENT", "RETURN"]);
+        expect(merged.nodes.every((n) => n.diffState === undefined)).toBe(true);
+    });
+
+    it("emits an added-only comment inline as added, without a hunk", () => {
         const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return x;")]);
         const newFlow = makeFlow([
             makeNode("EVENT_START", "start"),
@@ -256,10 +374,11 @@ describe("mergeFlowModelsForDiff", () => {
         const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
 
         expect(kinds(merged.nodes)).toEqual(["EVENT_START", "COMMENT", "RETURN"]);
-        expect(merged.nodes[1].diffState).toBeUndefined();
+        expect(merged.nodes[1].diffState).toBe("added");
+        expect(merged.nodes[2].diffState).toBeUndefined();
     });
 
-    it("drops a removed-only comment without a hunk", () => {
+    it("keeps a removed-only comment inline as removed, without a hunk", () => {
         const oldFlow = makeFlow([
             makeNode("EVENT_START", "start"),
             makeNode("COMMENT", "// obsolete note"),
@@ -269,15 +388,21 @@ describe("mergeFlowModelsForDiff", () => {
 
         const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
 
-        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "RETURN"]);
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "COMMENT", "RETURN"]);
+        expect(merged.nodes[1].diffState).toBe("removed");
+        expect(merged.nodes[1].codedata.sourceCode).toBe("// obsolete note");
+        expect(merged.nodes[2].diffState).toBeUndefined();
     });
 
     it("keeps a comment inside a hunk lane when it accompanies changed code", () => {
-        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("FUNCTION_CALL", "log(x);")]);
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("FUNCTION_CALL", "log(x);", undefined, { symbol: "log" }),
+        ]);
         const newFlow = makeFlow([
             makeNode("EVENT_START", "start"),
             makeNode("COMMENT", "// print instead of log"),
-            makeNode("FUNCTION_CALL", "io:println(x);"),
+            makeNode("FUNCTION_CALL", "io:println(x);", undefined, { symbol: "println", module: "io" }),
         ]);
 
         const merged = mergeFlowModelsForDiff(oldFlow, newFlow);

--- a/packages/bi-diagram/src/test/diff.test.ts
+++ b/packages/bi-diagram/src/test/diff.test.ts
@@ -1,0 +1,327 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { mergeFlowModelsForDiff, stampDiffState, DIFF_HUNK_NODE } from "../utils/diff";
+import { Branch, Flow, FlowNode, NodeKind } from "../utils/types";
+
+let idCounter = 0;
+
+function makeNode(kind: NodeKind, sourceCode: string, branches?: Branch[]): FlowNode {
+    idCounter += 1;
+    return {
+        id: `node-${idCounter}`,
+        metadata: { label: kind, description: "" },
+        codedata: { node: kind, sourceCode },
+        branches: branches ?? [],
+        returning: kind === "RETURN",
+    };
+}
+
+function makeBranch(label: string, children: FlowNode[], kind: NodeKind = "CONDITIONAL"): Branch {
+    return {
+        label,
+        kind: "block",
+        codedata: { node: kind },
+        repeatable: "ONE",
+        properties: {},
+        children,
+    };
+}
+
+function makeFlow(nodes: FlowNode[]): Flow {
+    return { fileName: "main.bal", nodes };
+}
+
+function kinds(nodes: FlowNode[]): string[] {
+    return nodes.map((n) => n.codedata.node as string);
+}
+
+function hunkBranchLabels(hunk: FlowNode): string[] {
+    return hunk.branches.map((b) => b.label);
+}
+
+describe("mergeFlowModelsForDiff", () => {
+    beforeEach(() => {
+        idCounter = 0;
+    });
+
+    it("returns identical flow unchanged with no hunks", () => {
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return 1;")]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return 1;")]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "RETURN"]);
+        expect(merged.nodes.every((n) => n.diffState === undefined)).toBe(true);
+    });
+
+    it("wraps a pure insertion in a hunk with only an added branch", () => {
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return x;")]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("FUNCTION_CALL", "io:println(x);"),
+            makeNode("RETURN", "return x;"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", DIFF_HUNK_NODE, "RETURN"]);
+        const hunk = merged.nodes[1];
+        expect(hunkBranchLabels(hunk)).toEqual(["Added"]);
+        expect(hunk.branches[0].children[0].diffState).toBe("added");
+        expect(hunk.branches[0].children[0].codedata.sourceCode).toBe("io:println(x);");
+    });
+
+    it("wraps a pure deletion in a hunk with only a removed branch", () => {
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("FUNCTION_CALL", "log(x);"),
+            makeNode("RETURN", "return x;"),
+        ]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return x;")]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", DIFF_HUNK_NODE, "RETURN"]);
+        const hunk = merged.nodes[1];
+        expect(hunkBranchLabels(hunk)).toEqual(["Removed"]);
+        expect(hunk.branches[0].children[0].diffState).toBe("removed");
+        expect(hunk.branches[0].children[0].codedata.sourceCode).toBe("log(x);");
+    });
+
+    it("pairs a replaced statement into a removed+added hunk", () => {
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("VARIABLE", "string s = orderValue.status;"),
+            makeNode("FUNCTION_CALL", "logOrderStatusRetrieved(s);"),
+            makeNode("RETURN", "return s;"),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("VARIABLE", "string s = orderValue.status;"),
+            makeNode("FUNCTION_CALL", "io:println(s);"),
+            makeNode("RETURN", "return s;"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "VARIABLE", DIFF_HUNK_NODE, "RETURN"]);
+        const hunk = merged.nodes[2];
+        // dash-free id: `<id>-lastNode`/`<id>-StartContainer` custom ids are parsed by
+        // reverseCustomNodeId (splits on "-"), e.g. for rendering the End node after a hunk
+        expect(hunk.id).not.toContain("-");
+        expect(hunkBranchLabels(hunk)).toEqual(["Removed", "Added"]);
+        expect(hunk.branches[0].children[0].codedata.sourceCode).toBe("logOrderStatusRetrieved(s);");
+        expect(hunk.branches[0].children[0].diffState).toBe("removed");
+        expect(hunk.branches[1].children[0].codedata.sourceCode).toBe("io:println(s);");
+        expect(hunk.branches[1].children[0].diffState).toBe("added");
+    });
+
+    it("ignores whitespace-only differences", () => {
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return  x ;")]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return x;")]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "RETURN"]);
+    });
+
+    it("recurses into a container whose header is unchanged", () => {
+        const oldIf = makeNode("IF", "if x > 5 {\n  log(x);\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);")]),
+        ]);
+        const newIf = makeNode("IF", "if x > 5 {\n  io:println(x);\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "io:println(x);")]),
+        ]);
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), oldIf]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), newIf]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "IF"]);
+        const ifNode = merged.nodes[1];
+        expect(ifNode.diffState).toBeUndefined();
+        expect(kinds(ifNode.branches[0].children)).toEqual([DIFF_HUNK_NODE]);
+        const hunk = ifNode.branches[0].children[0];
+        expect(hunkBranchLabels(hunk)).toEqual(["Removed", "Added"]);
+    });
+
+    it("treats a container with a changed header as removed+added pair", () => {
+        const oldIf = makeNode("IF", "if x > 5 {\n  log(x);\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);")]),
+        ]);
+        const newIf = makeNode("IF", "if x > 10 {\n  log(x);\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "log(x);")]),
+        ]);
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), oldIf]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), newIf]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", DIFF_HUNK_NODE]);
+        const hunk = merged.nodes[1];
+        expect(hunkBranchLabels(hunk)).toEqual(["Removed", "Added"]);
+        expect(hunk.branches[0].children[0].codedata.node).toBe("IF");
+        expect(hunk.branches[0].children[0].diffState).toBe("removed");
+        // nested children are stamped too
+        expect(hunk.branches[0].children[0].branches[0].children[0].diffState).toBe("removed");
+        expect(hunk.branches[1].children[0].diffState).toBe("added");
+    });
+
+    it("keeps a branch removed in the new version and stamps its children", () => {
+        const oldIf = makeNode("IF", "if x {\n  a();\n} else {\n  b();\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "a();")]),
+            makeBranch("Else", [makeNode("FUNCTION_CALL", "b();")], "ELSE"),
+        ]);
+        const newIf = makeNode("IF", "if x {\n  a();\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "a();")]),
+        ]);
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), oldIf]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), newIf]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        const ifNode = merged.nodes[1];
+        expect(ifNode.codedata.node).toBe("IF");
+        expect(ifNode.branches.map((b) => b.label)).toEqual(["Then", "Else"]);
+        expect(ifNode.branches[1].children[0].diffState).toBe("removed");
+    });
+
+    it("stamps an added branch's children in the new version", () => {
+        const oldIf = makeNode("IF", "if x {\n  a();\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "a();")]),
+        ]);
+        const newIf = makeNode("IF", "if x {\n  a();\n} else {\n  b();\n}", [
+            makeBranch("Then", [makeNode("FUNCTION_CALL", "a();")]),
+            makeBranch("Else", [makeNode("FUNCTION_CALL", "b();")], "ELSE"),
+        ]);
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), oldIf]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), newIf]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        const ifNode = merged.nodes[1];
+        expect(ifNode.branches[1].label).toBe("Else");
+        expect(ifNode.branches[1].children[0].diffState).toBe("added");
+    });
+
+    it("treats a note (comment) text change as unchanged", () => {
+        // Statement sourceCode from the LS includes the leading comment line,
+        // so both the COMMENT node and the following statement differ textually.
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// old note"),
+            makeNode("FUNCTION_CALL", "// old note\nsyncEmailHeadings(firstRun);"),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// new note"),
+            makeNode("FUNCTION_CALL", "// new note\nsyncEmailHeadings(firstRun);"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "COMMENT", "FUNCTION_CALL"]);
+        expect(merged.nodes.every((n) => n.diffState === undefined)).toBe(true);
+        // the new note text is kept
+        expect(merged.nodes[1].codedata.sourceCode).toBe("// new note");
+    });
+
+    it("emits an added-only comment inline without a hunk", () => {
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return x;")]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// explain the return"),
+            makeNode("RETURN", "return x;"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "COMMENT", "RETURN"]);
+        expect(merged.nodes[1].diffState).toBeUndefined();
+    });
+
+    it("drops a removed-only comment without a hunk", () => {
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// obsolete note"),
+            makeNode("RETURN", "return x;"),
+        ]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return x;")]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "RETURN"]);
+    });
+
+    it("keeps a comment inside a hunk lane when it accompanies changed code", () => {
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("FUNCTION_CALL", "log(x);")]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// print instead of log"),
+            makeNode("FUNCTION_CALL", "io:println(x);"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", DIFF_HUNK_NODE]);
+        const hunk = merged.nodes[1];
+        expect(hunkBranchLabels(hunk)).toEqual(["Removed", "Added"]);
+        expect(kinds(hunk.branches[1].children)).toEqual(["COMMENT", "FUNCTION_CALL"]);
+        expect(hunk.branches[1].children.every((n) => n.diffState === "added")).toBe(true);
+    });
+
+    it("always pairs EVENT_START even when its source changed", () => {
+        const oldFlow = makeFlow([makeNode("EVENT_START", "get resource()"), makeNode("RETURN", "return x;")]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "get resource(int y)"), makeNode("RETURN", "return x;")]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "RETURN"]);
+        expect(merged.nodes[0].codedata.sourceCode).toBe("get resource(int y)");
+    });
+
+    it("does not mutate its inputs", () => {
+        const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("FUNCTION_CALL", "log(x);")]);
+        const newFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("FUNCTION_CALL", "io:println(x);")]);
+
+        mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(oldFlow.nodes[1].diffState).toBeUndefined();
+        expect(newFlow.nodes[1].diffState).toBeUndefined();
+    });
+});
+
+describe("stampDiffState", () => {
+    it("stamps all nodes recursively without mutating the input", () => {
+        const flow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("IF", "if x {\n  a();\n}", [makeBranch("Then", [makeNode("FUNCTION_CALL", "a();")])]),
+        ]);
+
+        const stamped = stampDiffState(flow, "added");
+
+        expect(stamped.nodes[0].diffState).toBe("added");
+        expect(stamped.nodes[1].diffState).toBe("added");
+        expect(stamped.nodes[1].branches[0].children[0].diffState).toBe("added");
+        expect(flow.nodes[0].diffState).toBeUndefined();
+    });
+});

--- a/packages/bi-diagram/src/test/diff.test.ts
+++ b/packages/bi-diagram/src/test/diff.test.ts
@@ -363,6 +363,34 @@ describe("mergeFlowModelsForDiff", () => {
         expect(merged.nodes.every((n) => n.diffState === undefined)).toBe(true);
     });
 
+    it("marks an inserted note as added and leaves the existing note unchanged", () => {
+        // A note inserted above an existing one must not mispair: because every comment
+        // once shared a single match key, the LCS could pair the inserted note with the
+        // existing one (marking the insert "modified" and the original "added").
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// keep this"),
+            makeNode("RETURN", "return x;"),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "start"),
+            makeNode("COMMENT", "// brand new"),
+            makeNode("COMMENT", "// keep this"),
+            makeNode("RETURN", "return x;"),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(kinds(merged.nodes)).toEqual(["EVENT_START", "COMMENT", "COMMENT", "RETURN"]);
+        // the inserted note is added...
+        expect(merged.nodes[1].codedata.sourceCode).toBe("// brand new");
+        expect(merged.nodes[1].diffState).toBe("added");
+        // ...and the existing note is untouched (not shown as modified/added)
+        expect(merged.nodes[2].codedata.sourceCode).toBe("// keep this");
+        expect(merged.nodes[2].diffState).toBeUndefined();
+        expect(merged.nodes[3].diffState).toBeUndefined();
+    });
+
     it("emits an added-only comment inline as added, without a hunk", () => {
         const oldFlow = makeFlow([makeNode("EVENT_START", "start"), makeNode("RETURN", "return x;")]);
         const newFlow = makeFlow([

--- a/packages/bi-diagram/src/test/diff.test.ts
+++ b/packages/bi-diagram/src/test/diff.test.ts
@@ -521,6 +521,22 @@ describe("mergeFlowModelsForDiff", () => {
         expect(merged.nodes[0].diffPreviousText).toBe("get resource()");
     });
 
+    it("does not mark EVENT_START modified when only its embedded function body changes", () => {
+        const oldFlow = makeFlow([
+            makeNode("EVENT_START", "function onError() {\n    log:printError(\"old\");\n}"),
+            makeNode("FUNCTION_CALL", "log:printError(\"old\");", undefined, { symbol: "printError", module: "log" }),
+        ]);
+        const newFlow = makeFlow([
+            makeNode("EVENT_START", "function onError() {\n    log:printError(\"new\");\n}"),
+            makeNode("FUNCTION_CALL", "log:printError(\"new\");", undefined, { symbol: "printError", module: "log" }),
+        ]);
+
+        const merged = mergeFlowModelsForDiff(oldFlow, newFlow);
+
+        expect(merged.nodes[0].diffState).toBeUndefined();
+        expect(merged.nodes[1].diffState).toBe("modified");
+    });
+
     it("uses a bounded coarse diff for very large node lists", () => {
         const oldMiddle = Array.from({ length: 500 }, (_, index) =>
             makeNode("FUNCTION_CALL", `old${index}();`, undefined, { symbol: `old${index}` })

--- a/packages/bi-diagram/src/test/jest.env.ts
+++ b/packages/bi-diagram/src/test/jest.env.ts
@@ -39,6 +39,9 @@ jest.mock('resize-observer-polyfill', () => {
   };
 });
 
+// DOM mocks — skip in non-DOM test environments (e.g. @jest-environment node)
+if (typeof Element !== 'undefined') {
+
 // Mock getBoundingClientRect for canvas elements
 Element.prototype.getBoundingClientRect = jest.fn(() => ({
   width: 800,
@@ -77,4 +80,6 @@ HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
   strokeStyle: '',
   globalAlpha: 1,
 })) as any;
+
+}
 

--- a/packages/bi-diagram/src/test/matchMedia.ts
+++ b/packages/bi-diagram/src/test/matchMedia.ts
@@ -16,20 +16,23 @@
  * under the License.
  */
 
-Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-    })),
-});
+// Skip in non-DOM test environments (e.g. @jest-environment node for pure-logic tests)
+if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
 
-window.HTMLElement.prototype.scrollIntoView = jest.fn()
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+}
 
 

--- a/packages/bi-diagram/src/test/node-factory-comments.test.ts
+++ b/packages/bi-diagram/src/test/node-factory-comments.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ */
+
+import { NodeFactoryVisitor } from "../visitors/NodeFactoryVisitor";
+import { FlowNode, NodeKind } from "../utils/types";
+
+function makeNode(id: string, kind: NodeKind, sourceCode: string): FlowNode {
+    return {
+        id,
+        metadata: { label: kind, description: sourceCode },
+        codedata: { node: kind, sourceCode },
+        branches: [],
+        returning: false,
+        viewState: {
+            x: 0,
+            y: 0,
+            lw: 0,
+            rw: 0,
+            h: 0,
+            clw: 0,
+            crw: 0,
+            ch: 0,
+        },
+    };
+}
+
+describe("NodeFactoryVisitor comment attachment", () => {
+    it("keeps every consecutive comment on the following node", () => {
+        const visitor = new NodeFactoryVisitor();
+        const start = makeNode("start", "EVENT_START", "start");
+        const first = makeNode("comment-1", "COMMENT", "// first");
+        const second = makeNode("comment-2", "COMMENT", "// second");
+        const statement = makeNode("statement", "EXPRESSION", "doWork();");
+
+        visitor.beginVisitEventStart(start);
+        visitor.beginVisitComment(first);
+        visitor.beginVisitComment(second);
+        visitor.beginVisitNode(statement);
+
+        expect(visitor.getNodeComments().get(statement.id)).toEqual([first, second]);
+    });
+
+    it("attaches trailing comments to the preceding visible node", () => {
+        const visitor = new NodeFactoryVisitor();
+        const start = makeNode("start", "EVENT_START", "start");
+        const trailing = makeNode("trailing-comment", "COMMENT", "// trailing");
+
+        visitor.beginVisitEventStart(start);
+        visitor.beginVisitComment(trailing);
+
+        expect(visitor.getNodeComments().get(start.id)).toEqual([trailing]);
+    });
+});

--- a/packages/bi-diagram/src/utils/diagram.ts
+++ b/packages/bi-diagram/src/utils/diagram.ts
@@ -21,7 +21,7 @@ import { NodePortFactory, NodePortModel } from "../components/NodePort";
 import { NodeLinkFactory, NodeLinkModel, NodeLinkModelOptions } from "../components/NodeLink";
 import { EmptyNodeFactory } from "../components/nodes/EmptyNode";
 import { OverlayLayerFactory } from "../components/OverlayLayer";
-import { LinkableNodeModel, NodeModel } from "./types";
+import { FlowNode, FlowNodeDiffState, LinkableNodeModel, NodeModel } from "./types";
 import { VerticalScrollCanvasAction } from "../actions/VerticalScrollCanvasAction";
 import { IfNodeFactory } from "../components/nodes/IfNode/IfNodeFactory";
 import { StartNodeFactory } from "../components/nodes/StartNode/StartNodeFactory";
@@ -100,12 +100,24 @@ export function createNodesLink(sourceNode: NodeModel, targetNode: NodeModel, op
     const source = sourceNode as LinkableNodeModel;
     const target = targetNode as LinkableNodeModel;
 
+    // Links attached to a review-diff node inherit its removed/added styling
+    const diffState = getNodeDiffState(targetNode) ?? getNodeDiffState(sourceNode);
+    if (diffState && !options?.diffState) {
+        options = { ...options, diffState };
+    }
+
     const sourcePort = source.getOutPort();
     const targetPort = target.getInPort();
     const link = createPortsLink(sourcePort, targetPort, options);
     link.setSourceNode(sourceNode);
     link.setTargetNode(targetNode);
     return link;
+}
+
+// get the diff state of the flow node wrapped by a diagram node model, if any
+function getNodeDiffState(nodeModel: NodeModel): FlowNodeDiffState | undefined {
+    const flowNode = (nodeModel as { node?: FlowNode }).node;
+    return flowNode?.diffState;
 }
 
 // save diagram zoom level and position to local storage

--- a/packages/bi-diagram/src/utils/diagram.ts
+++ b/packages/bi-diagram/src/utils/diagram.ts
@@ -114,10 +114,12 @@ export function createNodesLink(sourceNode: NodeModel, targetNode: NodeModel, op
     return link;
 }
 
-// get the diff state of the flow node wrapped by a diagram node model, if any
+// get the diff state of the flow node wrapped by a diagram node model, if any.
+// Modified nodes sit inline in the main flow, so their links stay unstyled.
 function getNodeDiffState(nodeModel: NodeModel): FlowNodeDiffState | undefined {
     const flowNode = (nodeModel as { node?: FlowNode }).node;
-    return flowNode?.diffState;
+    const diffState = flowNode?.diffState;
+    return diffState === "added" || diffState === "removed" ? diffState : undefined;
 }
 
 // save diagram zoom level and position to local storage

--- a/packages/bi-diagram/src/utils/diff.ts
+++ b/packages/bi-diagram/src/utils/diff.ts
@@ -23,7 +23,23 @@ export const DIFF_HUNK_NODE = "DIFF_HUNK";
 export const DIFF_REMOVED_BRANCH_LABEL = "Removed";
 export const DIFF_ADDED_BRANCH_LABEL = "Added";
 
-type NodeMatch = "exact" | "container" | null;
+type NodeMatch = "exact" | "container" | "container-modified" | "modified" | null;
+
+// Exact matches outrank header-equal containers, which outrank content edits, so an
+// unchanged sibling is always preferred as an alignment anchor over a modified pairing.
+function matchScore(match: NodeMatch): number {
+    switch (match) {
+        case "exact":
+            return 3;
+        case "container":
+            return 2;
+        case "container-modified":
+        case "modified":
+            return 1;
+        default:
+            return 0;
+    }
+}
 
 /**
  * Merges the old and new flow models of the same function into a single flow model
@@ -77,7 +93,36 @@ function isComment(node: FlowNode): boolean {
     return node.codedata?.node === "COMMENT";
 }
 
+/**
+ * Display text of a COMMENT node — shared by the note chip and the diff merge
+ * so edit detection and rendering always read the same accessors.
+ * (Lives here rather than utils/node.ts to keep this module free of UI imports.)
+ */
+export function getCommentText(node: FlowNode): string {
+    const properties = node.properties as Record<string, { value?: unknown }> | undefined;
+    const value = properties?.comment?.value;
+    return node.metadata?.description || (typeof value === "string" ? value : "");
+}
+
+// Comment text normalized for comparison: whitespace-collapsed, sourceCode fallback.
+function commentText(node: FlowNode): string {
+    const raw = getCommentText(node) || node.codedata?.sourceCode || "";
+    return raw.replace(/\s+/g, " ").trim();
+}
+
+// Memoized: alignNodes compares every old/new node pair, so keys are requested O(n·m) times.
+const nodeKeyCache = new WeakMap<FlowNode, string>();
 function nodeKey(node: FlowNode): string {
+    const cached = nodeKeyCache.get(node);
+    if (cached !== undefined) {
+        return cached;
+    }
+    const key = computeNodeKey(node);
+    nodeKeyCache.set(node, key);
+    return key;
+}
+
+function computeNodeKey(node: FlowNode): string {
     // Comments pair positionally regardless of text — a note edit is not a code change.
     if (isComment(node)) {
         return "kind:COMMENT";
@@ -96,16 +141,53 @@ function hasBranches(node: FlowNode): boolean {
     return Array.isArray(node.branches) && node.branches.length > 0;
 }
 
-// Header of a container node: the source up to the first block opening brace,
-// e.g. `if count > 5`, `while true`, `foreach var item in items`.
-function containerHeaderKey(node: FlowNode): string {
-    const source = node.codedata?.sourceCode;
-    if (!source) {
-        return `kind:${node.codedata?.node}`;
+// What a node *refers to*, independent of its content: the called symbol for calls
+// (org/module/object/symbol) or the declared variable name. Two nodes with the same
+// identity but different source are the same node with edited content, not a replacement.
+// Returns null for kinds with no identity (RETURN, EXPRESSION, ...).
+function nodeIdentityKey(node: FlowNode): string | null {
+    const codedata = node.codedata;
+    const symbolParts = [codedata?.org, codedata?.module, codedata?.object, codedata?.symbol].filter(Boolean);
+    if (symbolParts.length > 0) {
+        return `${codedata?.node}:${symbolParts.join("/")}`;
     }
-    const normalized = normalizeSource(stripCommentLines(source));
-    const braceIndex = normalized.indexOf("{");
-    return braceIndex >= 0 ? normalized.slice(0, braceIndex) : normalized;
+    const properties = node.properties as Record<string, { value?: unknown }> | undefined;
+    const variableName = properties?.variable?.value;
+    if (typeof variableName === "string" && variableName) {
+        return `${codedata?.node}:var:${variableName}`;
+    }
+    return null;
+}
+
+// Text before the first block opening brace, e.g. `if count > 5`, `while true`.
+function headerBeforeBrace(text: string): string {
+    const braceIndex = text.indexOf("{");
+    return braceIndex >= 0 ? text.slice(0, braceIndex) : text;
+}
+
+/**
+ * Human-readable source of a node for diff UI (the modified-node hover card):
+ * containers show only their header, since their sourceCode holds the whole body.
+ */
+export function getDiffDisplaySource(node: FlowNode): string {
+    const source = node.codedata?.sourceCode ?? "";
+    const text = hasBranches(node) ? headerBeforeBrace(source) : source;
+    return text.trim();
+}
+
+// Header of a container node, normalized for comparison.
+const containerHeaderKeyCache = new WeakMap<FlowNode, string>();
+function containerHeaderKey(node: FlowNode): string {
+    const cached = containerHeaderKeyCache.get(node);
+    if (cached !== undefined) {
+        return cached;
+    }
+    const source = node.codedata?.sourceCode;
+    const key = source
+        ? headerBeforeBrace(normalizeSource(stripCommentLines(source)))
+        : `kind:${node.codedata?.node}`;
+    containerHeaderKeyCache.set(node, key);
+    return key;
 }
 
 function matchNodes(oldNode: FlowNode, newNode: FlowNode): NodeMatch {
@@ -119,8 +201,14 @@ function matchNodes(oldNode: FlowNode, newNode: FlowNode): NodeMatch {
     if (nodeKey(oldNode) === nodeKey(newNode)) {
         return "exact";
     }
-    if (hasBranches(oldNode) && hasBranches(newNode) && containerHeaderKey(oldNode) === containerHeaderKey(newNode)) {
-        return "container";
+    if (hasBranches(oldNode) && hasBranches(newNode)) {
+        // Same container kind: header equal → recurse silently; header edited (condition,
+        // iterable, ...) → still recurse, but mark the container itself as modified.
+        return containerHeaderKey(oldNode) === containerHeaderKey(newNode) ? "container" : "container-modified";
+    }
+    const identity = nodeIdentityKey(oldNode);
+    if (identity && identity === nodeIdentityKey(newNode)) {
+        return "modified";
     }
     return null;
 }
@@ -138,16 +226,41 @@ function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter:
         oldIndex = oldEnd;
         newIndex = newEnd;
 
+        // A one-for-one replacement by the same kind of identity-less node (RETURN,
+        // EXPRESSION, ...) is a content edit: render one modified node, not two lanes.
+        // Identity-carrying kinds pair via matchNodes instead, so differing identities
+        // (a genuinely different call or variable) still fall through to a hunk.
+        const removedCode = removedRun.filter((node) => !isComment(node));
+        const addedCode = addedRun.filter((node) => !isComment(node));
+        if (removedCode.length === 1 && addedCode.length === 1 && isContentEdit(removedCode[0], addedCode[0])) {
+            const removedComments = removedRun.filter(isComment);
+            removedComments.forEach((node) => stampNodeDeep(node, "removed"));
+            merged.push(...removedComments);
+            for (const node of addedRun) {
+                if (node === addedCode[0]) {
+                    merged.push(markModified(node, removedCode[0]));
+                } else {
+                    stampNodeDeep(node, "added");
+                    merged.push(node);
+                }
+            }
+            return;
+        }
+
         // Comments render as note chips on the following node, never as widgets, so a
-        // comment-only lane would render nothing. Comment-only runs are kept out of hunks:
-        // added comments flow through inline (chip on the next node), removed ones drop out.
-        const removedLane = removedRun.some((node) => !isComment(node)) ? removedRun : [];
-        const addedHasCode = addedRun.some((node) => !isComment(node));
-        const addedLane = addedHasCode ? addedRun : [];
+        // comment-only lane would render nothing. Comment-only runs are kept out of hunks
+        // and flow through inline, stamped so the chip renders the change.
+        const removedLane = removedCode.length > 0 ? removedRun : [];
+        const addedLane = addedCode.length > 0 ? addedRun : [];
+        if (removedCode.length === 0) {
+            removedRun.forEach((node) => stampNodeDeep(node, "removed"));
+            merged.push(...removedRun);
+        }
         if (removedLane.length > 0 || addedLane.length > 0) {
             merged.push(createDiffHunk(removedLane, addedLane, hunkCounter));
         }
-        if (!addedHasCode) {
+        if (addedCode.length === 0) {
+            addedRun.forEach((node) => stampNodeDeep(node, "added"));
             merged.push(...addedRun);
         }
     };
@@ -156,11 +269,22 @@ function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter:
         flushGap(pair.oldIndex, pair.newIndex);
         const oldNode = oldNodes[pair.oldIndex];
         const newNode = newNodes[pair.newIndex];
-        if (pair.match === "container") {
-            merged.push({
+        if (pair.match === "container" || pair.match === "container-modified") {
+            const mergedContainer: FlowNode = {
                 ...newNode,
                 branches: mergeBranches(oldNode.branches ?? [], newNode.branches ?? [], hunkCounter),
-            });
+            };
+            if (pair.match === "container-modified") {
+                mergedContainer.diffState = "modified";
+                mergedContainer.diffPreviousText = getDiffDisplaySource(oldNode) || undefined;
+            }
+            merged.push(mergedContainer);
+        } else if (pair.match === "modified") {
+            merged.push(markModified(newNode, oldNode));
+        } else if (isComment(newNode) && commentText(oldNode) !== commentText(newNode)) {
+            // Comments pair positionally, so an edited note lands here as an "exact" match.
+            // Mark it modified so the note chip renders the old and new texts.
+            merged.push(markModified(newNode, oldNode));
         } else {
             merged.push(newNode);
         }
@@ -196,6 +320,25 @@ function mergeBranches(oldBranches: Branch[], newBranches: Branch[], hunkCounter
     });
 
     return merged;
+}
+
+function isContentEdit(oldNode: FlowNode, newNode: FlowNode): boolean {
+    return (
+        oldNode.codedata?.node === newNode.codedata?.node &&
+        !hasBranches(oldNode) &&
+        !hasBranches(newNode) &&
+        nodeIdentityKey(oldNode) === null &&
+        nodeIdentityKey(newNode) === null
+    );
+}
+
+function markModified(newNode: FlowNode, oldNode: FlowNode): FlowNode {
+    const previousText = isComment(oldNode) ? commentText(oldNode) : getDiffDisplaySource(oldNode);
+    return {
+        ...newNode,
+        diffState: "modified",
+        diffPreviousText: previousText || undefined,
+    };
 }
 
 function createDiffHunk(removedRun: FlowNode[], addedRun: FlowNode[], hunkCounter: { count: number }): FlowNode {
@@ -257,11 +400,10 @@ function alignNodes(oldNodes: FlowNode[], newNodes: FlowNode[]): AlignedPair[] {
     for (let i = n - 1; i >= 0; i--) {
         for (let j = m - 1; j >= 0; j--) {
             const match = matchTable[i][j];
-            const matchScore = match === "exact" ? 2 : match === "container" ? 1 : 0;
             scores[i][j] = Math.max(
                 scores[i + 1][j],
                 scores[i][j + 1],
-                match ? scores[i + 1][j + 1] + matchScore : 0
+                match ? scores[i + 1][j + 1] + matchScore(match) : 0
             );
         }
     }
@@ -271,8 +413,7 @@ function alignNodes(oldNodes: FlowNode[], newNodes: FlowNode[]): AlignedPair[] {
     let j = 0;
     while (i < n && j < m) {
         const match = matchTable[i][j];
-        const matchScore = match === "exact" ? 2 : match === "container" ? 1 : 0;
-        if (match && scores[i][j] === scores[i + 1][j + 1] + matchScore) {
+        if (match && scores[i][j] === scores[i + 1][j + 1] + matchScore(match)) {
             aligned.push({ oldIndex: i, newIndex: j, match });
             i++;
             j++;

--- a/packages/bi-diagram/src/utils/diff.ts
+++ b/packages/bi-diagram/src/utils/diff.ts
@@ -25,6 +25,15 @@ export const DIFF_ADDED_BRANCH_LABEL = "Added";
 
 type NodeMatch = "exact" | "container" | "container-modified" | "modified" | null;
 
+interface DiffCounters {
+    hunk: number;
+    namespace: number;
+}
+
+// Each cell currently costs one NodeMatch entry and one numeric score entry. Keep the
+// quadratic path bounded so a generated function cannot exhaust or block the webview.
+const MAX_LCS_MATRIX_CELLS = 250_000;
+
 // Exact matches outrank header-equal containers, which outrank content edits, so an
 // unchanged sibling is always preferred as an alignment anchor over a modified pairing.
 function matchScore(match: NodeMatch): number {
@@ -48,12 +57,12 @@ function matchScore(match: NodeMatch): number {
  * `diffState` so widgets can render them accordingly.
  */
 export function mergeFlowModelsForDiff(oldFlow: Flow, newFlow: Flow): Flow {
-    const hunkCounter = { count: 0 };
+    const counters: DiffCounters = { hunk: 0, namespace: 0 };
     const oldNodes = cloneDeep(oldFlow.nodes ?? []);
     const newNodes = cloneDeep(newFlow.nodes ?? []);
     return {
         ...newFlow,
-        nodes: mergeNodeLists(oldNodes, newNodes, hunkCounter),
+        nodes: mergeNodeLists(oldNodes, newNodes, counters),
     };
 }
 
@@ -72,21 +81,72 @@ function stampNodeDeep(node: FlowNode, state: FlowNodeDiffState): void {
     node.branches?.forEach((branch) => branch.children?.forEach((child) => stampNodeDeep(child, state)));
 }
 
-// Whitespace is stripped entirely so formatter-only differences never register as changes.
+type StringDelimiter = '"' | "`";
+
+/**
+ * Removes formatter whitespace while preserving all text inside string and raw-template
+ * literals. A regular expression cannot make that distinction and would make `"a b"`
+ * compare equal to `"ab"`.
+ */
 function normalizeSource(text: string): string {
-    return text.replace(/\s+/g, "");
+    let result = "";
+    let delimiter: StringDelimiter | null = null;
+    let escaped = false;
+
+    for (const char of text) {
+        if (delimiter) {
+            result += char;
+            if (escaped) {
+                escaped = false;
+            } else if (char === "\\") {
+                escaped = true;
+            } else if (char === delimiter) {
+                delimiter = null;
+            }
+            continue;
+        }
+
+        if (char === '"' || char === "`") {
+            delimiter = char;
+            result += char;
+        } else if (!/\s/.test(char)) {
+            result += char;
+        }
+    }
+
+    return result;
 }
 
 // Full comment lines (`// ...` and doc `# ...`) are trivia: statement sourceCode from the LS
 // includes leading comments, so a note edit must not read as a change to the statement itself.
 function stripCommentLines(text: string): string {
-    return text
-        .split("\n")
-        .filter((line) => {
-            const trimmed = line.trim();
-            return !trimmed.startsWith("//") && !trimmed.startsWith("#");
-        })
-        .join("\n");
+    const keptLines: string[] = [];
+    let delimiter: StringDelimiter | null = null;
+    let escaped = false;
+
+    for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (!delimiter && (trimmed.startsWith("//") || trimmed.startsWith("#"))) {
+            continue;
+        }
+
+        keptLines.push(line);
+        for (const char of `${line}\n`) {
+            if (delimiter) {
+                if (escaped) {
+                    escaped = false;
+                } else if (char === "\\") {
+                    escaped = true;
+                } else if (char === delimiter) {
+                    delimiter = null;
+                }
+            } else if (char === '"' || char === "`") {
+                delimiter = char;
+            }
+        }
+    }
+
+    return keptLines.join("\n");
 }
 
 function isComment(node: FlowNode): boolean {
@@ -159,10 +219,29 @@ function nodeIdentityKey(node: FlowNode): string | null {
     return null;
 }
 
-// Text before the first block opening brace, e.g. `if count > 5`, `while true`.
+// Text before the first block opening brace outside a literal, e.g. `if count > 5`, `while true`.
 function headerBeforeBrace(text: string): string {
-    const braceIndex = text.indexOf("{");
-    return braceIndex >= 0 ? text.slice(0, braceIndex) : text;
+    let delimiter: StringDelimiter | null = null;
+    let escaped = false;
+
+    for (let index = 0; index < text.length; index++) {
+        const char = text[index];
+        if (delimiter) {
+            if (escaped) {
+                escaped = false;
+            } else if (char === "\\") {
+                escaped = true;
+            } else if (char === delimiter) {
+                delimiter = null;
+            }
+        } else if (char === '"' || char === "`") {
+            delimiter = char;
+        } else if (char === "{") {
+            return text.slice(0, index);
+        }
+    }
+
+    return text;
 }
 
 /**
@@ -194,9 +273,9 @@ function matchNodes(oldNode: FlowNode, newNode: FlowNode): NodeMatch {
     if (oldNode.codedata?.node !== newNode.codedata?.node) {
         return null;
     }
-    // The function start event is never part of the diff; always pair it.
+    // Keep the single start event aligned, but surface signature/resource-path edits.
     if (newNode.codedata?.node === "EVENT_START") {
-        return "exact";
+        return nodeKey(oldNode) === nodeKey(newNode) ? "exact" : "modified";
     }
     // Comments align by text: equal text is a stable anchor (exact); differing text is an
     // in-place note edit (modified). Handling them before nodeKey — which collapses every
@@ -220,7 +299,7 @@ function matchNodes(oldNode: FlowNode, newNode: FlowNode): NodeMatch {
     return null;
 }
 
-function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter: { count: number }): FlowNode[] {
+function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], counters: DiffCounters): FlowNode[] {
     const aligned = alignNodes(oldNodes, newNodes);
 
     const merged: FlowNode[] = [];
@@ -241,13 +320,14 @@ function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter:
         const addedCode = addedRun.filter((node) => !isComment(node));
         if (removedCode.length === 1 && addedCode.length === 1 && isContentEdit(removedCode[0], addedCode[0])) {
             const removedComments = removedRun.filter(isComment);
-            removedComments.forEach((node) => stampNodeDeep(node, "removed"));
+            stampAndNamespaceNodes(removedComments, "removed", counters);
             merged.push(...removedComments);
+            const addedComments = addedRun.filter(isComment);
+            stampAndNamespaceNodes(addedComments, "added", counters);
             for (const node of addedRun) {
                 if (node === addedCode[0]) {
                     merged.push(markModified(node, removedCode[0]));
                 } else {
-                    stampNodeDeep(node, "added");
                     merged.push(node);
                 }
             }
@@ -260,14 +340,14 @@ function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter:
         const removedLane = removedCode.length > 0 ? removedRun : [];
         const addedLane = addedCode.length > 0 ? addedRun : [];
         if (removedCode.length === 0) {
-            removedRun.forEach((node) => stampNodeDeep(node, "removed"));
+            stampAndNamespaceNodes(removedRun, "removed", counters);
             merged.push(...removedRun);
         }
         if (removedLane.length > 0 || addedLane.length > 0) {
-            merged.push(createDiffHunk(removedLane, addedLane, hunkCounter));
+            merged.push(createDiffHunk(removedLane, addedLane, counters));
         }
         if (addedCode.length === 0) {
-            addedRun.forEach((node) => stampNodeDeep(node, "added"));
+            stampAndNamespaceNodes(addedRun, "added", counters);
             merged.push(...addedRun);
         }
     };
@@ -279,7 +359,7 @@ function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter:
         if (pair.match === "container" || pair.match === "container-modified") {
             const mergedContainer: FlowNode = {
                 ...newNode,
-                branches: mergeBranches(oldNode.branches ?? [], newNode.branches ?? [], hunkCounter),
+                branches: mergeBranches(oldNode.branches ?? [], newNode.branches ?? [], counters),
             };
             if (pair.match === "container-modified") {
                 mergedContainer.diffState = "modified";
@@ -301,26 +381,26 @@ function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter:
     return merged;
 }
 
-function mergeBranches(oldBranches: Branch[], newBranches: Branch[], hunkCounter: { count: number }): Branch[] {
+function mergeBranches(oldBranches: Branch[], newBranches: Branch[], counters: DiffCounters): Branch[] {
     const unmatchedOld = [...oldBranches];
     const merged: Branch[] = newBranches.map((newBranch) => {
         const oldBranchIndex = unmatchedOld.findIndex(
             (oldBranch) => oldBranch.label === newBranch.label && oldBranch.codedata?.node === newBranch.codedata?.node
         );
         if (oldBranchIndex === -1) {
-            newBranch.children?.forEach((child) => stampNodeDeep(child, "added"));
+            stampAndNamespaceNodes(newBranch.children ?? [], "added", counters);
             return newBranch;
         }
         const oldBranch = unmatchedOld.splice(oldBranchIndex, 1)[0];
         return {
             ...newBranch,
-            children: mergeNodeLists(oldBranch.children ?? [], newBranch.children ?? [], hunkCounter),
+            children: mergeNodeLists(oldBranch.children ?? [], newBranch.children ?? [], counters),
         };
     });
 
     // Branches removed in the new version are kept (stamped removed) so the user sees them.
     unmatchedOld.forEach((oldBranch) => {
-        oldBranch.children?.forEach((child) => stampNodeDeep(child, "removed"));
+        stampAndNamespaceNodes(oldBranch.children ?? [], "removed", counters);
         merged.push(oldBranch);
     });
 
@@ -346,9 +426,39 @@ function markModified(newNode: FlowNode, oldNode: FlowNode): FlowNode {
     };
 }
 
-function createDiffHunk(removedRun: FlowNode[], addedRun: FlowNode[], hunkCounter: { count: number }): FlowNode {
-    removedRun.forEach((node) => stampNodeDeep(node, "removed"));
-    addedRun.forEach((node) => stampNodeDeep(node, "added"));
+function namespaceNodeIds(nodes: FlowNode[], prefix: string): void {
+    const ids = new Map<string, string>();
+    let nodeCount = 0;
+
+    const collect = (node: FlowNode) => {
+        ids.set(node.id, `${prefix}node${++nodeCount}`);
+        node.branches?.forEach((branch) => branch.children?.forEach(collect));
+    };
+    nodes.forEach(collect);
+
+    const apply = (node: FlowNode) => {
+        const originalId = node.id;
+        node.id = ids.get(originalId) ?? originalId;
+        if (node.viewState?.startNodeId && ids.has(node.viewState.startNodeId)) {
+            node.viewState.startNodeId = ids.get(node.viewState.startNodeId);
+        }
+        node.branches?.forEach((branch) => branch.children?.forEach(apply));
+    };
+    nodes.forEach(apply);
+}
+
+function stampAndNamespaceNodes(nodes: FlowNode[], state: "added" | "removed", counters: DiffCounters): void {
+    if (nodes.length === 0) {
+        return;
+    }
+    const prefix = `diffnamespace${++counters.namespace}${state}`;
+    namespaceNodeIds(nodes, prefix);
+    nodes.forEach((node) => stampNodeDeep(node, state));
+}
+
+function createDiffHunk(removedRun: FlowNode[], addedRun: FlowNode[], counters: DiffCounters): FlowNode {
+    stampAndNamespaceNodes(removedRun, "removed", counters);
+    stampAndNamespaceNodes(addedRun, "added", counters);
 
     const branches: Branch[] = [];
     if (removedRun.length > 0) {
@@ -358,11 +468,11 @@ function createDiffHunk(removedRun: FlowNode[], addedRun: FlowNode[], hunkCounte
         branches.push(createHunkBranch(DIFF_ADDED_BRANCH_LABEL, addedRun));
     }
 
-    hunkCounter.count += 1;
+    counters.hunk += 1;
     return {
         // No dashes: custom ids derived from this (e.g. `<id>-lastNode` for the end node)
         // are parsed by reverseCustomNodeId, which splits on "-".
-        id: `diffhunk${hunkCounter.count}`,
+        id: `diffhunk${counters.hunk}`,
         metadata: { label: "", description: "" },
         codedata: { node: DIFF_HUNK_NODE },
         branches,
@@ -393,6 +503,9 @@ interface AlignedPair {
 function alignNodes(oldNodes: FlowNode[], newNodes: FlowNode[]): AlignedPair[] {
     const n = oldNodes.length;
     const m = newNodes.length;
+    if (n * m > MAX_LCS_MATRIX_CELLS) {
+        return alignNodesBounded(oldNodes, newNodes);
+    }
     const matchTable: NodeMatch[][] = [];
     for (let i = 0; i < n; i++) {
         matchTable.push([]);
@@ -429,4 +542,37 @@ function alignNodes(oldNodes: FlowNode[], newNodes: FlowNode[]): AlignedPair[] {
         }
     }
     return aligned;
+}
+
+/**
+ * Low-memory fallback for unusually large lists. It preserves matching prefixes and
+ * suffixes and presents the remaining middle as one replacement hunk. The result is less
+ * granular than LCS, but never hides a change and uses constant auxiliary memory.
+ */
+function alignNodesBounded(oldNodes: FlowNode[], newNodes: FlowNode[]): AlignedPair[] {
+    const alignedPrefix: AlignedPair[] = [];
+    let prefix = 0;
+    while (prefix < oldNodes.length && prefix < newNodes.length) {
+        const match = matchNodes(oldNodes[prefix], newNodes[prefix]);
+        if (!match) {
+            break;
+        }
+        alignedPrefix.push({ oldIndex: prefix, newIndex: prefix, match });
+        prefix++;
+    }
+
+    const alignedSuffix: AlignedPair[] = [];
+    let oldIndex = oldNodes.length - 1;
+    let newIndex = newNodes.length - 1;
+    while (oldIndex >= prefix && newIndex >= prefix) {
+        const match = matchNodes(oldNodes[oldIndex], newNodes[newIndex]);
+        if (!match) {
+            break;
+        }
+        alignedSuffix.push({ oldIndex, newIndex, match });
+        oldIndex--;
+        newIndex--;
+    }
+
+    return [...alignedPrefix, ...alignedSuffix.reverse()];
 }

--- a/packages/bi-diagram/src/utils/diff.ts
+++ b/packages/bi-diagram/src/utils/diff.ts
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { cloneDeep } from "lodash";
+import { Branch, Flow, FlowNode, FlowNodeDiffState } from "./types";
+
+export const DIFF_HUNK_NODE = "DIFF_HUNK";
+export const DIFF_REMOVED_BRANCH_LABEL = "Removed";
+export const DIFF_ADDED_BRANCH_LABEL = "Added";
+
+type NodeMatch = "exact" | "container" | null;
+
+/**
+ * Merges the old and new flow models of the same function into a single flow model
+ * where removed and added nodes are grouped into synthetic DIFF_HUNK container nodes.
+ * Unchanged nodes come from the new model. Removed/added subtrees are stamped with
+ * `diffState` so widgets can render them accordingly.
+ */
+export function mergeFlowModelsForDiff(oldFlow: Flow, newFlow: Flow): Flow {
+    const hunkCounter = { count: 0 };
+    const oldNodes = cloneDeep(oldFlow.nodes ?? []);
+    const newNodes = cloneDeep(newFlow.nodes ?? []);
+    return {
+        ...newFlow,
+        nodes: mergeNodeLists(oldNodes, newNodes, hunkCounter),
+    };
+}
+
+/**
+ * Stamps every node in the flow (recursively through branches) with the given diff state.
+ * Used to tint whole ADDITION/DELETION views. Returns a new flow; input is not mutated.
+ */
+export function stampDiffState(flow: Flow, state: FlowNodeDiffState): Flow {
+    const nodes = cloneDeep(flow.nodes ?? []);
+    nodes.forEach((node) => stampNodeDeep(node, state));
+    return { ...flow, nodes };
+}
+
+function stampNodeDeep(node: FlowNode, state: FlowNodeDiffState): void {
+    node.diffState = state;
+    node.branches?.forEach((branch) => branch.children?.forEach((child) => stampNodeDeep(child, state)));
+}
+
+// Whitespace is stripped entirely so formatter-only differences never register as changes.
+function normalizeSource(text: string): string {
+    return text.replace(/\s+/g, "");
+}
+
+// Full comment lines (`// ...` and doc `# ...`) are trivia: statement sourceCode from the LS
+// includes leading comments, so a note edit must not read as a change to the statement itself.
+function stripCommentLines(text: string): string {
+    return text
+        .split("\n")
+        .filter((line) => {
+            const trimmed = line.trim();
+            return !trimmed.startsWith("//") && !trimmed.startsWith("#");
+        })
+        .join("\n");
+}
+
+function isComment(node: FlowNode): boolean {
+    return node.codedata?.node === "COMMENT";
+}
+
+function nodeKey(node: FlowNode): string {
+    // Comments pair positionally regardless of text — a note edit is not a code change.
+    if (isComment(node)) {
+        return "kind:COMMENT";
+    }
+    const source = node.codedata?.sourceCode;
+    if (source) {
+        const normalized = normalizeSource(stripCommentLines(source));
+        if (normalized) {
+            return normalized;
+        }
+    }
+    return `kind:${node.codedata?.node}|label:${node.metadata?.label ?? ""}`;
+}
+
+function hasBranches(node: FlowNode): boolean {
+    return Array.isArray(node.branches) && node.branches.length > 0;
+}
+
+// Header of a container node: the source up to the first block opening brace,
+// e.g. `if count > 5`, `while true`, `foreach var item in items`.
+function containerHeaderKey(node: FlowNode): string {
+    const source = node.codedata?.sourceCode;
+    if (!source) {
+        return `kind:${node.codedata?.node}`;
+    }
+    const normalized = normalizeSource(stripCommentLines(source));
+    const braceIndex = normalized.indexOf("{");
+    return braceIndex >= 0 ? normalized.slice(0, braceIndex) : normalized;
+}
+
+function matchNodes(oldNode: FlowNode, newNode: FlowNode): NodeMatch {
+    if (oldNode.codedata?.node !== newNode.codedata?.node) {
+        return null;
+    }
+    // The function start event is never part of the diff; always pair it.
+    if (newNode.codedata?.node === "EVENT_START") {
+        return "exact";
+    }
+    if (nodeKey(oldNode) === nodeKey(newNode)) {
+        return "exact";
+    }
+    if (hasBranches(oldNode) && hasBranches(newNode) && containerHeaderKey(oldNode) === containerHeaderKey(newNode)) {
+        return "container";
+    }
+    return null;
+}
+
+function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter: { count: number }): FlowNode[] {
+    const aligned = alignNodes(oldNodes, newNodes);
+
+    const merged: FlowNode[] = [];
+    let oldIndex = 0;
+    let newIndex = 0;
+
+    const flushGap = (oldEnd: number, newEnd: number) => {
+        const removedRun = oldNodes.slice(oldIndex, oldEnd);
+        const addedRun = newNodes.slice(newIndex, newEnd);
+        oldIndex = oldEnd;
+        newIndex = newEnd;
+
+        // Comments render as note chips on the following node, never as widgets, so a
+        // comment-only lane would render nothing. Comment-only runs are kept out of hunks:
+        // added comments flow through inline (chip on the next node), removed ones drop out.
+        const removedLane = removedRun.some((node) => !isComment(node)) ? removedRun : [];
+        const addedHasCode = addedRun.some((node) => !isComment(node));
+        const addedLane = addedHasCode ? addedRun : [];
+        if (removedLane.length > 0 || addedLane.length > 0) {
+            merged.push(createDiffHunk(removedLane, addedLane, hunkCounter));
+        }
+        if (!addedHasCode) {
+            merged.push(...addedRun);
+        }
+    };
+
+    for (const pair of aligned) {
+        flushGap(pair.oldIndex, pair.newIndex);
+        const oldNode = oldNodes[pair.oldIndex];
+        const newNode = newNodes[pair.newIndex];
+        if (pair.match === "container") {
+            merged.push({
+                ...newNode,
+                branches: mergeBranches(oldNode.branches ?? [], newNode.branches ?? [], hunkCounter),
+            });
+        } else {
+            merged.push(newNode);
+        }
+        oldIndex = pair.oldIndex + 1;
+        newIndex = pair.newIndex + 1;
+    }
+    flushGap(oldNodes.length, newNodes.length);
+
+    return merged;
+}
+
+function mergeBranches(oldBranches: Branch[], newBranches: Branch[], hunkCounter: { count: number }): Branch[] {
+    const unmatchedOld = [...oldBranches];
+    const merged: Branch[] = newBranches.map((newBranch) => {
+        const oldBranchIndex = unmatchedOld.findIndex(
+            (oldBranch) => oldBranch.label === newBranch.label && oldBranch.codedata?.node === newBranch.codedata?.node
+        );
+        if (oldBranchIndex === -1) {
+            newBranch.children?.forEach((child) => stampNodeDeep(child, "added"));
+            return newBranch;
+        }
+        const oldBranch = unmatchedOld.splice(oldBranchIndex, 1)[0];
+        return {
+            ...newBranch,
+            children: mergeNodeLists(oldBranch.children ?? [], newBranch.children ?? [], hunkCounter),
+        };
+    });
+
+    // Branches removed in the new version are kept (stamped removed) so the user sees them.
+    unmatchedOld.forEach((oldBranch) => {
+        oldBranch.children?.forEach((child) => stampNodeDeep(child, "removed"));
+        merged.push(oldBranch);
+    });
+
+    return merged;
+}
+
+function createDiffHunk(removedRun: FlowNode[], addedRun: FlowNode[], hunkCounter: { count: number }): FlowNode {
+    removedRun.forEach((node) => stampNodeDeep(node, "removed"));
+    addedRun.forEach((node) => stampNodeDeep(node, "added"));
+
+    const branches: Branch[] = [];
+    if (removedRun.length > 0) {
+        branches.push(createHunkBranch(DIFF_REMOVED_BRANCH_LABEL, removedRun));
+    }
+    if (addedRun.length > 0) {
+        branches.push(createHunkBranch(DIFF_ADDED_BRANCH_LABEL, addedRun));
+    }
+
+    hunkCounter.count += 1;
+    return {
+        // No dashes: custom ids derived from this (e.g. `<id>-lastNode` for the end node)
+        // are parsed by reverseCustomNodeId, which splits on "-".
+        id: `diffhunk${hunkCounter.count}`,
+        metadata: { label: "", description: "" },
+        codedata: { node: DIFF_HUNK_NODE },
+        branches,
+        returning: false,
+    };
+}
+
+function createHunkBranch(label: string, children: FlowNode[]): Branch {
+    return {
+        label,
+        kind: "block",
+        codedata: { node: "BODY" },
+        repeatable: "ONE",
+        properties: {},
+        children,
+    };
+}
+
+interface AlignedPair {
+    oldIndex: number;
+    newIndex: number;
+    match: NodeMatch;
+}
+
+// Longest-common-subsequence alignment between the two node lists.
+// Exact matches are weighted above container (header-only) matches so an unchanged
+// sibling is preferred over pairing with a changed container of the same kind.
+function alignNodes(oldNodes: FlowNode[], newNodes: FlowNode[]): AlignedPair[] {
+    const n = oldNodes.length;
+    const m = newNodes.length;
+    const matchTable: NodeMatch[][] = [];
+    for (let i = 0; i < n; i++) {
+        matchTable.push([]);
+        for (let j = 0; j < m; j++) {
+            matchTable[i].push(matchNodes(oldNodes[i], newNodes[j]));
+        }
+    }
+
+    const scores: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+    for (let i = n - 1; i >= 0; i--) {
+        for (let j = m - 1; j >= 0; j--) {
+            const match = matchTable[i][j];
+            const matchScore = match === "exact" ? 2 : match === "container" ? 1 : 0;
+            scores[i][j] = Math.max(
+                scores[i + 1][j],
+                scores[i][j + 1],
+                match ? scores[i + 1][j + 1] + matchScore : 0
+            );
+        }
+    }
+
+    const aligned: AlignedPair[] = [];
+    let i = 0;
+    let j = 0;
+    while (i < n && j < m) {
+        const match = matchTable[i][j];
+        const matchScore = match === "exact" ? 2 : match === "container" ? 1 : 0;
+        if (match && scores[i][j] === scores[i + 1][j + 1] + matchScore) {
+            aligned.push({ oldIndex: i, newIndex: j, match });
+            i++;
+            j++;
+        } else if (scores[i + 1][j] >= scores[i][j + 1]) {
+            i++;
+        } else {
+            j++;
+        }
+    }
+    return aligned;
+}

--- a/packages/bi-diagram/src/utils/diff.ts
+++ b/packages/bi-diagram/src/utils/diff.ts
@@ -250,7 +250,7 @@ function headerBeforeBrace(text: string): string {
  */
 export function getDiffDisplaySource(node: FlowNode): string {
     const source = node.codedata?.sourceCode ?? "";
-    const text = hasBranches(node) ? headerBeforeBrace(source) : source;
+    const text = hasBranches(node) || node.codedata?.node === "EVENT_START" ? headerBeforeBrace(source) : source;
     return text.trim();
 }
 
@@ -273,9 +273,11 @@ function matchNodes(oldNode: FlowNode, newNode: FlowNode): NodeMatch {
     if (oldNode.codedata?.node !== newNode.codedata?.node) {
         return null;
     }
-    // Keep the single start event aligned, but surface signature/resource-path edits.
+    // EVENT_START source can contain the complete function body. Compare only the
+    // declaration header so an edit inside the function does not mark Start modified.
+    // Signature and resource-path edits still surface on the Start node.
     if (newNode.codedata?.node === "EVENT_START") {
-        return nodeKey(oldNode) === nodeKey(newNode) ? "exact" : "modified";
+        return containerHeaderKey(oldNode) === containerHeaderKey(newNode) ? "exact" : "modified";
     }
     // Comments align by text: equal text is a stable anchor (exact); differing text is an
     // in-place note edit (modified). Handling them before nodeKey — which collapses every

--- a/packages/bi-diagram/src/utils/diff.ts
+++ b/packages/bi-diagram/src/utils/diff.ts
@@ -123,7 +123,7 @@ function nodeKey(node: FlowNode): string {
 }
 
 function computeNodeKey(node: FlowNode): string {
-    // Comments pair positionally regardless of text — a note edit is not a code change.
+    // Fallback only: matchNodes aligns comments by text before it ever reaches nodeKey.
     if (isComment(node)) {
         return "kind:COMMENT";
     }
@@ -197,6 +197,13 @@ function matchNodes(oldNode: FlowNode, newNode: FlowNode): NodeMatch {
     // The function start event is never part of the diff; always pair it.
     if (newNode.codedata?.node === "EVENT_START") {
         return "exact";
+    }
+    // Comments align by text: equal text is a stable anchor (exact); differing text is an
+    // in-place note edit (modified). Handling them before nodeKey — which collapses every
+    // comment to "kind:COMMENT" — stops the LCS from pairing an inserted note with an
+    // existing one and mislabeling both.
+    if (isComment(newNode)) {
+        return commentText(oldNode) === commentText(newNode) ? "exact" : "modified";
     }
     if (nodeKey(oldNode) === nodeKey(newNode)) {
         return "exact";
@@ -280,10 +287,8 @@ function mergeNodeLists(oldNodes: FlowNode[], newNodes: FlowNode[], hunkCounter:
             }
             merged.push(mergedContainer);
         } else if (pair.match === "modified") {
-            merged.push(markModified(newNode, oldNode));
-        } else if (isComment(newNode) && commentText(oldNode) !== commentText(newNode)) {
-            // Comments pair positionally, so an edited note lands here as an "exact" match.
-            // Mark it modified so the note chip renders the old and new texts.
+            // An edited note pairs here too (matchNodes returns "modified" when comment text
+            // differs), so the chip renders the old and new texts.
             merged.push(markModified(newNode, oldNode));
         } else {
             merged.push(newNode);

--- a/packages/bi-diagram/src/utils/node.ts
+++ b/packages/bi-diagram/src/utils/node.ts
@@ -21,6 +21,8 @@ import { CSSProperties } from "react";
 import {
     DIFF_ADDED_BG_COLOR,
     DIFF_ADDED_COLOR,
+    DIFF_MODIFIED_BG_COLOR,
+    DIFF_MODIFIED_COLOR,
     DIFF_REMOVED_BG_COLOR,
     DIFF_REMOVED_COLOR,
 } from "../resources/constants";
@@ -28,18 +30,29 @@ import { Branch, FlowNode } from "./types";
 
 const WORKFLOW_NODE_KINDS = new Set(["WORKFLOW_RUN", "ACTIVITY_CALL", "SEND_DATA", "WAIT_DATA"]);
 
+// Colors for a node in the unified review-diff diagram, keyed by its diff state.
+// Raw strings so both `style`-prop consumers and SVG fill/stroke attributes can use them.
+export function getDiffColors(node: FlowNode): { background: string; border: string } | undefined {
+    switch (node?.diffState) {
+        case "removed":
+            return { background: DIFF_REMOVED_BG_COLOR, border: DIFF_REMOVED_COLOR };
+        case "added":
+            return { background: DIFF_ADDED_BG_COLOR, border: DIFF_ADDED_COLOR };
+        case "modified":
+            return { background: DIFF_MODIFIED_BG_COLOR, border: DIFF_MODIFIED_COLOR };
+        default:
+            return undefined;
+    }
+}
+
 // Inline style overrides for nodes rendered inside the unified review-diff diagram.
 // Applied on top of the widget's styled-component so every node kind gets the same treatment.
 export function getDiffContainerStyles(node: FlowNode): CSSProperties | undefined {
-    if (!node?.diffState) {
+    const colors = getDiffColors(node);
+    if (!colors) {
         return undefined;
     }
-    const removed = node.diffState === "removed";
-    return {
-        backgroundColor: removed ? DIFF_REMOVED_BG_COLOR : DIFF_ADDED_BG_COLOR,
-        borderColor: removed ? DIFF_REMOVED_COLOR : DIFF_ADDED_COLOR,
-        borderStyle: "solid",
-    };
+    return { backgroundColor: colors.background, borderColor: colors.border, borderStyle: "solid" };
 }
 
 export function getDiffTitleStyles(node: FlowNode): CSSProperties | undefined {

--- a/packages/bi-diagram/src/utils/node.ts
+++ b/packages/bi-diagram/src/utils/node.ts
@@ -16,9 +16,38 @@
  * under the License.
  */
 
+import { CSSProperties } from "react";
+
+import {
+    DIFF_ADDED_BG_COLOR,
+    DIFF_ADDED_COLOR,
+    DIFF_REMOVED_BG_COLOR,
+    DIFF_REMOVED_COLOR,
+} from "../resources/constants";
 import { Branch, FlowNode } from "./types";
 
 const WORKFLOW_NODE_KINDS = new Set(["WORKFLOW_RUN", "ACTIVITY_CALL", "SEND_DATA", "WAIT_DATA"]);
+
+// Inline style overrides for nodes rendered inside the unified review-diff diagram.
+// Applied on top of the widget's styled-component so every node kind gets the same treatment.
+export function getDiffContainerStyles(node: FlowNode): CSSProperties | undefined {
+    if (!node?.diffState) {
+        return undefined;
+    }
+    const removed = node.diffState === "removed";
+    return {
+        backgroundColor: removed ? DIFF_REMOVED_BG_COLOR : DIFF_ADDED_BG_COLOR,
+        borderColor: removed ? DIFF_REMOVED_COLOR : DIFF_ADDED_COLOR,
+        borderStyle: "solid",
+    };
+}
+
+export function getDiffTitleStyles(node: FlowNode): CSSProperties | undefined {
+    if (!node?.diffState) {
+        return undefined;
+    }
+    return node.diffState === "removed" ? { textDecoration: "line-through" } : undefined;
+}
 
 export function getNodeIdFromModel(node: FlowNode, prefix?: string) {
     if (!node) {

--- a/packages/bi-diagram/src/utils/node.ts
+++ b/packages/bi-diagram/src/utils/node.ts
@@ -26,9 +26,26 @@ import {
     DIFF_REMOVED_BG_COLOR,
     DIFF_REMOVED_COLOR,
 } from "../resources/constants";
-import { Branch, FlowNode } from "./types";
+import { Branch, FlowNode, FlowNodeDiffState } from "./types";
 
 const WORKFLOW_NODE_KINDS = new Set(["WORKFLOW_RUN", "ACTIVITY_CALL", "SEND_DATA", "WAIT_DATA"]);
+
+export interface DiffStatePresentation {
+    symbol: "+" | "−" | "~";
+    label: "Added" | "Removed" | "Modified";
+    borderStyle: "solid" | "dashed" | "dotted";
+    strokeDasharray?: string;
+}
+
+const DIFF_STATE_PRESENTATIONS: Record<FlowNodeDiffState, DiffStatePresentation> = {
+    added: { symbol: "+", label: "Added", borderStyle: "solid" },
+    removed: { symbol: "−", label: "Removed", borderStyle: "dashed", strokeDasharray: "6 4" },
+    modified: { symbol: "~", label: "Modified", borderStyle: "dotted", strokeDasharray: "2 2" },
+};
+
+export function getDiffStatePresentation(state?: FlowNodeDiffState): DiffStatePresentation | undefined {
+    return state ? DIFF_STATE_PRESENTATIONS[state] : undefined;
+}
 
 // Colors for a node in the unified review-diff diagram, keyed by its diff state.
 // Raw strings so both `style`-prop consumers and SVG fill/stroke attributes can use them.
@@ -49,10 +66,21 @@ export function getDiffColors(node: FlowNode): { background: string; border: str
 // Applied on top of the widget's styled-component so every node kind gets the same treatment.
 export function getDiffContainerStyles(node: FlowNode): CSSProperties | undefined {
     const colors = getDiffColors(node);
-    if (!colors) {
+    const presentation = getDiffStatePresentation(node?.diffState);
+    if (!colors || !presentation) {
         return undefined;
     }
-    return { backgroundColor: colors.background, borderColor: colors.border, borderStyle: "solid" };
+    return {
+        backgroundColor: colors.background,
+        borderColor: colors.border,
+        borderStyle: presentation.borderStyle,
+        outline: "1px solid var(--vscode-contrastBorder, transparent)",
+        outlineOffset: "2px",
+    };
+}
+
+export function getDiffStrokeDasharray(node: FlowNode): string | undefined {
+    return getDiffStatePresentation(node?.diffState)?.strokeDasharray;
 }
 
 export function getDiffTitleStyles(node: FlowNode): CSSProperties | undefined {

--- a/packages/bi-diagram/src/utils/types.ts
+++ b/packages/bi-diagram/src/utils/types.ts
@@ -56,6 +56,7 @@ export type {
     ClientKind,
     ClientScope,
     FlowNode,
+    FlowNodeDiffState,
     NodeKind,
     Branch,
     LineRange,

--- a/packages/bi-diagram/src/visitors/InitVisitor.ts
+++ b/packages/bi-diagram/src/visitors/InitVisitor.ts
@@ -84,6 +84,7 @@ export class InitVisitor implements BaseVisitor {
             "ERROR_HANDLER",
             "FORK",
             "LOCK",
+            "DIFF_HUNK",
         ];
         if (node.branches && !supportedNodeTypes.includes(node.codedata.node)) {
             // unsupported node types with children and branches
@@ -151,6 +152,15 @@ export class InitVisitor implements BaseVisitor {
                 children: [emptyElseBranch],
             });
         }
+    }
+
+    // Synthetic review-diff container (see utils/diff.ts). Branches hold the removed/added lanes.
+    beginVisitDiffHunk(node: FlowNode, parent?: FlowNode): void {
+        if (!this.validateNode(node)) return;
+        node.viewState = this.getDefaultViewState();
+        node.branches?.forEach((branch) => {
+            branch.viewState = this.getDefaultViewState();
+        });
     }
 
     beginVisitMatch(node: FlowNode, parent?: FlowNode): void {

--- a/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
+++ b/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
@@ -55,8 +55,9 @@ export class NodeFactoryVisitor implements BaseVisitor {
     private hasSuggestedNode = false;
     private linkCounter = 0;
     private visibleBtnCounter = 0;
-    private pendingComment: FlowNode | undefined = undefined; // comment node awaiting attachment to next node
-    private nodeComments: Map<string, FlowNode> = new Map(); // maps node id -> preceding comment node
+    private pendingComments: FlowNode[] = []; // comment nodes awaiting attachment to the next node
+    private nodeComments: Map<string, FlowNode[]> = new Map(); // maps node id -> preceding/trailing comments
+    private lastCommentTargetId: string | undefined;
 
     constructor() {
         // console.log(">>> node factory visitor started");
@@ -71,10 +72,11 @@ export class NodeFactoryVisitor implements BaseVisitor {
     }
 
     private updateNodeLinks(node: FlowNode, nodeModel: NodeModel, options?: NodeLinkModelOptions): void {
-        // Associate any preceding comment node with this node
-        if (this.pendingComment) {
-            this.nodeComments.set(node.id, this.pendingComment);
-            this.pendingComment = undefined;
+        // Synthetic empty nodes have no widget. Keep comments pending until a real node,
+        // or attach them to the preceding real node when a branch/flow ends.
+        if (node.codedata.node !== "EMPTY") {
+            this.flushPendingComments(node.id);
+            this.lastCommentTargetId = node.id;
         }
         if (node.viewState?.startNodeId) {
             // new sub flow start
@@ -91,6 +93,15 @@ export class NodeFactoryVisitor implements BaseVisitor {
             }
         }
         this.lastNodeModel = nodeModel;
+    }
+
+    private flushPendingComments(targetId: string | undefined = this.lastCommentTargetId): void {
+        if (!targetId || this.pendingComments.length === 0) {
+            return;
+        }
+        const existing = this.nodeComments.get(targetId) ?? [];
+        this.nodeComments.set(targetId, [...existing, ...this.pendingComments]);
+        this.pendingComments = [];
     }
 
     private createBaseNode(node: FlowNode): NodeModel {
@@ -467,17 +478,20 @@ export class NodeFactoryVisitor implements BaseVisitor {
 
     endVisitConditional(node: Branch, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
+        this.flushPendingComments();
         this.lastNodeModel = undefined;
     }
 
     endVisitBody(node: Branch, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
         // `Body` is inside `Foreach` node
+        this.flushPendingComments();
         this.lastNodeModel = undefined;
     }
 
     endVisitElse(node: Branch, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
+        this.flushPendingComments();
         this.lastNodeModel = undefined;
     }
 
@@ -731,6 +745,7 @@ export class NodeFactoryVisitor implements BaseVisitor {
 
     endVisitWorker(node: Branch, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
+        this.flushPendingComments();
         this.lastNodeModel = undefined;
     }
 
@@ -820,12 +835,15 @@ export class NodeFactoryVisitor implements BaseVisitor {
 
     beginVisitComment(node: FlowNode, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
-        // Store the comment as pending; it will be attached to the next non-comment node
-        // as a note chip rather than rendered as a standalone node in the diagram.
-        this.pendingComment = node;
+        // Keep every adjacent comment. A single pending slot made an inserted note overwrite
+        // the existing note before either could be rendered.
+        this.pendingComments.push(node);
     }
 
-    getNodeComments(): Map<string, FlowNode> {
+    getNodeComments(): Map<string, FlowNode[]> {
+        // A final comment has no following node; attach it to the preceding real node so it
+        // remains visible instead of being silently dropped.
+        this.flushPendingComments();
         return this.nodeComments;
     }
 

--- a/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
+++ b/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
@@ -176,8 +176,9 @@ export class NodeFactoryVisitor implements BaseVisitor {
     private getBranchLastFlowNode(branch: Branch): FlowNode | undefined {
         // Comments render as note chips on the following node, not as widgets — skip them
         for (let i = branch.children.length - 1; i >= 0; i--) {
-            if (branch.children.at(i).codedata.node !== "COMMENT") {
-                return branch.children.at(i);
+            const child = branch.children[i];
+            if (child.codedata.node !== "COMMENT") {
+                return child;
             }
         }
         return undefined;

--- a/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
+++ b/packages/bi-diagram/src/visitors/NodeFactoryVisitor.ts
@@ -161,33 +161,49 @@ export class NodeFactoryVisitor implements BaseVisitor {
     }
 
     private getBranchStartNode(branch: Branch): NodeModel | undefined {
-        let firstChildId = branch.children.at(0).id;
-        if (branch.children.at(0).codedata.node === "ERROR_HANDLER") {
-            firstChildId = getCustomNodeId(branch.children.at(0).id, START_CONTAINER);
+        // Comments render as note chips on the following node, not as widgets — skip them
+        const firstChild = branch.children.find((child) => child.codedata.node !== "COMMENT");
+        if (!firstChild) {
+            return undefined;
+        }
+        let firstChildId = firstChild.id;
+        if (firstChild.codedata.node === "ERROR_HANDLER" || firstChild.codedata.node === "DIFF_HUNK") {
+            firstChildId = getCustomNodeId(firstChild.id, START_CONTAINER);
         }
         return this.nodes.find((n) => n.getID() === firstChildId);
     }
 
+    private getBranchLastFlowNode(branch: Branch): FlowNode | undefined {
+        // Comments render as note chips on the following node, not as widgets — skip them
+        for (let i = branch.children.length - 1; i >= 0; i--) {
+            if (branch.children.at(i).codedata.node !== "COMMENT") {
+                return branch.children.at(i);
+            }
+        }
+        return undefined;
+    }
+
     private getBranchEndNode(branch: Branch): NodeModel | undefined {
         // get last child node model
-        const lastNode = branch.children.at(-1);
+        const lastNode = this.getBranchLastFlowNode(branch);
         if (!lastNode) {
             return;
         }
         let lastChildNodeModel: NodeModel | undefined;
-        if (branch.children.at(-1).codedata.node === "IF" || branch.children.at(-1).codedata.node === "MATCH") {
+        if (lastNode.codedata.node === "IF" || lastNode.codedata.node === "MATCH") {
             // if last child is IF, find endIf node
             lastChildNodeModel = this.nodes.find((n) => n.getID() === `${lastNode.id}-endif`);
         } else if (
-            branch.children.at(-1).codedata.node === "ERROR_HANDLER" &&
-            branch.children.at(-1)?.branches.find((b) => b.codedata.node === "ON_FAILURE")?.viewState
+            lastNode.codedata.node === "ERROR_HANDLER" &&
+            lastNode.branches.find((b) => b.codedata.node === "ON_FAILURE")?.viewState
         ) {
             lastChildNodeModel = this.nodes.find((n) => n.getID() === getCustomNodeId(lastNode.id, END_CONTAINER));
         } else if (
-            branch.children.at(-1).codedata.node === "WHILE" ||
-            branch.children.at(-1).codedata.node === "FOREACH" ||
-            branch.children.at(-1).codedata.node === "FORK" ||
-            branch.children.at(-1).codedata.node === "LOCK"
+            lastNode.codedata.node === "WHILE" ||
+            lastNode.codedata.node === "FOREACH" ||
+            lastNode.codedata.node === "FORK" ||
+            lastNode.codedata.node === "LOCK" ||
+            lastNode.codedata.node === "DIFF_HUNK"
         ) {
             // if last child is WHILE or FOREACH, find endwhile node
             lastChildNodeModel = this.nodes.find((n) => n.getID() === getCustomNodeId(lastNode.id, END_CONTAINER));
@@ -363,6 +379,89 @@ export class NodeFactoryVisitor implements BaseVisitor {
 
     endVisitMatch(node: FlowNode, parent?: FlowNode): void {
         this.endVisitIf(node, parent);
+    }
+
+    // Synthetic review-diff container: no widget of its own — an invisible fork anchor
+    // connects the previous node to the removed/added lanes, and an invisible join
+    // anchor connects the lanes back to the next node.
+    beginVisitDiffHunk(node: FlowNode, parent?: FlowNode): void {
+        if (!this.validateNode(node)) return;
+        const forkAnchor = this.createEmptyNode(
+            getCustomNodeId(node.id, START_CONTAINER),
+            node.viewState.x + node.viewState.lw - EMPTY_NODE_WIDTH / 2,
+            node.viewState.y - EMPTY_NODE_WIDTH / 2,
+            false
+        );
+        forkAnchor.setParentFlowNode(node);
+        // Link from the previous node directly (not via updateNodeLinks) so a pending
+        // comment chip stays available for the first real node inside the lanes.
+        if (this.lastNodeModel) {
+            const link = this.createNodeLinkWithCounter(this.lastNodeModel, forkAnchor);
+            if (link) {
+                this.links.push(link);
+            }
+        }
+        this.lastNodeModel = undefined;
+    }
+
+    endVisitDiffHunk(node: FlowNode, parent?: FlowNode): void {
+        if (!this.validateNode(node)) return;
+        const forkAnchor = this.nodes.find((n) => n.getID() === getCustomNodeId(node.id, START_CONTAINER));
+        if (!forkAnchor) {
+            console.error("Diff hunk fork anchor not found", node);
+            return;
+        }
+
+        const joinAnchor = this.createEmptyNode(
+            getCustomNodeId(node.id, END_CONTAINER),
+            node.viewState.x + node.viewState.lw - EMPTY_NODE_WIDTH / 2,
+            node.viewState.y + node.viewState.ch - EMPTY_NODE_WIDTH / 2,
+            false
+        );
+        joinAnchor.setParentFlowNode(node);
+
+        node.branches?.forEach((branch) => {
+            if (!branch.children || branch.children.length === 0) {
+                console.error("Diff hunk branch has no children", branch);
+                return;
+            }
+
+            const firstChildNodeModel = this.getBranchStartNode(branch);
+            if (firstChildNodeModel) {
+                const inLink = this.createNodeLinkWithCounter(forkAnchor, firstChildNodeModel, {
+                    id: getBranchInLinkId(node.id, branch.label, 0),
+                    showAddButton: false,
+                });
+                if (inLink) {
+                    this.links.push(inLink);
+                }
+            }
+
+            const lastNode = this.getBranchLastFlowNode(branch);
+            const lastChildNodeModel = this.getBranchEndNode(branch);
+            if (lastChildNodeModel) {
+                const outLink = this.createNodeLinkWithCounter(lastChildNodeModel, joinAnchor, {
+                    alignBottom: true,
+                    brokenLine: lastNode?.returning,
+                    showAddButton: false,
+                });
+                if (outLink) {
+                    this.links.push(outLink);
+                }
+            }
+
+            // Lane with no renderable node (safety net): keep the flow connected
+            if (!firstChildNodeModel && !lastChildNodeModel) {
+                const passThroughLink = this.createNodeLinkWithCounter(forkAnchor, joinAnchor, {
+                    showAddButton: false,
+                });
+                if (passThroughLink) {
+                    this.links.push(passThroughLink);
+                }
+            }
+        });
+
+        this.lastNodeModel = joinAnchor;
     }
 
     endVisitConditional(node: Branch, parent?: FlowNode): void {

--- a/packages/bi-diagram/src/visitors/PositionVisitor.ts
+++ b/packages/bi-diagram/src/visitors/PositionVisitor.ts
@@ -114,6 +114,46 @@ export class PositionVisitor implements BaseVisitor {
         this.endVisitIf(node, parent);
     }
 
+    // Synthetic review-diff container: headless fork — lanes start right below the previous node.
+    beginVisitDiffHunk(node: FlowNode, parent?: FlowNode): void {
+        if (!this.validateNode(node)) return;
+        node.viewState.y = this.lastNodeY;
+        this.lastNodeY += NODE_GAP_Y;
+
+        const centerX = getTopNodeCenter(node, parent, this.diagramCenterX);
+        node.viewState.x = centerX - node.viewState.lw;
+
+        node.branches.forEach((branch, index) => {
+            if (!branch?.viewState) {
+                console.error("Branch view state is not defined", branch);
+                return;
+            }
+            if (node.branches.length === 1) {
+                // single lane is centered under the hunk
+                branch.viewState.x = centerX - branch.viewState.clw;
+            } else if (index === 0) {
+                branch.viewState.x = centerX - node.viewState.clw;
+            } else {
+                const previousBranch = node.branches.at(index - 1);
+                if (!previousBranch.viewState) {
+                    console.error("Previous branch view state is not defined", previousBranch);
+                    return;
+                }
+                branch.viewState.x =
+                    previousBranch.viewState.x +
+                    previousBranch.viewState.clw +
+                    previousBranch.viewState.crw +
+                    NODE_GAP_X;
+            }
+            branch.viewState.y = this.lastNodeY;
+        });
+    }
+
+    endVisitDiffHunk(node: FlowNode, parent?: FlowNode): void {
+        if (!this.validateNode(node)) return;
+        this.lastNodeY = node.viewState.y + node.viewState.ch + NODE_GAP_Y;
+    }
+
     beginVisitConditional(node: Branch, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
         this.lastNodeY = node.viewState.y;

--- a/packages/bi-diagram/src/visitors/PositionVisitor.ts
+++ b/packages/bi-diagram/src/visitors/PositionVisitor.ts
@@ -78,12 +78,20 @@ export class PositionVisitor implements BaseVisitor {
             return;
         }
 
+        this.positionBranchLanes(node, centerX);
+    }
+
+    // Places a container's branches side by side under it, NODE_GAP_X apart,
+    // all starting at the current lastNodeY. A single branch is centered.
+    private positionBranchLanes(node: FlowNode, centerX: number): void {
         node.branches.forEach((branch, index) => {
             if (!branch?.viewState) {
                 console.error("Branch view state is not defined", branch);
                 return;
             }
-            if (index === 0) {
+            if (node.branches.length === 1) {
+                branch.viewState.x = centerX - branch.viewState.clw;
+            } else if (index === 0) {
                 branch.viewState.x = centerX - node.viewState.clw;
             } else {
                 const previousBranch = node.branches.at(index - 1);
@@ -123,35 +131,11 @@ export class PositionVisitor implements BaseVisitor {
         const centerX = getTopNodeCenter(node, parent, this.diagramCenterX);
         node.viewState.x = centerX - node.viewState.lw;
 
-        node.branches.forEach((branch, index) => {
-            if (!branch?.viewState) {
-                console.error("Branch view state is not defined", branch);
-                return;
-            }
-            if (node.branches.length === 1) {
-                // single lane is centered under the hunk
-                branch.viewState.x = centerX - branch.viewState.clw;
-            } else if (index === 0) {
-                branch.viewState.x = centerX - node.viewState.clw;
-            } else {
-                const previousBranch = node.branches.at(index - 1);
-                if (!previousBranch.viewState) {
-                    console.error("Previous branch view state is not defined", previousBranch);
-                    return;
-                }
-                branch.viewState.x =
-                    previousBranch.viewState.x +
-                    previousBranch.viewState.clw +
-                    previousBranch.viewState.crw +
-                    NODE_GAP_X;
-            }
-            branch.viewState.y = this.lastNodeY;
-        });
+        this.positionBranchLanes(node, centerX);
     }
 
     endVisitDiffHunk(node: FlowNode, parent?: FlowNode): void {
-        if (!this.validateNode(node)) return;
-        this.lastNodeY = node.viewState.y + node.viewState.ch + NODE_GAP_Y;
+        this.endVisitIf(node, parent);
     }
 
     beginVisitConditional(node: Branch, parent?: FlowNode): void {

--- a/packages/bi-diagram/src/visitors/SizingVisitor.ts
+++ b/packages/bi-diagram/src/visitors/SizingVisitor.ts
@@ -181,9 +181,11 @@ export class SizingVisitor implements BaseVisitor {
     }
 
     // Container left/right widths for a row of branch lanes joined by a horizontal bar.
-    private computeBranchRowWidths(branchViewStates: Branch["viewState"][]): { left: number; right: number } {
-        const first = branchViewStates.at(0);
-        const last = branchViewStates.at(-1);
+    // Callers pass only defined view states (see collectBranchViewStates), and the row is
+    // never empty, so first/last are safe to index directly.
+    private computeBranchRowWidths(branchViewStates: NonNullable<Branch["viewState"]>[]): { left: number; right: number } {
+        const first = branchViewStates[0];
+        const last = branchViewStates[branchViewStates.length - 1];
         const middleBranchesWidth = branchViewStates
             .slice(1, -1)
             .reduce((acc, viewState) => acc + viewState.clw + viewState.crw, 0);
@@ -192,15 +194,21 @@ export class SizingVisitor implements BaseVisitor {
     }
 
     // Tallest branch lane in the row (each lane counts at least one node gap).
-    private computeBranchRowHeight(branchViewStates: Branch["viewState"][]): number {
+    private computeBranchRowHeight(branchViewStates: NonNullable<Branch["viewState"]>[]): number {
         return branchViewStates.reduce((max, viewState) => Math.max(max, Math.max(viewState.ch, NODE_GAP_Y)), 0);
+    }
+
+    // The defined view states of a node's branches, narrowed so callers get non-optional
+    // elements (a branch without layout can't contribute to sizing).
+    private collectBranchViewStates(node: FlowNode): NonNullable<Branch["viewState"]>[] {
+        return node.branches
+            .map((branch) => branch.viewState)
+            .filter((viewState): viewState is NonNullable<Branch["viewState"]> => viewState !== undefined);
     }
 
     endVisitIf(node: FlowNode, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
-        const branchViewStates = node.branches
-            .map((branch) => branch.viewState)
-            .filter((viewState) => viewState !== undefined);
+        const branchViewStates = this.collectBranchViewStates(node);
         if (branchViewStates.length === 0) {
             console.error("No branch view states found in if node", node);
             return;
@@ -222,9 +230,7 @@ export class SizingVisitor implements BaseVisitor {
     // (no visible widget of its own, unlike the IF diamond).
     endVisitDiffHunk(node: FlowNode, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
-        const branchViewStates = node.branches
-            .map((branch) => branch.viewState)
-            .filter((viewState) => viewState !== undefined);
+        const branchViewStates = this.collectBranchViewStates(node);
         if (branchViewStates.length === 0) {
             console.error("No branch view states found in diff hunk node", node);
             return;

--- a/packages/bi-diagram/src/visitors/SizingVisitor.ts
+++ b/packages/bi-diagram/src/visitors/SizingVisitor.ts
@@ -442,51 +442,15 @@ export class SizingVisitor implements BaseVisitor {
     endVisitFork(node: FlowNode, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
 
-        if (!node.branches) {
+        const branchViewStates = this.collectBranchViewStates(node);
+        if (branchViewStates.length === 0) {
+            console.error("No branch view states found in fork node", node);
             return;
         }
 
-        // first branch
-        const firstBranchWidthViewState = node.branches.at(0)?.viewState;
-        if (!firstBranchWidthViewState) {
-            console.error("No first branch view state found in fork node", node);
-            return;
-        }
-        // last branch
-        const lastBranchWidthViewState = node.branches.at(-1)?.viewState;
-        if (!lastBranchWidthViewState) {
-            console.error("No last branch view state found in fork node", node);
-            return;
-        }
-        // middle branches width
-        const middleBranchesWidth = node.branches.slice(1, -1).reduce((acc, branch) => {
-            if (!branch?.viewState) {
-                console.error("Branch view state is not defined", branch);
-                return acc;
-            }
-            return acc + branch.viewState?.clw + branch.viewState?.crw;
-        }, 0);
-        const topBarWidth =
-            firstBranchWidthViewState?.crw +
-            middleBranchesWidth +
-            lastBranchWidthViewState?.clw +
-            NODE_GAP_X * (node.branches.length - 1);
-        // node container left width
-        const nodeContainerLeftWidth = firstBranchWidthViewState?.clw + topBarWidth / 2;
-        // node container right width
-        const nodeContainerRightWidth = topBarWidth / 2 + lastBranchWidthViewState?.crw;
-
-        // node container height
-        let containerHeight = 0;
-        if (node.branches) {
-            node.branches.forEach((child: Branch) => {
-                if (child.viewState) {
-                    containerHeight = Math.max(containerHeight, Math.max(child.viewState.ch, NODE_GAP_Y));
-                }
-            });
-        }
-        // add if node width and height
-        containerHeight += WHILE_NODE_WIDTH + NODE_GAP_Y;
+        const { left: nodeContainerLeftWidth, right: nodeContainerRightWidth } =
+            this.computeBranchRowWidths(branchViewStates);
+        const containerHeight = this.computeBranchRowHeight(branchViewStates) + WHILE_NODE_WIDTH + NODE_GAP_Y;
 
         const halfNodeWidth = WHILE_NODE_WIDTH / 2;
         const nodeHeight = WHILE_NODE_WIDTH;

--- a/packages/bi-diagram/src/visitors/SizingVisitor.ts
+++ b/packages/bi-diagram/src/visitors/SizingVisitor.ts
@@ -242,6 +242,41 @@ export class SizingVisitor implements BaseVisitor {
         this.endVisitIf(node, parent);
     }
 
+    // Synthetic review-diff container: removed/added lanes side by side, headless
+    // (no visible widget of its own, unlike the IF diamond).
+    endVisitDiffHunk(node: FlowNode, parent?: FlowNode): void {
+        if (!this.validateNode(node)) return;
+        const branchViewStates = node.branches
+            .map((branch) => branch.viewState)
+            .filter((viewState) => viewState !== undefined);
+        if (branchViewStates.length === 0) {
+            console.error("No branch view states found in diff hunk node", node);
+            return;
+        }
+
+        const firstBranch = branchViewStates.at(0);
+        const lastBranch = branchViewStates.at(-1);
+        let containerLeftWidth: number;
+        let containerRightWidth: number;
+        if (branchViewStates.length === 1) {
+            containerLeftWidth = firstBranch.clw;
+            containerRightWidth = firstBranch.crw;
+        } else {
+            const barWidth = firstBranch.crw + lastBranch.clw + NODE_GAP_X * (branchViewStates.length - 1);
+            containerLeftWidth = firstBranch.clw + barWidth / 2;
+            containerRightWidth = barWidth / 2 + lastBranch.crw;
+        }
+
+        let containerHeight = 0;
+        branchViewStates.forEach((viewState) => {
+            containerHeight = Math.max(containerHeight, Math.max(viewState.ch, NODE_GAP_Y));
+        });
+        // add fork gap above the lanes and join gap below them
+        containerHeight += NODE_GAP_Y + NODE_GAP_Y / 2;
+
+        this.setNodeSize(node, 0, 0, 0, containerLeftWidth, containerRightWidth, containerHeight);
+    }
+
     endVisitConditional(node: Branch, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
         this.createBlockNode(node);

--- a/packages/bi-diagram/src/visitors/SizingVisitor.ts
+++ b/packages/bi-diagram/src/visitors/SizingVisitor.ts
@@ -180,62 +180,38 @@ export class SizingVisitor implements BaseVisitor {
         this.setNodeSize(node, halfWidth, halfWidth, height);
     }
 
+    // Container left/right widths for a row of branch lanes joined by a horizontal bar.
+    private computeBranchRowWidths(branchViewStates: Branch["viewState"][]): { left: number; right: number } {
+        const first = branchViewStates.at(0);
+        const last = branchViewStates.at(-1);
+        const middleBranchesWidth = branchViewStates
+            .slice(1, -1)
+            .reduce((acc, viewState) => acc + viewState.clw + viewState.crw, 0);
+        const barWidth = first.crw + middleBranchesWidth + last.clw + NODE_GAP_X * (branchViewStates.length - 1);
+        return { left: first.clw + barWidth / 2, right: barWidth / 2 + last.crw };
+    }
+
+    // Tallest branch lane in the row (each lane counts at least one node gap).
+    private computeBranchRowHeight(branchViewStates: Branch["viewState"][]): number {
+        return branchViewStates.reduce((max, viewState) => Math.max(max, Math.max(viewState.ch, NODE_GAP_Y)), 0);
+    }
+
     endVisitIf(node: FlowNode, parent?: FlowNode): void {
         if (!this.validateNode(node)) return;
-        // first branch
-        const firstBranchWidthViewState = node.branches.at(0)?.viewState;
-        if (!firstBranchWidthViewState) {
-            console.error("No first branch view state found in if node", node);
+        const branchViewStates = node.branches
+            .map((branch) => branch.viewState)
+            .filter((viewState) => viewState !== undefined);
+        if (branchViewStates.length === 0) {
+            console.error("No branch view states found in if node", node);
             return;
         }
-        // last branch
-        const lastBranchWidthViewState = node.branches.at(-1)?.viewState;
-        if (!lastBranchWidthViewState) {
-            console.error("No last branch view state found in if node", node);
-            return;
-        }
-        const middleBranchesWidth = node.branches.slice(1, -1).reduce((acc, branch) => {
-            if (!branch?.viewState) {
-                console.error("Branch view state is not defined", branch);
-                return acc;
-            }
-            return acc + branch.viewState?.clw + branch.viewState?.crw;
-        }, 0);
-        // if bar width
-        const ifBarWidth =
-            firstBranchWidthViewState?.crw +
-            middleBranchesWidth +
-            lastBranchWidthViewState?.clw +
-            NODE_GAP_X * (node.branches.length - 1);
-        // if node container left width
-        const ifNodeContainerLeftWidth = firstBranchWidthViewState?.clw + ifBarWidth / 2;
-        // if node container right width
-        const ifNodeContainerRightWidth = ifBarWidth / 2 + lastBranchWidthViewState?.crw;
 
-        // if node container height
-        let containerHeight = 0;
-        if (node.branches) {
-            node.branches.forEach((child: Branch) => {
-                if (child.viewState) {
-                    containerHeight = Math.max(containerHeight, Math.max(child.viewState.ch, NODE_GAP_Y));
-                }
-            });
-        }
+        const { left, right } = this.computeBranchRowWidths(branchViewStates);
         // add if node width and height
-        containerHeight += IF_NODE_WIDTH + (NODE_GAP_Y * 5) / 2;
+        const containerHeight = this.computeBranchRowHeight(branchViewStates) + IF_NODE_WIDTH + (NODE_GAP_Y * 5) / 2;
 
         const halfNodeWidth = IF_NODE_WIDTH / 2;
-        const nodeHeight = IF_NODE_WIDTH;
-
-        this.setNodeSize(
-            node,
-            halfNodeWidth,
-            halfNodeWidth,
-            nodeHeight,
-            ifNodeContainerLeftWidth,
-            ifNodeContainerRightWidth,
-            containerHeight
-        );
+        this.setNodeSize(node, halfNodeWidth, halfNodeWidth, IF_NODE_WIDTH, left, right, containerHeight);
     }
 
     endVisitMatch(node: FlowNode, parent?: FlowNode): void {
@@ -254,27 +230,15 @@ export class SizingVisitor implements BaseVisitor {
             return;
         }
 
-        const firstBranch = branchViewStates.at(0);
-        const lastBranch = branchViewStates.at(-1);
-        let containerLeftWidth: number;
-        let containerRightWidth: number;
-        if (branchViewStates.length === 1) {
-            containerLeftWidth = firstBranch.clw;
-            containerRightWidth = firstBranch.crw;
-        } else {
-            const barWidth = firstBranch.crw + lastBranch.clw + NODE_GAP_X * (branchViewStates.length - 1);
-            containerLeftWidth = firstBranch.clw + barWidth / 2;
-            containerRightWidth = barWidth / 2 + lastBranch.crw;
-        }
-
-        let containerHeight = 0;
-        branchViewStates.forEach((viewState) => {
-            containerHeight = Math.max(containerHeight, Math.max(viewState.ch, NODE_GAP_Y));
-        });
+        // a single lane sits inline, so the container is just that lane's width
+        const onlyLane = branchViewStates.length === 1 ? branchViewStates[0] : undefined;
+        const { left, right } = onlyLane
+            ? { left: onlyLane.clw, right: onlyLane.crw }
+            : this.computeBranchRowWidths(branchViewStates);
         // add fork gap above the lanes and join gap below them
-        containerHeight += NODE_GAP_Y + NODE_GAP_Y / 2;
+        const containerHeight = this.computeBranchRowHeight(branchViewStates) + NODE_GAP_Y + NODE_GAP_Y / 2;
 
-        this.setNodeSize(node, 0, 0, 0, containerLeftWidth, containerRightWidth, containerHeight);
+        this.setNodeSize(node, 0, 0, 0, left, right, containerHeight);
     }
 
     endVisitConditional(node: Branch, parent?: FlowNode): void {


### PR DESCRIPTION
## What this does

Reworks the Copilot **Reviewing Changes** view into a single unified diff diagram, and makes a pending review survive restarts.

- **Unified diff diagram** — one diagram renders added (green), removed (red, strikethrough) and in-place modified (amber) nodes, replacing the separate New/Old tabs. Toggle is `Diff | New | Old` (Diff default) with a legend; modified nodes show old-vs-new source on hover, and note edits are diffed on the chip.
- **Pending review restore** — closing the Copilot panel or reloading the window while a review is pending no longer drops it: the review state and LS documents are rebuilt from persisted data, so the diff reopens and auto-accept keeps working.
- **Line-shift guard** — reopening a diff verifies the old and new flow models resolve to the same function before merging, so an edit that shifted lines can't pull in a different function; falls back to New when the old version is missing or mismatched.

## Validation

- `rush build --to @wso2/ballerina-visualizer`
- bi-diagram diff-merge unit tests (jest)

Also addresses the CodeRabbit and Copilot review feedback on this PR.

Related issue: https://github.com/wso2-enterprise/integration-engineering/issues/1882
