### PR TITLE
Recover in-progress Copilot chat when the panel is closed and reopened

### DIFF
--- a/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -43,6 +43,8 @@ import {
     CheckpointInfo,
     AbortAIGenerationRequest,
     UsageResponse,
+    ActiveGenerationState,
+    GetActiveGenerationStateRequest,
     OpenFileDiffRequest,
     WebToolApprovalRequest,
     CompactConversationRequest,
@@ -136,6 +138,7 @@ export interface AIPanelAPI {
     updateChatMessage: (params: UpdateChatMessageRequest) => Promise<void>;
     getActiveTempDir: () => Promise<string>;
     getUsage: () => Promise<UsageResponse | undefined>;
+    getActiveGenerationState: (params: GetActiveGenerationStateRequest) => Promise<ActiveGenerationState>;
     openFileDiff: (params: OpenFileDiffRequest) => void;
     approveWebTool: (params: WebToolApprovalRequest) => Promise<void>;
     declineWebTool: (params: WebToolApprovalRequest) => Promise<void>;

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -543,6 +543,12 @@ export interface ActiveGenerationState {
      * these through its normal renderer to rebuild everything it missed while it was closed.
      */
     events?: ChatNotify[];
+    /**
+     * Request ids of interactive prompts (clarify/approval/etc.) that are still awaiting a user
+     * response. On reopen the panel re-surfaces the journaled prompt for these (so the question can
+     * be answered) and skips prompts already resolved earlier in the run.
+     */
+    pendingRequestIds?: string[];
 }
 
 export interface OpenFileDiffRequest {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -18,7 +18,7 @@
  */
 
 import { FunctionDefinition } from "@wso2/syntax-tree";
-import { AIMachineContext, AIMachineStateValue } from "../../state-machine-types";
+import { AIMachineContext, AIMachineStateValue, ChatNotify } from "../../state-machine-types";
 import { Command, SkillCommand, TemplateId } from "../../interfaces/ai-panel";
 import { AllDataMapperSourceRequest, ExtendedDataMapperMetadata } from "../../interfaces/extended-lang-client";
 import { ComponentInfo, Diagnostics, DMModel, ImportStatements, LinePosition, LineRange, OperationType } from "../..";
@@ -519,6 +519,30 @@ export interface AbortAIGenerationRequest {
 export interface UsageResponse {
     remainingUsagePercentage: number;
     resetsIn: number; // in seconds
+}
+
+/**
+ * Request for the active generation state. The event journal can be large, so it is only
+ * included when explicitly requested (reopen/replay); the spinner watchdog omits it.
+ */
+export interface GetActiveGenerationStateRequest {
+    includeEvents?: boolean;
+}
+
+/**
+ * State of the in-flight (or just-finished-but-unrecorded) generation for a thread.
+ * Returned to a reopened panel so it can reflect the real run state and replay missed steps.
+ */
+export interface ActiveGenerationState {
+    /** True while a generation is actively executing in the extension host. */
+    isGenerating: boolean;
+    /** Id of the active (or most recently journaled) generation, if any. */
+    generationId?: string;
+    /**
+     * The recorded UI event stream for the generation, if a journal exists. The panel replays
+     * these through its normal renderer to rebuild everything it missed while it was closed.
+     */
+    events?: ChatNotify[];
 }
 
 export interface OpenFileDiffRequest {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -45,6 +45,8 @@ import {
     CheckpointInfo,
     AbortAIGenerationRequest,
     UsageResponse,
+    ActiveGenerationState,
+    GetActiveGenerationStateRequest,
     OpenFileDiffRequest,
     WebToolApprovalRequest,
     CompactConversationRequest,
@@ -124,6 +126,7 @@ export const clearChat: RequestType<void, void> = { method: `${_preFix}/clearCha
 export const updateChatMessage: RequestType<UpdateChatMessageRequest, void> = { method: `${_preFix}/updateChatMessage` };
 export const getActiveTempDir: RequestType<void, string> = { method: `${_preFix}/getActiveTempDir` };
 export const getUsage: RequestType<void, UsageResponse | undefined> = { method: `${_preFix}/getUsage` };
+export const getActiveGenerationState: RequestType<GetActiveGenerationStateRequest, ActiveGenerationState> = { method: `${_preFix}/getActiveGenerationState` };
 export const openFileDiff: NotificationType<OpenFileDiffRequest> = { method: `${_preFix}/openFileDiff` };
 export const approveWebTool: RequestType<WebToolApprovalRequest, void> = { method: `${_preFix}/approveWebTool` };
 export const declineWebTool: RequestType<WebToolApprovalRequest, void> = { method: `${_preFix}/declineWebTool` };

--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -95,6 +95,16 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
             existingTempPath: pendingReview?.reviewState.tempProjectPath
         });
 
+        // Record the UI event stream for this generation so a panel that is closed mid-run and
+        // reopened can replay everything it missed. The generation runs in the extension host and
+        // survives the panel, but the streamed notifications don't — the journal bridges that gap.
+        chatStateStorage.startJournal(projectRootPath, threadId, config.generationId);
+        const forwardEvent = config.eventHandler;
+        config.eventHandler = (event) => {
+            chatStateStorage.appendJournalEvent(projectRootPath, threadId, config.generationId, event);
+            forwardEvent(event);
+        };
+
         // Inject migration source tools for projects that have been AI-enhanced
         const migrationSourcePath = getMigrationSourcePathForProject(projectRootPath);
         if (migrationSourcePath) {

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
@@ -718,6 +718,58 @@ export class ApprovalManager {
     }
 
     /**
+     * Cancel only the interactive requests that cannot be recovered after the AI panel is closed
+     * and reopened, and tear down transient UI. Called when the panel is *disposed* (not aborted).
+     *
+     * Popup-based requests (the configuration collector, whose popup view is torn down here) are
+     * resolved as skipped because they cannot be replayed into the reopened chat — leaving them
+     * pending would strand the run. In-chat prompts (plan/task/connector/web-tool/clarify/skill)
+     * are intentionally LEFT PENDING: the agent run survives the panel in the extension host, and
+     * these prompts are re-surfaced from the event journal on reopen so the user can still answer
+     * them. (Full cancellation still happens on explicit abort via cancelAllPending.)
+     */
+    cancelOnPanelClose(reason: string): void {
+        console.log(`[ApprovalManager] Panel closed — preserving in-chat prompts, cancelling popup-based ones: ${reason}`);
+
+        // Close popup approval views (currently only the configuration collector).
+        approvalViewManager.cleanupAllViews();
+
+        // Resolve configuration requests as skipped — popup-based, not replayable into the chat.
+        for (const [, resolver] of this.configurationRequests.entries()) {
+            if (resolver.timeoutId) {
+                clearTimeout(resolver.timeoutId);
+            }
+            resolver.resolve({ provided: false, comment: reason });
+        }
+        this.configurationRequests.clear();
+
+        // Reset notification counters and fire handlers (e.g. turn off the web-search globe).
+        for (const [type, count] of this.notificationCounters.entries()) {
+            if (count > 0) {
+                this.notificationCounters.set(type, 0);
+                this.notificationHandlers.get(type)?.(false);
+            }
+        }
+    }
+
+    /**
+     * All request ids that are currently awaiting a user response, across every interactive type.
+     * Used on reopen to decide which journaled prompt to re-surface (still pending) vs. skip
+     * (already resolved earlier in the run).
+     */
+    getPendingRequestIds(): string[] {
+        return [
+            ...this.planApprovals.keys(),
+            ...this.taskApprovals.keys(),
+            ...this.connectorSpecs.keys(),
+            ...this.configurationRequests.keys(),
+            ...this.webToolApprovals.keys(),
+            ...this.clarifyRequests.keys(),
+            ...this.skillEnableRequests.keys(),
+        ];
+    }
+
+    /**
      * Get count of pending approvals (useful for debugging)
      */
     getPendingCount(): { plans: number; tasks: number; connectorSpecs: number; configurations: number; webTools: number; clarify: number } {

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -326,7 +326,18 @@ export function sendWebToolToggleNotification(active: boolean): void {
 }
 
 export function sendAIPanelNotification(msg: ChatNotify): void {
-    RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, msg);
+    // The agent keeps running after the panel is closed (by design), but posting to a disposed
+    // webview throws "Webview is disposed" and floods the logs. The event is already recorded in
+    // the journal before this call, so skipping the post loses nothing — reconnect replays it from
+    // the journal on reopen. Guard on the live panel, and swallow any late-dispose race defensively.
+    if (!AiPanelWebview.currentPanel) {
+        return;
+    }
+    try {
+        RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, msg);
+    } catch (e) {
+        // Panel was disposed between the guard and the send — safe to ignore (journal has the event).
+    }
 }
 
 /**

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -90,6 +90,8 @@ import {
     declineWebTool,
     WebToolApprovalRequest,
     getUsage,
+    getActiveGenerationState,
+    GetActiveGenerationStateRequest,
     compactConversation,
     CompactConversationRequest,
     getShowContextUsage,
@@ -191,6 +193,7 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(updateChatMessage, (args: UpdateChatMessageRequest) => rpcManger.updateChatMessage(args));
     messenger.onRequest(getActiveTempDir, () => rpcManger.getActiveTempDir());
     messenger.onRequest(getUsage, () => rpcManger.getUsage());
+    messenger.onRequest(getActiveGenerationState, (args: GetActiveGenerationStateRequest) => rpcManger.getActiveGenerationState(args));
     messenger.onNotification(openFileDiff, (args: OpenFileDiffRequest) => rpcManger.openFileDiff(args));
     messenger.onRequest(approveWebTool, (args: WebToolApprovalRequest) => rpcManger.approveWebTool(args));
     messenger.onRequest(declineWebTool, (args: WebToolApprovalRequest) => rpcManger.declineWebTool(args));

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -809,6 +809,7 @@ User reverted the last made changes. The files have been restored to the state b
             isGenerating: !!active,
             generationId: active?.generationId ?? journal?.generationId,
             events: params?.includeEvents ? journal?.events : undefined,
+            pendingRequestIds: approvalManager.getPendingRequestIds(),
         };
     }
 

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -45,6 +45,8 @@ import {
     UIChatMessage,
     UpdateChatMessageRequest,
     UsageResponse,
+    ActiveGenerationState,
+    GetActiveGenerationStateRequest,
     WebToolApprovalRequest,
     CompactConversationRequest,
     CompactConversationResponse,
@@ -684,6 +686,14 @@ User reverted the last made changes. The files have been restored to the state b
             uiResponse: params.content
         });
 
+        // Once the transcript is durably saved as uiResponse and the run is no longer active, the
+        // event journal is redundant — drop it so a future reopen doesn't replay a finished run.
+        const active = chatStateStorage.getActiveExecution(projectRootPath, threadId);
+        const journal = chatStateStorage.getJournal(projectRootPath, threadId);
+        if (journal?.generationId === params.messageId && active?.generationId !== params.messageId) {
+            chatStateStorage.clearJournal(projectRootPath, threadId);
+        }
+
         console.log(`[RPC] Updated generation ${params.messageId} UI response`);
     }
 
@@ -781,6 +791,25 @@ User reverted the last made changes. The files have been restored to the state b
             console.error("Failed to fetch usage:", error);
             return undefined;
         }
+    }
+
+    async getActiveGenerationState(params?: GetActiveGenerationStateRequest): Promise<ActiveGenerationState> {
+        const projectRootPath = resolveProjectRootPath();
+        const threadId = 'default';
+
+        const active = chatStateStorage.getActiveExecution(projectRootPath, threadId);
+        const journal = chatStateStorage.getJournal(projectRootPath, threadId);
+
+        // isGenerating reflects the real run state (an AbortController is registered for the whole
+        // run lifetime). The journal is only serialized when explicitly requested (reopen/replay);
+        // the spinner watchdog polls without it. The journal is returned whenever one exists —
+        // including when a run finished while the panel was closed and its uiResponse was never
+        // recorded — so the reopened panel can replay it and re-persist the transcript.
+        return {
+            isGenerating: !!active,
+            generationId: active?.generationId ?? journal?.generationId,
+            events: params?.includeEvents ? journal?.events : undefined,
+        };
     }
 
     private static diffContentProviderRegistered = false;

--- a/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -24,6 +24,7 @@ import {
     GenerationMetadata,
     GenerationReviewState,
     Checkpoint,
+    ChatNotify,
 } from '@wso2/ballerina-core/lib/state-machine-types';
 import { approvalManager } from '../../features/ai/state/ApprovalManager';
 import { generateId } from './idGenerators';
@@ -57,6 +58,23 @@ function resolveWorkspaceIdentity(projectRootPath: string): string {
 export interface ActiveExecution {
     generationId: string;              // For logging and correlation with generation
     abortController: AbortController;  // For actual abort operation
+}
+
+/**
+ * In-memory recording of the UI event stream for the most recent generation on a thread.
+ *
+ * The agent generation runs in the extension host and survives the webview panel being
+ * closed/reopened. This journal lets a reopened panel replay every ChatNotify it missed
+ * (text, tool calls/results, review/plan cards, terminal signals) through the exact same
+ * renderer it uses for live events, so the conversation comes back complete.
+ *
+ * Runtime-only (like activeExecutions): scoped to a single VS Code session. A full window
+ * reload restarts the extension host and also kills the running generation, so there is no
+ * live run to reconnect to in that case.
+ */
+export interface GenerationJournal {
+    generationId: string;
+    events: ChatNotify[];
 }
 
 // ============================================
@@ -251,6 +269,10 @@ export class ChatStateStorage {
     // Track active executions per workspace/thread for abort functionality (runtime-only)
     private activeExecutions: Map<string, Map<string, ActiveExecution>> = new Map();
 
+    // Record the UI event stream of the latest generation per workspace/thread so a reopened
+    // panel can replay what it missed (runtime-only; see GenerationJournal).
+    private generationJournals: Map<string, Map<string, GenerationJournal>> = new Map();
+
     // File-based persistence store
     private readonly persistenceStore: CopilotPersistenceStore;
 
@@ -441,6 +463,8 @@ export class ChatStateStorage {
         }
 
         this.storage.delete(projectRootPath);
+        // Drop any recorded event journals so a cleared chat can't be replayed
+        this.generationJournals.delete(projectRootPath);
         // Also remove persisted data
         this.persistenceStore.deleteWorkspace(projectRootPath);
         console.log(`[ChatStateStorage] Cleared workspace: ${projectRootPath}`);
@@ -1152,6 +1176,63 @@ export class ChatStateStorage {
      */
     getActiveExecution(projectRootPath: string, threadId: string): ActiveExecution | undefined {
         return this.activeExecutions.get(projectRootPath)?.get(threadId);
+    }
+
+    // ============================================
+    // Generation event journal (reconnect/replay)
+    // ============================================
+
+    /**
+     * Begin recording the UI event stream for a new generation on a thread.
+     * Replaces any prior journal for the thread (only the latest generation is retained).
+     */
+    startJournal(projectRootPath: string, threadId: string, generationId: string): void {
+        let threadMap = this.generationJournals.get(projectRootPath);
+        if (!threadMap) {
+            threadMap = new Map();
+            this.generationJournals.set(projectRootPath, threadMap);
+        }
+        threadMap.set(threadId, { generationId, events: [] });
+    }
+
+    /**
+     * Append an emitted event to the journal for the given generation.
+     * No-op if journaling wasn't started or the generationId doesn't match the current journal
+     * (e.g. a stale event from a superseded run).
+     */
+    appendJournalEvent(
+        projectRootPath: string,
+        threadId: string,
+        generationId: string,
+        event: ChatNotify
+    ): void {
+        const journal = this.generationJournals.get(projectRootPath)?.get(threadId);
+        if (!journal || journal.generationId !== generationId) {
+            return;
+        }
+        journal.events.push(event);
+    }
+
+    /**
+     * Get the recorded journal for a thread (the latest generation), if any.
+     */
+    getJournal(projectRootPath: string, threadId: string): GenerationJournal | undefined {
+        return this.generationJournals.get(projectRootPath)?.get(threadId);
+    }
+
+    /**
+     * Discard the journal for a thread. Called once the transcript is durably persisted as
+     * uiResponse (so replay is no longer needed) and on chat clear.
+     */
+    clearJournal(projectRootPath: string, threadId: string): void {
+        const threadMap = this.generationJournals.get(projectRootPath);
+        if (!threadMap) {
+            return;
+        }
+        threadMap.delete(threadId);
+        if (threadMap.size === 0) {
+            this.generationJournals.delete(projectRootPath);
+        }
     }
 }
 

--- a/packages/ballerina-extension/src/views/ai-panel/webview.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/webview.ts
@@ -128,7 +128,12 @@ export class AiPanelWebview {
 
     public dispose() {
 
-        approvalManager.cancelAllPending("AI Panel closed");
+        // Closing the panel must not discard an in-progress run's pending question. The agent keeps
+        // running in the extension host, so leave in-chat prompts (clarify/approval/etc.) pending —
+        // they are re-surfaced from the journal on reopen and remain answerable. Only popup-based
+        // prompts that can't be replayed (configuration) are cancelled here. Explicit abort still
+        // cancels everything via chatStateStorage.abortActiveExecution → cancelAllPending.
+        approvalManager.cancelOnPanelClose("AI Panel closed");
 
         AiPanelWebview.currentPanel = undefined;
         AIStateMachine.sendEvent(AIMachineEventType.DISPOSE);

--- a/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -49,6 +49,8 @@ import {
     UIChatMessage,
     UpdateChatMessageRequest,
     UsageResponse,
+    ActiveGenerationState,
+    GetActiveGenerationStateRequest,
     WebToolApprovalRequest,
     ClarifyAnswerRequest,
     ClarifyCancelRequest,
@@ -103,6 +105,7 @@ import {
     updateChatMessage,
     updateRequirementSpecification,
     getUsage,
+    getActiveGenerationState,
     compactConversation,
     CompactConversationRequest,
     CompactConversationResponse,
@@ -341,6 +344,10 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     getUsage(): Promise<UsageResponse | undefined> {
         return this._messenger.sendRequest(getUsage, HOST_EXTENSION);
+    }
+
+    getActiveGenerationState(params: GetActiveGenerationStateRequest): Promise<ActiveGenerationState> {
+        return this._messenger.sendRequest(getActiveGenerationState, HOST_EXTENSION, params);
     }
 
     openFileDiff(params: OpenFileDiffRequest): void {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -352,6 +352,10 @@ const AIChat: React.FC = () => {
     const processChatNotifyRef = useRef<(r: ChatNotify) => void | Promise<void>>();
     // Ensures the reconnect/replay runs at most once for this panel mount.
     const didReconnectRef = useRef(false);
+    // Request ids of interactive prompts still awaiting a response, captured at reconnect. During
+    // replay, a journaled prompt is re-shown only if its id is in here (still pending); prompts
+    // resolved earlier in the run are skipped so their banner doesn't reappear.
+    const pendingRequestIdsRef = useRef<Set<string>>(new Set());
 
     /* REFACTORED CODE START [2] */
     // custom hooks: commands + attachments
@@ -654,6 +658,10 @@ const AIChat: React.FC = () => {
                 } catch (e) {
                     console.error('[AIChat] Failed to query active generation state:', e);
                 }
+                // Prompts still awaiting an answer — used by the replay skip guard to re-show only
+                // still-pending interactive prompts (see processChatNotify).
+                pendingRequestIdsRef.current = new Set(genState?.pendingRequestIds ?? []);
+
                 const journalEvents = genState?.events;
                 const generationId = genState?.generationId;
                 const hasJournal = !!(journalEvents && journalEvents.length > 0 && generationId);
@@ -829,13 +837,18 @@ const AIChat: React.FC = () => {
     const processChatNotify = async (response: ChatNotify) => {
         const type = response.type;
 
-        // When replaying a journal on reopen, suppress interactive-prompt events. Closing the
-        // panel already cancelled any pending approvals (webview dispose → cancelAllPending), so
-        // these requests are resolved/stale — re-showing them would pop dead dialogs. The tool
-        // cards they relate to render from their own (non-skipped) tool_call/tool_result events,
-        // and any approval the live run still needs after reopen arrives as a fresh live event.
+        // When replaying a journal on reopen, an interactive prompt is only re-shown if it's still
+        // awaiting a response (its requestId is in pendingRequestIdsRef). Prompts resolved earlier
+        // in the run are skipped so their banner doesn't reappear — the transcript around them is
+        // still rebuilt from their non-skipped tool_call/tool_result/text events. A pending prompt,
+        // by contrast, is re-surfaced so the user can answer it (the backend keeps it alive across
+        // panel close), fixing the "question lost on reopen" case.
         if (replayingRef.current && REPLAY_SKIP_EVENT_TYPES.has(type)) {
-            return;
+            const reqId = (response as any).requestId;
+            if (!reqId || !pendingRequestIdsRef.current.has(reqId)) {
+                return;
+            }
+            // still pending → fall through and render the live prompt
         }
 
         if (type === "content_block") {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -356,6 +356,13 @@ const AIChat: React.FC = () => {
     // replay, a journaled prompt is re-shown only if its id is in here (still pending); prompts
     // resolved earlier in the run are skipped so their banner doesn't reappear.
     const pendingRequestIdsRef = useRef<Set<string>>(new Set());
+    // Live-event gate. The onChatNotify subscription is active from the first render, but reconnect
+    // (history load + journal replay) happens later and asynchronously. While the gate is CLOSED,
+    // incoming live events are queued instead of processed, so they can't race the replay (arrive
+    // mid-replay and interleave, or arrive before the base transcript is set and corrupt it). The
+    // reconnect effect drains the queue in order and opens the gate once replay is done.
+    const liveGateClosedRef = useRef(true);
+    const liveQueueRef = useRef<ChatNotify[]>([]);
 
     /* REFACTORED CODE START [2] */
     // custom hooks: commands + attachments
@@ -631,6 +638,14 @@ const AIChat: React.FC = () => {
      */
     useEffect(function loadInitialChatHistory() {
         const loadHistory = async () => {
+            // Duplicate/concurrent mount (React StrictMode, or an rpcClient identity change): the
+            // primary run owns history load, gate and replay. Bail immediately so we never replay
+            // twice, double-open the gate, or race the primary's setMessages.
+            if (didReconnectRef.current) {
+                return;
+            }
+            didReconnectRef.current = true;
+
             try {
                 const historyMessages = await rpcClient.getAiPanelRpcClient().getChatMessages();
                 let baseMessages = (historyMessages && historyMessages.length > 0)
@@ -641,23 +656,20 @@ const AIChat: React.FC = () => {
                 // panel was closed. The extension host keeps generating even after the panel is torn
                 // down, and records every event in a journal — replay it so the conversation comes
                 // back complete and the spinner reflects the real state.
-                //
-                // Guard against double-execution (React StrictMode remount, or an rpcClient identity
-                // change): replaying the journal twice would duplicate the recovered transcript.
-                // History loading above stays idempotent (the setMessages below keeps any existing
-                // messages), so only the reconnect/replay is gated.
-                if (didReconnectRef.current) {
-                    setMessages((prevMessages) => (prevMessages.length > 0 ? prevMessages : baseMessages));
-                    return;
-                }
-                didReconnectRef.current = true;
-
                 let genState: ActiveGenerationState | undefined;
                 try {
                     genState = await rpcClient.getAiPanelRpcClient().getActiveGenerationState({ includeEvents: true });
                 } catch (e) {
                     console.error('[AIChat] Failed to query active generation state:', e);
                 }
+
+                // The journal snapshot above (taken on the backend when getActiveGenerationState ran)
+                // already contains every event up to that point. Any live event queued before now is
+                // therefore ≤ snapshot and would be a duplicate of a journaled event — discard them.
+                // Events that arrive AFTER this point are post-snapshot and are drained (below) once
+                // replay completes. (Messenger delivery is FIFO, so the RPC response ordering holds.)
+                liveQueueRef.current = [];
+
                 // Prompts still awaiting an answer — used by the replay skip guard to re-show only
                 // still-pending interactive prompts (see processChatNotify).
                 pendingRequestIdsRef.current = new Set(genState?.pendingRequestIds ?? []);
@@ -716,6 +728,22 @@ const AIChat: React.FC = () => {
             } catch (error) {
                 console.error('[AIChat] Failed to load initial chat history:', error);
                 // Continue with empty messages - don't block the UI
+            } finally {
+                // Open the gate: replay is done (or was skipped). Drain any live events that arrived
+                // after the snapshot, IN ORDER, then resume direct dispatch. Events that arrive during
+                // this drain re-queue and are picked up by the loop, so opening the gate right after
+                // the loop (synchronously) can't drop anything.
+                const q = liveQueueRef.current;
+                while (q.length > 0) {
+                    const ev = q.shift();
+                    if (!ev) { continue; }
+                    try {
+                        await processChatNotifyRef.current?.(ev);
+                    } catch (e) {
+                        console.error('[AIChat] live drain failed:', e);
+                    }
+                }
+                liveGateClosedRef.current = false;
             }
         };
 
@@ -1290,7 +1318,16 @@ const AIChat: React.FC = () => {
         }
     };
     processChatNotifyRef.current = processChatNotify;
-    rpcClient?.onChatNotify(processChatNotify);
+    // Live subscription. While the reconnect gate is closed (mount → replay done), queue events so
+    // they can't race the async replay; the reconnect effect drains them in order and opens the gate.
+    const onLiveChatNotify = (response: ChatNotify) => {
+        if (liveGateClosedRef.current) {
+            liveQueueRef.current.push(response);
+            return;
+        }
+        return processChatNotify(response);
+    };
+    rpcClient?.onChatNotify(onLiveChatNotify);
 
     function generateNaturalProgrammingTemplate(isReqFileExists: boolean) {
         if (isReqFileExists) {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -26,6 +26,7 @@ import {
     Command,
     TemplateId,
     ChatNotify,
+    ActiveGenerationState,
     DocumentationGeneratorIntermediaryState,
     OperationType,
     DocGenerationRequest,
@@ -188,6 +189,16 @@ function appendToLastEntry(entries: StreamEntry[], item: StreamItem): StreamEntr
     return [...entries.slice(0, -1), { ...last, items: [...last.items, item] }];
 }
 
+// Interactive-prompt event types skipped while replaying a journal on reopen (their live
+// interaction is already resolved/cancelled; only the passive transcript should be rebuilt).
+const REPLAY_SKIP_EVENT_TYPES = new Set<string>([
+    "task_approval_request",
+    "web_tool_approval_request",
+    "configuration_collection_event",
+    "clarify_event",
+    "skill_enable_event",
+]);
+
 const SCAFFOLD_DONE_PREFIX = "ballerina.scaffold.done:";
 
 // Stable, non-crypto hash for keying scaffold runs by (prompt + steps).
@@ -214,15 +225,30 @@ const AIChat: React.FC = () => {
         return -1;
     };
 
+    const getLatestUserMessageIndex = (chatMessages: Array<{ role: string }>): number => {
+        for (let i = chatMessages.length - 1; i >= 0; i--) {
+            const role = chatMessages[i]?.role;
+            if (role === "User" || role === "user") {
+                return i;
+            }
+        }
+        return -1;
+    };
+
     const ensureAssistantMessage = (
         chatMessages: Array<{ role: string; content: string; type: string; checkpointId?: string; messageId?: string }>
     ): number => {
-        let targetIndex = getLatestAssistantMessageIndex(chatMessages);
-        if (targetIndex === -1) {
-            chatMessages.push({ role: "Copilot", content: "", type: "assistant_message" });
-            targetIndex = chatMessages.length - 1;
+        const targetIndex = getLatestAssistantMessageIndex(chatMessages);
+        // Reuse the trailing assistant bubble only if it belongs to the CURRENT turn — i.e. it
+        // comes after the most recent user message. Otherwise (a newer user prompt exists, or there
+        // is no assistant yet) start a fresh bubble so streamed content lands under the right turn.
+        // Without this, replaying a follow-up turn's events on reopen merges them into the previous
+        // turn's bubble and the follow-up prompt is pushed below its own response.
+        if (targetIndex !== -1 && targetIndex > getLatestUserMessageIndex(chatMessages)) {
+            return targetIndex;
         }
-        return targetIndex;
+        chatMessages.push({ role: "Copilot", content: "", type: "assistant_message" });
+        return chatMessages.length - 1;
     };
 
     const updateLastMessage = (updater: (content: string) => string) => {
@@ -312,6 +338,20 @@ const AIChat: React.FC = () => {
     const activeScaffoldKeyRef = useRef<string | null>(null);
 
     const messagesEndRef = React.useRef<HTMLDivElement>(null);
+
+    // ── Reconnect / replay plumbing ─────────────────────────────────────────────
+    // True while replaying a journal on reopen, so the notify handler can suppress
+    // side effects (e.g. the save_chat round-trip) that only make sense for live events.
+    const replayingRef = useRef(false);
+    // Always-fresh mirror of `messages`, used to read the rebuilt transcript after a replay
+    // (the notify handler's own closure would be stale inside an async replay loop).
+    const latestMessagesRef = useRef(messages);
+    useEffect(() => { latestMessagesRef.current = messages; }, [messages]);
+    // Stable handle to the latest notify handler so the reconnect/replay effect can invoke it
+    // without depending on the (re-created-every-render) closure.
+    const processChatNotifyRef = useRef<(r: ChatNotify) => void | Promise<void>>();
+    // Ensures the reconnect/replay runs at most once for this panel mount.
+    const didReconnectRef = useRef(false);
 
     /* REFACTORED CODE START [2] */
     // custom hooks: commands + attachments
@@ -589,9 +629,81 @@ const AIChat: React.FC = () => {
         const loadHistory = async () => {
             try {
                 const historyMessages = await rpcClient.getAiPanelRpcClient().getChatMessages();
-                if (historyMessages && historyMessages.length > 0) {
-                    const uiMessages = convertToUIMessages(historyMessages);
-                    setMessages((prevMessages) => (prevMessages.length > 0 ? prevMessages : uiMessages));
+                let baseMessages = (historyMessages && historyMessages.length > 0)
+                    ? convertToUIMessages(historyMessages)
+                    : [];
+
+                // Reconnect to a run that was in progress (or finished but never recorded) while the
+                // panel was closed. The extension host keeps generating even after the panel is torn
+                // down, and records every event in a journal — replay it so the conversation comes
+                // back complete and the spinner reflects the real state.
+                //
+                // Guard against double-execution (React StrictMode remount, or an rpcClient identity
+                // change): replaying the journal twice would duplicate the recovered transcript.
+                // History loading above stays idempotent (the setMessages below keeps any existing
+                // messages), so only the reconnect/replay is gated.
+                if (didReconnectRef.current) {
+                    setMessages((prevMessages) => (prevMessages.length > 0 ? prevMessages : baseMessages));
+                    return;
+                }
+                didReconnectRef.current = true;
+
+                let genState: ActiveGenerationState | undefined;
+                try {
+                    genState = await rpcClient.getAiPanelRpcClient().getActiveGenerationState({ includeEvents: true });
+                } catch (e) {
+                    console.error('[AIChat] Failed to query active generation state:', e);
+                }
+                const journalEvents = genState?.events;
+                const generationId = genState?.generationId;
+                const hasJournal = !!(journalEvents && journalEvents.length > 0 && generationId);
+                // The persisted transcript already covers a finished turn once its uiResponse is
+                // saved (getChatMessages then returns its assistant bubble). Only replay the journal
+                // when a run is genuinely live, or when the last turn's transcript is missing
+                // (finished while the panel was closed) — otherwise a stale journal would re-render a
+                // resolved turn, including its review card.
+                const assistantAlreadyLoaded = !!generationId &&
+                    baseMessages.some((m) => m.role === "Copilot" && m.messageId === generationId);
+                const shouldReplay = hasJournal && (!!genState?.isGenerating || !assistantAlreadyLoaded);
+
+                if (shouldReplay) {
+                    // Drop any assistant bubble already loaded for this generation; the journal
+                    // replays the full turn from the start, so we rebuild it cleanly from scratch.
+                    baseMessages = baseMessages.filter(
+                        (m) => !(m.role === "Copilot" && m.messageId === generationId)
+                    );
+                }
+
+                setMessages((prevMessages) => (prevMessages.length > 0 ? prevMessages : baseMessages));
+
+                if (shouldReplay) {
+                    replayingRef.current = true;
+                    try {
+                        for (const ev of journalEvents) {
+                            await processChatNotifyRef.current?.(ev as ChatNotify);
+                        }
+                    } finally {
+                        replayingRef.current = false;
+                    }
+                }
+
+                if (genState?.isGenerating) {
+                    // A run is genuinely still executing — show the spinner and let live events continue.
+                    setIsLoading(true);
+                } else if (shouldReplay && generationId) {
+                    // Finished while we were closed and uiResponse was never captured. Persist the
+                    // rebuilt transcript once (after React commits the replayed messages) so it's
+                    // durable and getChatMessages returns it thereafter.
+                    setTimeout(() => {
+                        const msgs = latestMessagesRef.current;
+                        const idx = getLatestAssistantMessageIndex(msgs);
+                        const content = idx >= 0 ? msgs[idx]?.content : "";
+                        if (content) {
+                            rpcClient.getAiPanelRpcClient()
+                                .updateChatMessage({ messageId: generationId, content })
+                                .catch((e) => console.error('[AIChat] Failed to persist recovered transcript:', e));
+                        }
+                    }, 0);
                 }
             } catch (error) {
                 console.error('[AIChat] Failed to load initial chat history:', error);
@@ -601,6 +713,68 @@ const AIChat: React.FC = () => {
 
         loadHistory();
     }, [rpcClient]);
+
+    /**
+     * Effect: Spinner watchdog. Streaming completion normally arrives as a `stop`/`abort`/`error`
+     * event that clears `isLoading`. If that terminal signal is ever missed (e.g. dropped while the
+     * panel was reconnecting), the panel would spin forever. While loading, poll the backend for the
+     * real run state; once the run is genuinely no longer active, clear the spinner. The on-screen
+     * transcript is already complete (streamed live and/or replayed from the journal), so we only
+     * release the loading state and don't touch the messages.
+     */
+    useEffect(function generationWatchdog() {
+        if (!isLoading) {
+            return;
+        }
+        let cancelled = false;
+        let sawActive = false;      // confirmed the run was actually in flight at least once
+        let negativePolls = 0;
+        const POLL_MS = 4000;
+        const MAX_STUCK_MS = 5 * 60 * 1000; // absolute ceiling before force-clearing
+        const startedAt = Date.now();
+
+        const clearSpinner = () => {
+            setIsLoading(false);
+            setIsCodeLoading(false);
+            setIsCompacting(false);
+            setIsMigrationEnhancementRunning(false);
+        };
+
+        const intervalId = setInterval(async () => {
+            if (cancelled) {
+                return;
+            }
+            let stillGenerating = false;
+            try {
+                const s = await rpcClient.getAiPanelRpcClient().getActiveGenerationState({ includeEvents: false });
+                stillGenerating = !!s?.isGenerating;
+            } catch (e) {
+                // Transient poll failure — treat as inconclusive, don't clear on it.
+                return;
+            }
+            if (stillGenerating) {
+                sawActive = true;
+                negativePolls = 0;
+                return;
+            }
+            const exceededCeiling = Date.now() - startedAt > MAX_STUCK_MS;
+            // Ignore "not generating" until we've confirmed a run was actually active, to avoid the
+            // startup race before the run registers in the extension host.
+            if (!sawActive && !exceededCeiling) {
+                return;
+            }
+            negativePolls += 1;
+            if (negativePolls >= 2 || exceededCeiling) {
+                console.warn('[AIChat] Watchdog clearing a stuck spinner (missed terminal signal).');
+                clearSpinner();
+            }
+        }, POLL_MS);
+
+        return () => {
+            cancelled = true;
+            clearInterval(intervalId);
+        };
+    }, [isLoading, rpcClient]);
 
     /**
      * Effect: Check for an active migration session that needs AI enhancement.
@@ -649,8 +823,20 @@ const AIChat: React.FC = () => {
         }
     });
 
-    rpcClient?.onChatNotify(async (response: ChatNotify) => {
+    // The notify handler is (re)registered every render; the messenger keeps a single handler
+    // per method (Map.set semantics), so this replaces rather than stacks — each registration
+    // closes over fresh state. It is also invoked directly during journal replay on reopen.
+    const processChatNotify = async (response: ChatNotify) => {
         const type = response.type;
+
+        // When replaying a journal on reopen, suppress interactive-prompt events. Closing the
+        // panel already cancelled any pending approvals (webview dispose → cancelAllPending), so
+        // these requests are resolved/stale — re-showing them would pop dead dialogs. The tool
+        // cards they relate to render from their own (non-skipped) tool_call/tool_result events,
+        // and any approval the live run still needs after reopen arrives as a fresh live event.
+        if (replayingRef.current && REPLAY_SKIP_EVENT_TYPES.has(type)) {
+            return;
+        }
 
         if (type === "content_block") {
             const content = response.content;
@@ -1025,6 +1211,12 @@ const AIChat: React.FC = () => {
 
         } else if (type === "save_chat") {
             console.log("Received save_chat signal");
+            // During replay we're rebuilding the transcript from the journal; the live `messages`
+            // closure is stale and persisting here would clobber uiResponse with empty content.
+            // The reconnect effect persists the rebuilt transcript once, after the replay settles.
+            if (replayingRef.current) {
+                return;
+            }
             const assistantIndex = getLatestAssistantMessageIndex(messages);
             const contentToSave = assistantIndex >= 0 ? messages[assistantIndex]?.content : messages[messages.length - 1]?.content;
             await rpcClient.getAiPanelRpcClient().updateChatMessage({
@@ -1083,7 +1275,9 @@ const AIChat: React.FC = () => {
             setIsLoading(false);
             isErrorChunkReceivedRef.current = true;
         }
-    });
+    };
+    processChatNotifyRef.current = processChatNotify;
+    rpcClient?.onChatNotify(processChatNotify);
 
     function generateNaturalProgrammingTemplate(isReqFileExists: boolean) {
         if (isReqFileExists) {


### PR DESCRIPTION
### Issue
If you close the Copilot panel while the agent is still generating, the run keeps
running in the extension host but the UI can't reconnect. On reopen the reply
produced while the panel was closed is missing, the "generating…" state doesn't
reflect reality, a pending clarifying question is silently skipped, and a missed
"finished" signal can leave the panel spinning forever.

### Fix
- Record each generation's UI event stream in an in-memory journal in the extension
  host, and add a `getActiveGenerationState` RPC so a reopened panel can ask "is a run
  in progress, and what did I miss?" and replay the missed events through the existing
  renderer — bringing the conversation back complete and correctly ordered.
- Reflect the real run state on reopen (show the spinner only when a run is genuinely
  active) and add a lightweight watchdog so a missed terminal signal can't strand the
  spinner.
- Keep in-chat prompts (clarify / approvals) alive when the panel closes so the run
  pauses instead of being skipped, and re-surface the still-pending prompt on reopen.
- Queue live events while the journal is replaying and drain them in order afterward,
  so live streaming can't interleave with replay; and stop posting notifications to a
  disposed panel (the journal already captured them), which removes the "Webview is
  disposed" log flood.

Fixes https://github.com/wso2/product-integrator/issues/1862

🤖 Generated with [Claude Code](https://claude.com/claude-code)
