### PR TITLE
Support PDF and image file attachments in BI Copilot chat

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -298,15 +298,24 @@ export function getUserPrompt(
                     type: 'image' as const,
                     image: attachment.content,
                 });
+            } else if (attachment.mimeType === 'application/pdf'
+                || attachment.fileName?.toLowerCase().endsWith('.pdf')) {
+                // Add PDF as a native file block so the model reads it directly
+                content.push({
+                    type: 'file' as const,
+                    data: attachment.content,
+                    mediaType: 'application/pdf',
+                });
             } else {
                 // Add text file attachment
-                const attachmentsText = params.fileAttachmentContents.map((attachment) =>
-                    `## File: ${attachment.fileName}\n\`\`\`\n${attachment.content}\n\`\`\``).join('\n\n');
                 content.push({
                     type: 'text' as const,
                     text: `<User Attachments>
-                            ${attachmentsText}
-                        </User Attachments>`
+## File: ${attachment.fileName}
+\`\`\`
+${attachment.content}
+\`\`\`
+</User Attachments>`
                 });
             }
         }

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -292,14 +292,22 @@ export function getUserPrompt(
     // Add file attachments if available
     if (params.fileAttachmentContents && params.fileAttachmentContents.length > 0) {
         for (const attachment of params.fileAttachmentContents) {
-            if (attachment.mimeType?.startsWith('image/')) {
-                // Add image attachment
+            const mimeType = attachment.mimeType ?? '';
+            const fileName = attachment.fileName?.toLowerCase() ?? '';
+            // Prefer the (already resolved) mime type; fall back to the filename
+            // extension only when no mime type is present, so a definitive type
+            // is never overridden by the file name.
+            const isImage = mimeType.startsWith('image/')
+                || (!mimeType && /\.(png|jpe?g|gif|webp)$/.test(fileName));
+            const isPdf = mimeType === 'application/pdf'
+                || (!mimeType && fileName.endsWith('.pdf'));
+            if (isImage) {
+                // Add image attachment (content is a self-describing base64 data URL)
                 content.push({
                     type: 'image' as const,
                     image: attachment.content,
                 });
-            } else if (attachment.mimeType === 'application/pdf'
-                || attachment.fileName?.toLowerCase().endsWith('.pdf')) {
+            } else if (isPdf) {
                 // Add PDF as a native file block so the model reads it directly
                 content.push({
                     type: 'file' as const,

--- a/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/attachmentManager.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/attachmentManager.ts
@@ -52,8 +52,9 @@ const IMAGE_TYPES = [
 
 /**
  * Combined text and image types for general commands.
+ * PDFs are included so they can be attached as native document blocks in the chat.
  */
-const TEXT_AND_IMAGE_TYPES = [...TEXT_BASED_TYPES, ...IMAGE_TYPES];
+const TEXT_AND_IMAGE_TYPES = [...TEXT_BASED_TYPES, ...IMAGE_TYPES, "application/pdf"];
 
 /**
  * Allowed file types for commands expecting documents/images.

--- a/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/attachmentUtils.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/attachmentUtils.ts
@@ -27,9 +27,12 @@ export const validateFileSize = (file: File): boolean => {
 
 /**
  * Validate file type by checking against a list of valid MIME types/extensions.
+ * Uses the resolved mime type so files with an empty browser-reported file.type
+ * (e.g. a .pdf/.png inferred from its extension) are validated consistently with
+ * how they are later read and labelled.
  */
 export const validateFileType = (file: File, validFileTypes: string[]): boolean => {
-    return validFileTypes.includes(file.type);
+    return validFileTypes.includes(resolveMimeType(file));
 };
 
 /**
@@ -53,10 +56,37 @@ export const readFileAsText = (file: File): Promise<string> => {
 };
 
 /**
- * Helper to check if a file is an image based on MIME type.
+ * Fallback MIME types inferred from the file extension. Used when the browser
+ * reports an empty `file.type`, which can happen for binary files (PDFs, images)
+ * depending on the OS / file-registration state.
+ */
+const EXTENSION_MIME_TYPES: Record<string, string> = {
+    pdf: "application/pdf",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    webp: "image/webp",
+};
+
+/**
+ * Best-known MIME type for a file: the browser-provided `file.type` when present,
+ * otherwise inferred from the file extension. Guarantees images and PDFs stay
+ * correctly typed even when `file.type` is empty.
+ */
+export const resolveMimeType = (file: File): string => {
+    if (file.type) {
+        return file.type;
+    }
+    const extension = file.name.toLowerCase().split(".").pop() ?? "";
+    return EXTENSION_MIME_TYPES[extension] ?? "";
+};
+
+/**
+ * Helper to check if a file is an image based on its resolved MIME type.
  */
 export const isImageFile = (file: File): boolean => {
-    return file.type.startsWith('image/');
+    return resolveMimeType(file).startsWith('image/');
 };
 
 /**

--- a/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/attachmentUtils.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/attachmentUtils.ts
@@ -78,3 +78,31 @@ export const readFileAsBase64 = (file: File): Promise<string> => {
         reader.readAsDataURL(file);
     });
 };
+
+/**
+ * Read a file as raw base64 (without the `data:...;base64,` prefix).
+ * Used for binary documents such as PDFs that are sent to the model as native
+ * file blocks. `readAsDataURL` emits single-line base64, so the stripped string
+ * has no embedded newlines.
+ */
+export const readFileAsRawBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+
+        reader.onload = () => {
+            if (typeof reader.result === "string") {
+                const base64String = reader.result.split(",")[1];
+                if (base64String) {
+                    resolve(base64String);
+                } else {
+                    reject(new Error("Failed to extract Base64 content."));
+                }
+            } else {
+                reject(new Error("File content is not a string."));
+            }
+        };
+
+        reader.onerror = () => reject(new Error("Error reading the file."));
+        reader.readAsDataURL(file);
+    });
+};

--- a/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/baseAttachment.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/baseAttachment.ts
@@ -18,7 +18,7 @@
 
 import { AttachmentHandler } from "./attachmentHandler";
 import { Attachment, AttachmentStatus } from "@wso2/ballerina-core";
-import { readFileAsText, readFileAsBase64, validateFileSize, validateFileType } from "./attachmentUtils";
+import { readFileAsText, readFileAsBase64, readFileAsRawBase64, validateFileSize, validateFileType } from "./attachmentUtils";
 
 /**
  * Abstract base class that provides common file-attachment handling logic.
@@ -60,11 +60,14 @@ export abstract class BaseAttachment implements AttachmentHandler {
 
             try {
                 const content = await this.readFileContent(file);
+                // Normalize the mime type so a PDF is always labelled application/pdf,
+                // even when the browser reports an empty file.type for a .pdf file.
+                const isPdf = file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
                 results.push({
                     name: file.name,
                     content,
                     status: AttachmentStatus.Success,
-                    mimeType: file.type,
+                    mimeType: isPdf ? "application/pdf" : file.type,
                 });
             } catch {
                 results.push({
@@ -81,12 +84,15 @@ export abstract class BaseAttachment implements AttachmentHandler {
 
     /**
      * Default method to read file content.
-     * Images are read as base64, text files as plain text.
+     * Images are read as base64 data URLs, PDFs as raw base64, text files as plain text.
      * Subclasses can override this if needed.
      */
     protected async readFileContent(file: File): Promise<string> {
         if (file.type.startsWith('image/')) {
             return readFileAsBase64(file);
+        }
+        if (file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')) {
+            return readFileAsRawBase64(file);
         }
         return readFileAsText(file);
     }

--- a/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/baseAttachment.ts
+++ b/packages/ballerina-visualizer/src/views/AIPanel/utils/attachment/baseAttachment.ts
@@ -18,7 +18,7 @@
 
 import { AttachmentHandler } from "./attachmentHandler";
 import { Attachment, AttachmentStatus } from "@wso2/ballerina-core";
-import { readFileAsText, readFileAsBase64, readFileAsRawBase64, validateFileSize, validateFileType } from "./attachmentUtils";
+import { readFileAsText, readFileAsBase64, readFileAsRawBase64, resolveMimeType, validateFileSize, validateFileType } from "./attachmentUtils";
 
 /**
  * Abstract base class that provides common file-attachment handling logic.
@@ -60,14 +60,13 @@ export abstract class BaseAttachment implements AttachmentHandler {
 
             try {
                 const content = await this.readFileContent(file);
-                // Normalize the mime type so a PDF is always labelled application/pdf,
-                // even when the browser reports an empty file.type for a .pdf file.
-                const isPdf = file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
                 results.push({
                     name: file.name,
                     content,
                     status: AttachmentStatus.Success,
-                    mimeType: isPdf ? "application/pdf" : file.type,
+                    // Resolve the mime type (falling back to the extension) so images
+                    // and PDFs stay correctly typed even when file.type is empty.
+                    mimeType: resolveMimeType(file),
                 });
             } catch {
                 results.push({
@@ -85,13 +84,15 @@ export abstract class BaseAttachment implements AttachmentHandler {
     /**
      * Default method to read file content.
      * Images are read as base64 data URLs, PDFs as raw base64, text files as plain text.
-     * Subclasses can override this if needed.
+     * The mime type is resolved from file.type with an extension fallback so binary
+     * files are never mis-read as text. Subclasses can override this if needed.
      */
     protected async readFileContent(file: File): Promise<string> {
-        if (file.type.startsWith('image/')) {
+        const mimeType = resolveMimeType(file);
+        if (mimeType.startsWith('image/')) {
             return readFileAsBase64(file);
         }
-        if (file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')) {
+        if (mimeType === 'application/pdf') {
             return readFileAsRawBase64(file);
         }
         return readFileAsText(file);


### PR DESCRIPTION
### Issue

The BI Copilot chat blocked PDF attachments, and binary files were mis-handled when the browser reported an empty `file.type`.

### Change

- Allow PDFs in the chat file picker and send them to the model as native document blocks.
- Resolve the mime type from the file extension when `file.type` is empty, so PDFs and images (`.png/.jpeg/.jpg/.gif/.webp`) are read/labelled correctly and never mis-read as text.
- Emit AI SDK `file`/`image` content parts (matching the Data Mapper reference); fix an N×N duplication of text attachments.

### Constraints

- 5 MB per-file cap unchanged (shared with Data Mapper / Type Creator).
- Uses the same Claude model/providers already handling PDFs (Anthropic / Bedrock / Vertex).
- Attachments are per-turn (not replayed into chat history).

Fixes https://github.com/wso2/product-integrator/issues/1860

🤖 Generated with [Claude Code](https://claude.com/claude-code)
