### PR TITLE
Guide Copilot to add @sql:Column when mapping records to DB tables

### DIFF
--- a/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/libs/function-registry.ts
@@ -882,6 +882,8 @@ async function getExternalRecords(
                     typeDefs: [typeDef],
                     services: library.services ? library.services : null,
                     annotations: library.annotations ? library.annotations : null,
+                    instructions: library.instructions ? library.instructions : null,
+                    readme: library.readme ? library.readme : null,
                 };
                 newLibraries.push(newLibrary);
             } else {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/resources/copilot/instructions/ballerina/sql/library.md
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/resources/copilot/instructions/ballerina/sql/library.md
@@ -4,19 +4,15 @@ The `ballerina/sql` library provides the core types, errors, and annotations for
 relational database access. Database-specific clients (`ballerinax/mysql`,
 `ballerinax/postgresql`, `ballerinax/mssql`, etc.) build on top of it.
 
-## CRITICAL: Annotate every field of a database-table record with `@sql:Column`
+## Mapping record fields to database columns with `@sql:Column`
 
-Whenever you define a Ballerina record type that represents a row of a database
-table, you MUST add a `@sql:Column {name: "<exact_column_name>"}` annotation to
-**every** field of that record, mapping the (camelCase) Ballerina field to its
-exact database column name (conventionally snake_case).
+When a SQL query result is mapped into a Ballerina record, the client matches
+each database column to a record field **by name**. Ballerina record fields use
+camelCase by convention, while database columns are commonly snake_case, so the
+names frequently do not match.
 
-Apply this rule to **all** fields, always:
-- Do it even if a field's name already matches its column name.
-- Do it even if no query has been written yet.
-
-The SQL client binds columns to record fields **by exact name**, so annotating
-every field with its column name guarantees the mapping is always correct.
+Use the `@sql:Column {name: "<column_name>"}` annotation to map a record field to
+its database column **whenever the field name differs from the column name**:
 
 ```ballerina
 import ballerina/sql;
@@ -28,3 +24,6 @@ type Customer record {|
     string customerName;
 |};
 ```
+
+A field whose name already matches its column exactly (e.g. a column `id` mapped
+to a field `id`) does not need the annotation.

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/resources/copilot/instructions/ballerina/sql/library.md
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/resources/copilot/instructions/ballerina/sql/library.md
@@ -1,0 +1,30 @@
+# Ballerina SQL Library Instructions
+
+The `ballerina/sql` library provides the core types, errors, and annotations for
+relational database access. Database-specific clients (`ballerinax/mysql`,
+`ballerinax/postgresql`, `ballerinax/mssql`, etc.) build on top of it.
+
+## CRITICAL: Annotate every field of a database-table record with `@sql:Column`
+
+Whenever you define a Ballerina record type that represents a row of a database
+table, you MUST add a `@sql:Column {name: "<exact_column_name>"}` annotation to
+**every** field of that record, mapping the (camelCase) Ballerina field to its
+exact database column name (conventionally snake_case).
+
+Apply this rule to **all** fields, always:
+- Do it even if a field's name already matches its column name.
+- Do it even if no query has been written yet.
+
+The SQL client binds columns to record fields **by exact name**, so annotating
+every field with its column name guarantees the mapping is always correct.
+
+```ballerina
+import ballerina/sql;
+
+type Customer record {|
+    @sql:Column {name: "customer_id"}
+    int customerId;
+    @sql:Column {name: "customer_name"}
+    string customerName;
+|};
+```


### PR DESCRIPTION
fixes: https://github.com/wso2/product-integrator/issues/1809
<img width="3248" height="1976" alt="Screenshot 2026-07-17 at 3 13 12 PM" src="https://github.com/user-attachments/assets/f5d91b15-521a-4ba2-96ac-8790f6c0dae5" />

## Problem
When Copilot generates a Ballerina record for a SQL table, it uses camelCase
field names (the Ballerina convention) while SQL columns are snake_case.
Without `@sql:Column {name: "..."}`, the sql client cannot bind columns to
fields at runtime. Copilot was not adding the annotation.

## Changes
- **New** `flow-model-generator-ls-extension/.../copilot/instructions/ballerina/sql/library.md`
  — instructs the model to annotate each field of a DB-table record with `@sql:Column`.
- **Fix** `function-registry.ts` `getExternalRecords`: preserve `instructions`
  and `readme` (previously only `services`/`annotations` were copied).

## Root cause — why the instruction alone wasn't enough
Per-library `instructions` reach the model via two paths:
- `toMaximizedLibrariesFromLibJson` (library has selected functions) — already copied `instructions`.
- `getExternalRecords` (library pulled in only as a type dependency) — did **not**.

In a DB flow the client is `ballerinax/mysql`; `ballerina/sql` contributes
only types, so it takes the external path and its `library.md` was dropped —
the model never saw the rule. Other libraries with a `library.md` (ai,
workflow, test) are always primary/selected, so they went through the main
path and were unaffected. This is why the gap surfaced now.