### PR TITLE
Fix record editor not opening for record fields in Knowledge Base and Connection Config forms

### DIFF
--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/ConnectionConfig.tsx
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/ConnectionConfig.tsx
@@ -126,6 +126,7 @@ export function ConnectionConfig(props: ConnectionConfigProps): JSX.Element {
                     property: {
                         ...property,
                         metadata: {
+                            ...property.metadata,
                             label: property.metadata?.label || key,
                             description: property.metadata?.description || "",
                         },

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/ConnectionConfig.tsx
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/ConnectionConfig.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FlowNode, LineRange, NodeKind, NodeProperties, getPrimaryInputType } from "@wso2/ballerina-core";
+import { FlowNode, LineRange, NodeKind, NodeProperties, PropertyTypeMemberInfo, RecordTypeField, getPrimaryInputType } from "@wso2/ballerina-core";
 import { FormField, FormImports, FormValues } from "@wso2/ballerina-side-panel";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ArtifactForm } from "../../views/BI/Forms/ArtifactForm";
@@ -38,6 +38,7 @@ export function ConnectionConfig(props: ConnectionConfigProps): JSX.Element {
 
     const [selectedConnectionValue, setSelectedConnectionValue] = useState<string>();
     const [selectedConnectionFields, setSelectedConnectionFields] = useState<FormField[]>([]);
+    const [recordTypeFields, setRecordTypeFields] = useState<RecordTypeField[]>([]);
     const [loading, setLoading] = useState<boolean>(false);
     const [savingForm, setSavingForm] = useState<boolean>(false);
     const [, forceRender] = useState(0);
@@ -108,6 +109,33 @@ export function ConnectionConfig(props: ConnectionConfigProps): JSX.Element {
         return fields;
     };
 
+    const getConnectionRecordTypeFields = (connectionValue: string): RecordTypeField[] => {
+        const connectionNode = connectionNodesMap.current.get(connectionValue);
+        if (!connectionNode) return [];
+
+        const { variable, ...restProperties } = connectionNode.properties;
+        return Object.entries(restProperties)
+            .filter(([_, property]) => {
+                const primaryInputType = getPrimaryInputType(property?.types);
+                return primaryInputType?.typeMembers?.some((member: PropertyTypeMemberInfo) => member.kind === "RECORD_TYPE");
+            })
+            .map(([key, property]) => {
+                const primaryInputType = getPrimaryInputType(property?.types);
+                return {
+                    key,
+                    property: {
+                        ...property,
+                        metadata: {
+                            label: property.metadata?.label || key,
+                            description: property.metadata?.description || "",
+                        },
+                    },
+                    recordTypeMembers:
+                        primaryInputType?.typeMembers?.filter((member: PropertyTypeMemberInfo) => member.kind === "RECORD_TYPE") ?? [],
+                };
+            });
+    };
+
     const updateFieldsForConnection = (connectionValue: string) => {
         const connectionSelectField = createConnectionSelectField(connectionValue, config, onCreateNewConnection, connectionKind, connectionNodesMap.current);
         const isExpression = connectionValue && !connectionNodesMap.current.has(connectionValue);
@@ -119,6 +147,7 @@ export function ConnectionConfig(props: ConnectionConfigProps): JSX.Element {
         }
         const configFields = isExpression ? [] : (connectionValue ? getConnectionConfigFields(connectionValue) : []);
         connectionConfigFields.current = configFields;
+        setRecordTypeFields(isExpression || !connectionValue ? [] : getConnectionRecordTypeFields(connectionValue));
         setSelectedConnectionValue(connectionValue);
         setSelectedConnectionFields([connectionSelectField, ...configFields]);
     };
@@ -226,6 +255,7 @@ export function ConnectionConfig(props: ConnectionConfigProps): JSX.Element {
                         disableSaveButton={savingForm}
                         isSaving={savingForm}
                         helperPaneSide="left"
+                        recordTypeFields={recordTypeFields}
                         injectedComponents={injectedComponents}
                     />
                 </>

--- a/packages/ballerina-visualizer/src/views/BI/Forms/KnowledgeBaseForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Forms/KnowledgeBaseForm/index.tsx
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Codicon } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
 
-import { EditorConfig, FlowNode, LineRange, SubPanel, SubPanelView } from "@wso2/ballerina-core";
+import { EditorConfig, FlowNode, getPrimaryInputType, LineRange, RecordTypeField, SubPanel, SubPanelView } from "@wso2/ballerina-core";
 import {
     FormValues,
     ExpressionFormField,
@@ -40,6 +40,9 @@ import {
 } from "../form-utils";
 import { SidePanelView } from "../../FlowDiagram/PanelManager";
 import { ConnectionKind } from "../../../../components/ConnectionSelector";
+import { useModalStack } from "../../../../Context";
+import DynamicModal from "../../../../components/Modal";
+import { ConfigureRecordPage } from "../../HelperPaneNew/Views/RecordConfigModal";
 
 const DEFAULT_CHUNKER_VALUE = "ai:AUTO";
 
@@ -111,11 +114,20 @@ export function KnowledgeBaseForm(props: KnowledgeBaseFormProps) {
     } = props;
 
     const { rpcClient } = useRpcContext();
+    const { addModal, closeModal, popModal } = useModalStack();
     const [knowledgeBaseFields, setKnowledgeBaseFields] = useState<FormField[]>([]);
     const [formImports, setFormImports] = useState<FormImports>({});
     const [isFormValid, setIsFormValid] = useState(true);
     const [knowledgeBaseFormValues, setKnowledgeBaseFormValues] = useState<FormValues>({});
     const [saving, setSaving] = useState<boolean>(false);
+    const [recordTypeFields, setRecordTypeFields] = useState<RecordTypeField[]>([]);
+    const [recordConfigPageState, setRecordConfigPageState] = useState<{
+        isOpen: boolean;
+        fieldKey?: string;
+        currentValue?: string;
+        recordTypeField?: RecordTypeField;
+        onChangeCallback?: (value: string) => void;
+    }>({ isOpen: false });
 
     useEffect(() => {
         initializeForm();
@@ -164,6 +176,23 @@ export function KnowledgeBaseForm(props: KnowledgeBaseFormProps) {
 
     const initializeForm = async () => {
         const formProperties = getFormProperties(node);
+
+        const recordFields = Object.entries(formProperties)
+            .filter(([_, property]) => {
+                const primaryInputType = getPrimaryInputType(property?.types);
+                return primaryInputType?.typeMembers?.some((member) => member.kind === "RECORD_TYPE");
+            })
+            .map(([key, property]) => {
+                const primaryInputType = getPrimaryInputType(property?.types);
+                return {
+                    key,
+                    property,
+                    recordTypeMembers:
+                        primaryInputType?.typeMembers?.filter((member) => member.kind === "RECORD_TYPE") ?? [],
+                };
+            });
+        setRecordTypeFields(recordFields);
+
         const fields = convertNodePropertiesToFormFields(formProperties);
         const actionFields = ["vectorStore", "embeddingModel", "chunker"];
         fields.forEach((field) => {
@@ -224,7 +253,32 @@ export function KnowledgeBaseForm(props: KnowledgeBaseFormProps) {
         }
     };
 
+    const openRecordConfigPage = useCallback((
+        fieldKey: string,
+        currentValue: string,
+        recordTypeField: RecordTypeField,
+        onChangeCallback: (value: string) => void
+    ) => {
+        setRecordConfigPageState({ isOpen: true, fieldKey, currentValue, recordTypeField, onChangeCallback });
+    }, []);
+
+    const closeRecordConfigPage = () => {
+        setRecordConfigPageState({ isOpen: false });
+    };
+
+    const popupManager = {
+        addPopup: addModal,
+        removeLastPopup: popModal,
+        closePopup: closeModal,
+    };
+
+    const formExpressionEditor = useMemo(
+        () => ({ ...expressionEditor, onOpenRecordConfigPage: openRecordConfigPage }),
+        [expressionEditor, openRecordConfigPage]
+    );
+
     return (
+        <>
         <S.Container footerActionButton={footerActionButton}>
             <S.ScrollableContent>
                 <S.Content>
@@ -235,7 +289,8 @@ export function KnowledgeBaseForm(props: KnowledgeBaseFormProps) {
                                 fileName={fileName}
                                 targetLineRange={targetLineRange}
                                 selectedNode={node.codedata.node}
-                                expressionEditor={expressionEditor}
+                                expressionEditor={formExpressionEditor}
+                                recordTypeFields={recordTypeFields}
                                 openSubPanel={openSubPanel}
                                 subPanelView={subPanelView}
                                 updatedExpressionField={updatedExpressionField}
@@ -258,6 +313,45 @@ export function KnowledgeBaseForm(props: KnowledgeBaseFormProps) {
                 </S.Content>
             </S.ScrollableContent>
         </S.Container>
+        {recordConfigPageState.isOpen &&
+            recordConfigPageState.fieldKey &&
+            recordConfigPageState.recordTypeField &&
+            recordConfigPageState.onChangeCallback && (
+                <DynamicModal
+                    width={800}
+                    height={600}
+                    anchorRef={undefined}
+                    title="Record Configuration"
+                    openState={recordConfigPageState.isOpen}
+                    setOpenState={(isOpen: boolean) => {
+                        if (!isOpen) {
+                            closeRecordConfigPage();
+                        }
+                    }}
+                    closeOnBackdropClick={true}
+                    closeButtonIcon="minimize"
+                >
+                    <ConfigureRecordPage
+                        fileName={fileName}
+                        targetLineRange={targetLineRange}
+                        onChange={(value: string) => {
+                            recordConfigPageState.onChangeCallback!(value);
+                        }}
+                        currentValue={recordConfigPageState.currentValue || ""}
+                        recordTypeField={recordConfigPageState.recordTypeField}
+                        onClose={closeRecordConfigPage}
+                        getHelperPane={expressionEditor.getHelperPane}
+                        field={knowledgeBaseFields.find((f) => f.key === recordConfigPageState.fieldKey)}
+                        triggerCharacters={expressionEditor.triggerCharacters}
+                        formContext={{
+                            expressionEditor: formExpressionEditor,
+                            popupManager: popupManager,
+                            nodeInfo: { kind: node.codedata.node },
+                        }}
+                    />
+                </DynamicModal>
+            )}
+        </>
     );
 }
 


### PR DESCRIPTION
### Purpose

Record-typed fields did not open the record configuration editor when clicked in a couple of forms. This wires up the missing record-editor configuration so clicking a record field opens `ConfigureRecordPage`, consistent with the forms where it already works (e.g. the variable form and connection creation).

Fixes wso2/product-integrator#1869

https://github.com/user-attachments/assets/324607f0-8651-4a22-a971-6e44a1d62129

### Root cause

For a field to open the record editor, the form must supply **both**:

1. `recordTypeFields` to the shared `<Form>` — the list of fields whose primary input type has `typeMembers` with `kind === "RECORD_TYPE"`. Without it, `FieldFactory` never marks the field as a record.
2. A rendered `ConfigureRecordPage` panel driven by an `onOpenRecordConfigPage` handler on the form's `expressionEditor`. If the handler fires but nothing renders the panel, clicking does nothing.

Each affected form was missing one or both halves.

### Changes

- **Knowledge Base form** — computed `recordTypeFields`, passed them to `<Form>`, and rendered `ConfigureRecordPage` via a local `onOpenRecordConfigPage` handler (self-contained, mirroring `ArtifactForm`).
- **Connection config** — rendered `ArtifactForm` (which provides the panel/handler) but never passed `recordTypeFields`. Computed them from the selected connection node's properties and passed them through, matching the connection-creation flow.
