### PR TITLE
feat: AI panel reconnection — agent runs survive panel close/reopen

### DIFF
--- a/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -84,6 +84,7 @@ import {
     // OpenMemoryRequest,
     GetRunStatusRequest,
     GetRunStatusResponse,
+    HasPendingReviewRequest,
 } from "./interfaces";
 
 export interface AIPanelAPI {
@@ -144,7 +145,7 @@ export interface AIPanelAPI {
     clearChat: () => Promise<void>;
     updateChatMessage: (params: UpdateChatMessageRequest) => Promise<void>;
     getActiveTempDir: () => Promise<string>;
-    hasPendingReview: () => Promise<boolean>;
+    hasPendingReview: (params: HasPendingReviewRequest) => Promise<boolean>;
     getRunStatus: (params: GetRunStatusRequest) => Promise<GetRunStatusResponse>;
     getUsage: () => Promise<UsageResponse | undefined>;
     requestQuota: (params: QuotaRequestParams) => Promise<QuotaRequestResult>;

--- a/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -82,6 +82,8 @@ import {
     // TODO(auto-memory): temporarily disabled for this release.
     // ClearMemoryRequest,
     // OpenMemoryRequest,
+    GetRunStatusRequest,
+    GetRunStatusResponse,
 } from "./interfaces";
 
 export interface AIPanelAPI {
@@ -143,6 +145,7 @@ export interface AIPanelAPI {
     updateChatMessage: (params: UpdateChatMessageRequest) => Promise<void>;
     getActiveTempDir: () => Promise<string>;
     hasPendingReview: () => Promise<boolean>;
+    getRunStatus: (params: GetRunStatusRequest) => Promise<GetRunStatusResponse>;
     getUsage: () => Promise<UsageResponse | undefined>;
     requestQuota: (params: QuotaRequestParams) => Promise<QuotaRequestResult>;
     openFileDiff: (params: OpenFileDiffRequest) => void;

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -569,6 +569,14 @@ export interface GetRunStatusResponse {
     isRunning: boolean;
     events: ChatNotify[];
     isPlanMode?: boolean;
+    /** Id of the buffered (active or finished-but-unrecorded) generation, if any. */
+    generationId?: string;
+    /**
+     * Request ids of interactive prompts (clarify/approval/etc.) still awaiting a user
+     * response. On reopen the panel re-surfaces the buffered prompt for these (so the
+     * question can be answered) and skips prompts already resolved earlier in the run.
+     */
+    pendingRequestIds?: string[];
 }
 
 export interface UsageResponse {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -572,6 +572,11 @@ export interface GetRunStatusResponse {
     /** Id of the buffered (active or finished-but-unrecorded) generation, if any. */
     generationId?: string;
     /**
+     * True when the buffer overflowed and its earliest events were evicted, so a
+     * replay cannot rebuild the turn from the beginning.
+     */
+    truncated?: boolean;
+    /**
      * Request ids of interactive prompts (clarify/approval/etc.) still awaiting a user
      * response. On reopen the panel re-surfaces the buffered prompt for these (so the
      * question can be answered) and skips prompts already resolved earlier in the run.

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -18,7 +18,7 @@
  */
 
 import { FunctionDefinition } from "@wso2/syntax-tree";
-import { AIMachineContext, AIMachineStateValue } from "../../state-machine-types";
+import { AIMachineContext, AIMachineStateValue, ChatNotify } from "../../state-machine-types";
 import { Command, SkillCommand, TemplateId } from "../../interfaces/ai-panel";
 import { AllDataMapperSourceRequest, ExtendedDataMapperMetadata } from "../../interfaces/extended-lang-client";
 import { ComponentInfo, Diagnostics, DMModel, ImportStatements, LinePosition, LineRange, OperationType } from "../..";
@@ -546,6 +546,29 @@ export interface AbortAIGenerationRequest {
     projectRootPath?: string;
     /** Thread identifier (defaults to 'default') */
     threadId?: string;
+}
+
+/**
+ * Request for the current run status of a thread (panel reconnection).
+ * Optional params default to current workspace and 'default' thread.
+ */
+export interface GetRunStatusRequest {
+    /** Project root path (defaults to current workspace/project root) */
+    projectRootPath?: string;
+    /** Thread identifier (defaults to 'default') */
+    threadId?: string;
+    /** When set, only return buffered events with `seq > sinceSeq` (polling dedup) */
+    sinceSeq?: number;
+}
+
+/**
+ * Response describing whether a run is in flight and the buffered events a
+ * reconnecting panel should replay.
+ */
+export interface GetRunStatusResponse {
+    isRunning: boolean;
+    events: ChatNotify[];
+    isPlanMode?: boolean;
 }
 
 export interface UsageResponse {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -302,6 +302,8 @@ export type CodeContext =
     | { type: 'selection'; startPosition: LinePosition; endPosition: LinePosition, filePath: string };
 
 export interface GenerateAgentCodeRequest {
+    /** Client-created run identity used to reject late events from older runs. */
+    generationId?: string;
     usecase: string;
     hiddenContext?: string;
     operationType?: OperationType;
@@ -428,6 +430,14 @@ export interface RestoreCheckpointRequest {
 export interface UpdateChatMessageRequest {
     messageId: string;
     content: string;
+    /** Exact workspace/thread owning the generation. Omitted only by legacy callers. */
+    projectRootPath?: string;
+    threadId?: string;
+    /**
+     * Set false for intermediate recovery writes. The reconnect buffer is only
+     * cleared by the final, fully rebuilt transcript write.
+     */
+    clearRunBuffer?: boolean;
 }
 
 export interface PlanApprovalRequest {
@@ -548,6 +558,13 @@ export interface AbortAIGenerationRequest {
     threadId?: string;
 }
 
+export interface HasPendingReviewRequest {
+    /** Project root path (defaults to current workspace/project root). */
+    projectRootPath?: string;
+    /** Thread identifier (defaults to the active thread). */
+    threadId?: string;
+}
+
 /**
  * Request for the current run status of a thread (panel reconnection).
  * Optional params default to current workspace and 'default' thread.
@@ -568,9 +585,14 @@ export interface GetRunStatusRequest {
 export interface GetRunStatusResponse {
     isRunning: boolean;
     events: ChatNotify[];
+    /** Resolved identity of the buffer that was queried. */
+    projectRootPath: string;
+    threadId: string;
     isPlanMode?: boolean;
     /** Id of the buffered (active or finished-but-unrecorded) generation, if any. */
     generationId?: string;
+    /** Persisted prompt for the buffered generation, when available. */
+    userPrompt?: string;
     /**
      * True when the buffer overflowed and its earliest events were evicted, so a
      * replay cannot rebuild the turn from the beginning.

--- a/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -85,6 +85,7 @@ import {
     // OpenMemoryRequest,
     GetRunStatusRequest,
     GetRunStatusResponse,
+    HasPendingReviewRequest,
 } from "./interfaces";
 import { RequestType, NotificationType } from "vscode-messenger-common";
 
@@ -132,7 +133,7 @@ export const restoreCheckpoint: RequestType<RestoreCheckpointRequest, void> = { 
 export const clearChat: RequestType<void, void> = { method: `${_preFix}/clearChat` };
 export const updateChatMessage: RequestType<UpdateChatMessageRequest, void> = { method: `${_preFix}/updateChatMessage` };
 export const getActiveTempDir: RequestType<void, string> = { method: `${_preFix}/getActiveTempDir` };
-export const hasPendingReview: RequestType<void, boolean> = { method: `${_preFix}/hasPendingReview` };
+export const hasPendingReview: RequestType<HasPendingReviewRequest, boolean> = { method: `${_preFix}/hasPendingReview` };
 export const getRunStatus: RequestType<GetRunStatusRequest, GetRunStatusResponse> = { method: `${_preFix}/getRunStatus` };
 export const getUsage: RequestType<void, UsageResponse | undefined> = { method: `${_preFix}/getUsage` };
 export const requestQuota: RequestType<QuotaRequestParams, QuotaRequestResult> = { method: `${_preFix}/requestQuota` };

--- a/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -83,6 +83,8 @@ import {
     // TODO(auto-memory): temporarily disabled for this release.
     // ClearMemoryRequest,
     // OpenMemoryRequest,
+    GetRunStatusRequest,
+    GetRunStatusResponse,
 } from "./interfaces";
 import { RequestType, NotificationType } from "vscode-messenger-common";
 
@@ -131,6 +133,7 @@ export const clearChat: RequestType<void, void> = { method: `${_preFix}/clearCha
 export const updateChatMessage: RequestType<UpdateChatMessageRequest, void> = { method: `${_preFix}/updateChatMessage` };
 export const getActiveTempDir: RequestType<void, string> = { method: `${_preFix}/getActiveTempDir` };
 export const hasPendingReview: RequestType<void, boolean> = { method: `${_preFix}/hasPendingReview` };
+export const getRunStatus: RequestType<GetRunStatusRequest, GetRunStatusResponse> = { method: `${_preFix}/getRunStatus` };
 export const getUsage: RequestType<void, UsageResponse | undefined> = { method: `${_preFix}/getUsage` };
 export const requestQuota: RequestType<QuotaRequestParams, QuotaRequestResult> = { method: `${_preFix}/requestQuota` };
 export const openFileDiff: NotificationType<OpenFileDiffRequest> = { method: `${_preFix}/openFileDiff` };

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -332,7 +332,20 @@ export interface DownloadProgress {
     step?: number;
 }
 
-export type ChatNotify =
+/**
+ * Metadata stamped onto every {@link ChatNotify} at emit time by the backend
+ * `RunEventStore` to support panel reconnection:
+ * - `seq`: monotonic sequence number used for replay dedup / polling (`sinceSeq`).
+ * - `generationId`: identifies the run so a reconnecting/late panel can drop
+ *   events belonging to a previously-interrupted run.
+ * Both are optional so existing emitters/consumers are unaffected.
+ */
+export interface ChatNotifyMeta {
+    seq?: number;
+    generationId?: string;
+}
+
+export type ChatNotify = (
     | ChatStart
     | IntermidaryState
     | ChatContent
@@ -359,7 +372,8 @@ export type ChatNotify =
     | CompactionEndEvent
     | CompactionDisabledEvent
     | ConfigChangeEvent
-    | MigrationProgressEvent;
+    | MigrationProgressEvent
+) & ChatNotifyMeta;
 
 /** Structured progress event emitted by the migration orchestrator at each stage boundary. */
 export interface MigrationProgressEvent {

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -360,6 +360,7 @@ export type ChatNotify = (
     | EvalsToolResult
     | UsageMetricsEvent
     | TaskApprovalRequest
+    | PlanApprovalResolved
     | WebToolApprovalEvent
     | GeneratedSourcesEvent
     | ConnectorGenerationNotification
@@ -495,6 +496,13 @@ export interface TaskApprovalRequest {
     taskDescription?: string;
     message?: string;
     autoApproved?: boolean;
+}
+
+export interface PlanApprovalResolved {
+    type: "plan_approval_resolved";
+    requestId: string;
+    approved: boolean;
+    comment?: string;
 }
 
 export interface WebToolApprovalEvent {

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -222,6 +222,22 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
         super(config);
     }
 
+    protected async prepareForExecution(): Promise<void> {
+        if (!this.config.chatStorage) {
+            return;
+        }
+        const { projectRootPath, threadId } = this.config.chatStorage;
+        if (chatStateStorage.getGeneration(projectRootPath, threadId, this.config.generationId)) {
+            return;
+        }
+        const params = this.config.params;
+        this.addGeneration(params.usecase, {
+            isPlanMode: params.isPlanMode,
+            operationType: params.operationType,
+            generationType: "agent",
+        });
+    }
+
     /**
      * Execute agent code generation
      *
@@ -273,6 +289,17 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
 
             const projectRootPath = this.config.executionContext.workspacePath || this.config.executionContext.projectPath || '';
             const agentsMd = await prepareAgentsMdForTurn(workspaceId || '', threadId);
+            if (agentsMd.hashToPersist !== undefined) {
+                const generation = chatStateStorage.getGeneration(projectRootPath, threadId, this.config.generationId);
+                if (generation) {
+                    chatStateStorage.updateGeneration(projectRootPath, threadId, this.config.generationId, {
+                        metadata: {
+                            ...generation.metadata,
+                            agentsMdLastReadHash: agentsMd.hashToPersist,
+                        },
+                    });
+                }
+            }
 
             const { allDisabled, projectSkills, userSkills, disabledSkillMetas } =
                 loadSkillsContext(projectRootPath || null);
@@ -289,14 +316,6 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
             if (supportsCompaction(loginMethod) && providerOptions === undefined) {
                 warnCompactionDisabledOnce(projectRootPath, this.config.eventHandler);
             }
-
-            // 3. Add generation to chat storage (if enabled)
-            this.addGeneration(params.usecase, {
-                isPlanMode: params.isPlanMode,
-                operationType: params.operationType,
-                generationType: 'agent',
-                agentsMdLastReadHash: agentsMd.hashToPersist,
-            });
 
             // Ensure the pre-edit snapshot exists before any tool can run.
             await chatStateStorage.waitForCheckpointCapture(this.config.generationId);
@@ -977,6 +996,8 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
             // stash what the diff view needs to reopen after an extension host restart.
             await savePendingReviewRestore({
                 generationId: context.messageId,
+                projectRootPath: workspaceId,
+                threadId,
                 tempProjectPath: workingProjectPath,
                 // Direct-edit mode keeps no on-disk baseline copy; the checkpoint snapshot
                 // (fallbackOriginalContents on restore) is the source of pre-generation originals.

--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -115,6 +115,9 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
             threadId,
         });
 
+        // Buffer this run's events so a closed/reopened panel can reconnect.
+        config.trackForReconnection = true;
+
         // Inject migration source tools for projects that have been AI-enhanced
         const migrationSourcePath = getMigrationSourcePathForProject(projectRootPath);
         if (migrationSourcePath) {

--- a/packages/ballerina-extension/src/features/ai/agent/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/index.ts
@@ -29,6 +29,7 @@ import {
 import { extension } from "../../../BalExtensionContext";
 import { getProjectMetrics } from "../../telemetry/common/project-metrics";
 import { getHashedProjectId } from "../../telemetry/common/project-id";
+import { runEventStore } from "../utils/run-event-store";
 
 // ==================================
 // Agent Generation Functions
@@ -58,16 +59,23 @@ export function createExecutorConfig<TParams>(
         existingTempPath?: string;
         projectRootPath?: string;
         threadId?: string;
+        generationId?: string;
     }
 ): AICommandConfig<TParams> {
     const projectRootPath = options.projectRootPath ?? resolveProjectRootPath();
     // Always use the active thread so new generations go to the correct thread
     // after the user has switched sessions via the history dropdown.
     const threadId = options.threadId ?? chatStateStorage.getActiveThread(projectRootPath)?.id ?? 'default';
+    const generationId = options.generationId
+        ?? `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
     return {
         executionContext: createExecutionContextFromStateMachine(),
-        eventHandler: createWebviewEventHandler(options.command),
-        generationId: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        eventHandler: createWebviewEventHandler(options.command, {
+            projectRootPath,
+            threadId,
+            generationId,
+        }),
+        generationId,
         abortController: new AbortController(),
         params,
         chatStorage: options.chatStorageEnabled ? {
@@ -87,13 +95,23 @@ export function createExecutorConfig<TParams>(
  * Handles plan mode configuration and review state management
  */
 export async function generateAgent(params: GenerateAgentCodeRequest): Promise<boolean> {
+    let preparedRun: {
+        projectRootPath: string;
+        threadId: string;
+        generationId: string;
+        eventHandler: AICommandConfig<GenerateAgentCodeRequest>["eventHandler"];
+    } | undefined;
+    let executorStarted = false;
     try {
         // Always use the active thread — params.threadId is legacy/unused
         const projectRootPath = resolveProjectRootPath();
         const threadId = chatStateStorage.getActiveThread(projectRootPath)?.id ?? 'default';
 
         // Only one generation may be in flight per thread at a time.
-        if (chatStateStorage.getActiveExecution(projectRootPath, threadId)) {
+        if (
+            chatStateStorage.getActiveExecution(projectRootPath, threadId)
+            || runEventStore.getRunStatus(projectRootPath, threadId).isRunning
+        ) {
             throw new Error('A generation is already in progress. Please wait for it to finish before starting a new one.');
         }
 
@@ -113,6 +131,7 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
             existingTempPath: projectRootPath,
             projectRootPath,
             threadId,
+            generationId: params.generationId,
         });
 
         // Buffer this run's events so a closed/reopened panel can reconnect.
@@ -123,6 +142,32 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
         if (migrationSourcePath) {
             config.toolOptions = { ...config.toolOptions, migrationSourcePath };
         }
+
+        // Persist the user turn and expose its run identity before any awaited
+        // telemetry/preflight work. A panel reopened during startup therefore
+        // loads the correct user message and cannot attach output to the prior turn.
+        chatStateStorage.addGeneration(
+            projectRootPath,
+            threadId,
+            params.usecase,
+            {
+                isPlanMode: params.isPlanMode,
+                operationType: params.operationType,
+                generationType: "agent",
+            },
+            config.generationId
+        );
+        chatStateStorage.setActiveExecution(projectRootPath, threadId, {
+            generationId: config.generationId,
+            abortController: config.abortController,
+        });
+        runEventStore.beginRun(projectRootPath, threadId, config.generationId);
+        preparedRun = {
+            projectRootPath,
+            threadId,
+            generationId: config.generationId,
+            eventHandler: config.eventHandler,
+        };
 
         // Get project metrics, project ID, and chat history for telemetry
         const projectMetrics = await getProjectMetrics(projectRootPath);
@@ -147,10 +192,33 @@ export async function generateAgent(params: GenerateAgentCodeRequest): Promise<b
             }
         );
 
+        executorStarted = true;
         await new AgentExecutor(config).run();
 
         return true;
     } catch (error) {
+        if (preparedRun) {
+            if (!executorStarted) {
+                preparedRun.eventHandler({
+                    type: "error",
+                    content: error instanceof Error ? error.message : String(error),
+                });
+                preparedRun.eventHandler({
+                    type: "save_chat",
+                    command: Command.Agent,
+                    messageId: preparedRun.generationId,
+                });
+            }
+            runEventStore.endRun(
+                preparedRun.projectRootPath,
+                preparedRun.threadId,
+                preparedRun.generationId
+            );
+            chatStateStorage.clearActiveExecution(
+                preparedRun.projectRootPath,
+                preparedRun.threadId
+            );
+        }
         console.error('[Agent] Error in generateAgent:', error);
         throw error;
     }

--- a/packages/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
@@ -21,6 +21,7 @@ import { CopilotEventHandler } from '../../utils/events';
 import { chatStateStorage, ChatStateStorage } from '../../../../views/ai-panel/chatStateStorage';
 import { getTempProject, cleanupTempProject } from '../../utils/project/temp-project';
 import { buildChatError } from '../../utils/ai-utils';
+import { runEventStore } from '../../utils/run-event-store';
 import { MigrationDebugLogger } from '../../migration/debug-logger';
 import { clearAiTouchedFiles } from '../../../../rpc-managers/diagram-validity';
 
@@ -54,6 +55,14 @@ export interface AICommandConfig<TParams = any> {
         threadId: string;
         enabled: boolean;
     };
+
+    /**
+     * Whether this run's events target the AI chat panel and should be buffered
+     * for panel reconnection (`getRunStatus` replay). Set only for the agent
+     * chat path; other executors (migration panel, data mapper) leave it unset
+     * so they don't register themselves as the buffered "current run".
+     */
+    trackForReconnection?: boolean;
 
     /** Optional lifecycle configuration */
     lifecycle?: {
@@ -179,6 +188,12 @@ export abstract class AICommandExecutor<TParams = any> {
                 abortController: this.config.abortController
             });
 
+            // Start buffering emitted events so a panel that closes/reopens
+            // mid-run can reconnect and replay what it missed (agent chat only).
+            if (this.config.trackForReconnection) {
+                runEventStore.beginRun(projectRootPath, threadId, this.config.generationId);
+            }
+
             // Stage 2: Initialize workspace/thread in chat storage
             await this.initializeWorkspaceThread();
 
@@ -199,7 +214,12 @@ export abstract class AICommandExecutor<TParams = any> {
             throw error;
         } finally {
             // Stage 6: Always clear active execution on completion (success or error)
-        chatStateStorage.clearActiveExecution(projectRootPath, threadId);
+            chatStateStorage.clearActiveExecution(projectRootPath, threadId);
+            // Mark the run ended (buffer kept so an in-flight poll can still pick
+            // up a terminal event).
+            if (this.config.trackForReconnection) {
+                runEventStore.endRun(projectRootPath, threadId);
+            }
         }
     }
 

--- a/packages/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
@@ -181,8 +181,11 @@ export abstract class AICommandExecutor<TParams = any> {
         try {
             console.log(`[AICommandExecutor] Starting ${this.getCommandType()} execution: ${this.config.generationId}`);
 
-            // Stage 1: Register active execution for abort support
             clearAiTouchedFiles();
+            await this.initializeWorkspaceThread();
+            await this.prepareForExecution();
+
+            // Stage 1: Register active execution for abort support
             chatStateStorage.setActiveExecution(projectRootPath, threadId, {
                 generationId: this.config.generationId,
                 abortController: this.config.abortController
@@ -193,9 +196,6 @@ export abstract class AICommandExecutor<TParams = any> {
             if (this.config.trackForReconnection) {
                 runEventStore.beginRun(projectRootPath, threadId, this.config.generationId);
             }
-
-            // Stage 2: Initialize workspace/thread in chat storage
-            await this.initializeWorkspaceThread();
 
             // Stage 3: Temp project initialization
             await this.initializeTempProject();
@@ -218,9 +218,17 @@ export abstract class AICommandExecutor<TParams = any> {
             // Mark the run ended (buffer kept so an in-flight poll can still pick
             // up a terminal event).
             if (this.config.trackForReconnection) {
-                runEventStore.endRun(projectRootPath, threadId);
+                runEventStore.endRun(projectRootPath, threadId, this.config.generationId);
             }
         }
+    }
+
+    /**
+     * Hook for subclasses that must persist turn metadata before an execution
+     * is exposed through the reconnection store.
+     */
+    protected async prepareForExecution(): Promise<void> {
+        return;
     }
 
     /**

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
@@ -718,6 +718,58 @@ export class ApprovalManager {
     }
 
     /**
+     * Cancel only the interactive requests that cannot be recovered after the AI panel is closed
+     * and reopened, and tear down transient UI. Called when the panel is *disposed* (not aborted).
+     *
+     * Popup-based requests (the configuration collector, whose popup view is torn down here) are
+     * resolved as skipped because they cannot be replayed into the reopened chat — leaving them
+     * pending would strand the run. In-chat prompts (plan/task/connector/web-tool/clarify/skill)
+     * are intentionally LEFT PENDING: the agent run survives the panel in the extension host, and
+     * these prompts are re-surfaced from the event buffer on reopen so the user can still answer
+     * them. (Full cancellation still happens on explicit abort via cancelAllPending.)
+     */
+    cancelOnPanelClose(reason: string): void {
+        console.log(`[ApprovalManager] Panel closed — preserving in-chat prompts, cancelling popup-based ones: ${reason}`);
+
+        // Close popup approval views (currently only the configuration collector).
+        approvalViewManager.cleanupAllViews();
+
+        // Resolve configuration requests as skipped — popup-based, not replayable into the chat.
+        for (const [, resolver] of this.configurationRequests.entries()) {
+            if (resolver.timeoutId) {
+                clearTimeout(resolver.timeoutId);
+            }
+            resolver.resolve({ provided: false, comment: reason });
+        }
+        this.configurationRequests.clear();
+
+        // Reset notification counters and fire handlers (e.g. turn off the web-search globe).
+        for (const [type, count] of this.notificationCounters.entries()) {
+            if (count > 0) {
+                this.notificationCounters.set(type, 0);
+                this.notificationHandlers.get(type)?.(false);
+            }
+        }
+    }
+
+    /**
+     * All request ids that are currently awaiting a user response, across every interactive type.
+     * Used on reopen to decide which buffered prompt to re-surface (still pending) vs. skip
+     * (already resolved earlier in the run).
+     */
+    getPendingRequestIds(): string[] {
+        return [
+            ...this.planApprovals.keys(),
+            ...this.taskApprovals.keys(),
+            ...this.connectorSpecs.keys(),
+            ...this.configurationRequests.keys(),
+            ...this.webToolApprovals.keys(),
+            ...this.clarifyRequests.keys(),
+            ...this.skillEnableRequests.keys(),
+        ];
+    }
+
+    /**
      * Get count of pending approvals (useful for debugging)
      */
     getPendingCount(): { plans: number; tasks: number; connectorSpecs: number; configurations: number; webTools: number; clarify: number } {

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
@@ -79,6 +79,10 @@ interface PromiseResolver<T> {
     timeoutId?: NodeJS.Timeout;
 }
 
+interface PlanApprovalResolver extends PromiseResolver<PlanApprovalResponse> {
+    eventHandler: CopilotEventHandler;
+}
+
 /**
  * A queued approval item — holds the emit function that fires the UI event.
  * The queue processes one item at a time so UI prompts never overlap.
@@ -98,7 +102,7 @@ interface ApprovalQueueItem {
 export class ApprovalManager {
     private static instance: ApprovalManager;
 
-    private planApprovals = new Map<string, PromiseResolver<PlanApprovalResponse>>();
+    private planApprovals = new Map<string, PlanApprovalResolver>();
     private taskApprovals = new Map<string, PromiseResolver<TaskApprovalResponse>>();
     private connectorSpecs = new Map<string, PromiseResolver<ConnectorSpecResponse>>();
     private configurationRequests = new Map<string, PromiseResolver<ConfigurationResponse>>();
@@ -161,7 +165,7 @@ export class ApprovalManager {
                 reject(new Error(`Plan approval timeout for request ${requestId}`));
             }, this.DEFAULT_TIMEOUT_MS);
 
-            this.planApprovals.set(requestId, { resolve, reject, timeoutId });
+            this.planApprovals.set(requestId, { resolve, reject, timeoutId, eventHandler });
         });
     }
 
@@ -180,6 +184,16 @@ export class ApprovalManager {
         }
 
         console.log(`[ApprovalManager] Resolving plan approval: ${requestId}, approved: ${approved}`);
+
+        // Persist the user's decision in the run event stream. A reopened panel
+        // can now reconstruct the final plan card instead of merely hiding the
+        // already-resolved approval footer.
+        resolver.eventHandler({
+            type: "plan_approval_resolved",
+            requestId,
+            approved,
+            comment,
+        });
 
         // Clear timeout
         if (resolver.timeoutId) {

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -473,8 +473,12 @@ export class ApprovalViewManager {
      * Data is cached for chip re-clicks while review is active.
      */
     openReviewMode(data: ReviewModeData, autoOpen: boolean = true): void {
-        if (!AiPanelWebview.currentPanel) { return; }
+        // Cache regardless of panel state: a run can finish while the AI panel is
+        // closed, and the chip click after reopen must hit this cache — the
+        // storage-rebuild fallback re-opens the LS documents and is meant for the
+        // extension-host-restart case only.
         this.cachedReviewData = data;
+        if (!AiPanelWebview.currentPanel) { return; }
         if (!autoOpen) { return; }
         void this.navigateReviewMode(data.currentIndex).catch((error) =>
             console.error('[ApprovalViewManager] Failed to open ReviewMode:', error));

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -526,14 +526,24 @@ export class ApprovalViewManager {
      */
     private async rebuildReviewDataFromStorage(): Promise<ReviewModeData | null> {
         const ctx = StateMachine.context();
-        const projectRootPath = ctx.workspacePath || ctx.projectPath || '';
-        const generation = chatStateStorage.getDoneGeneration(projectRootPath, 'default');
-        if (!generation) {
+        const restore = getPendingReviewRestore();
+        if (!restore) {
             return null;
         }
-        const restore = getPendingReviewRestore();
-        if (!restore || restore.generationId !== generation.id) {
-            console.error('[ApprovalViewManager] No restore data for pending review generation', generation.id);
+        const projectRootPath = restore.projectRootPath || ctx.workspacePath || ctx.projectPath || '';
+        let threadId = restore.threadId
+            || chatStateStorage.getActiveThread(projectRootPath)?.id
+            || 'default';
+        let generation = chatStateStorage.getGeneration(projectRootPath, threadId, restore.generationId);
+        if (!generation && !restore.threadId) {
+            const located = chatStateStorage.findGenerationScope(projectRootPath, restore.generationId);
+            if (located) {
+                threadId = located.threadId;
+                generation = located.generation;
+            }
+        }
+        if (!generation || generation.reviewState.status !== 'done') {
+            console.error('[ApprovalViewManager] No pending generation for review restore', restore.generationId);
             // Drop the stale payload so we don't repeat this failed lookup every navigation.
             await clearPendingReviewRestore();
             return null;
@@ -546,7 +556,7 @@ export class ApprovalViewManager {
 
         // Rehydrate runtime-only state as well as the view. Accept/decline can now clean up
         // restored temp projects even though chat persistence deliberately omits these fields.
-        chatStateStorage.updateReviewState(projectRootPath, 'default', generation.id, {
+        chatStateStorage.updateReviewState(projectRootPath, threadId, generation.id, {
             tempProjectPath: restore.tempProjectPath,
             affectedPackagePaths: restore.affectedPackagePaths,
         });

--- a/packages/ballerina-extension/src/features/ai/state/reviewRestoreStore.ts
+++ b/packages/ballerina-extension/src/features/ai/state/reviewRestoreStore.ts
@@ -28,6 +28,9 @@ import { extension } from '../../../BalExtensionContext';
  */
 export interface ReviewRestoreData {
     generationId: string;
+    /** Exact chat scope. Optional for payloads written by older versions. */
+    projectRootPath?: string;
+    threadId?: string;
     tempProjectPath: string;
     /** Frozen pre-generation Ballerina sources. Optional for payloads written by older versions. */
     baselineProjectPath?: string;

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -45,6 +45,7 @@ import { AiPanelWebview } from "../../../views/ai-panel/webview";
 import { MigrationPanelWebview } from "../../../views/migration-panel/webview";
 import { VisualizerWebview } from "../../../views/visualizer/webview";
 import { GenerationType } from "./libs/libraries";
+import { runEventStore } from "./run-event-store";
 // import { REQUIREMENTS_DOCUMENT_KEY } from "./code/np_prompts";
 
 export function populateHistory(chatHistory: ChatEntry[]): ModelMessage[] {
@@ -326,7 +327,12 @@ export function sendWebToolToggleNotification(active: boolean): void {
 }
 
 export function sendAIPanelNotification(msg: ChatNotify): void {
-    RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, msg);
+    // Stamp seq/generationId and buffer under the active run (for panel reconnection)
+    // before forwarding. No-op when no run is active. The panel-open hint lets the
+    // store mark runs whose terminal event fired while the panel was closed, so the
+    // next reconnect replays the finished turn.
+    const stamped = runEventStore.stampCurrent(msg, AiPanelWebview.currentPanel !== undefined);
+    RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, stamped);
 }
 
 /**

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -328,11 +328,19 @@ export function sendWebToolToggleNotification(active: boolean): void {
 
 export function sendAIPanelNotification(msg: ChatNotify): void {
     // Stamp seq/generationId and buffer under the active run (for panel reconnection)
-    // before forwarding. No-op when no run is active. The panel-open hint lets the
-    // store mark runs whose terminal event fired while the panel was closed, so the
-    // next reconnect replays the finished turn.
-    const stamped = runEventStore.stampCurrent(msg, AiPanelWebview.currentPanel !== undefined);
-    RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, stamped);
+    // before forwarding. No-op when no run is active.
+    const stamped = runEventStore.stampCurrent(msg);
+    // The agent keeps running after the panel is closed (by design). The event is
+    // already buffered above, so skipping the post loses nothing — reconnect replays
+    // it on reopen. Guard on the live panel and swallow any late-dispose race.
+    if (!AiPanelWebview.currentPanel) {
+        return;
+    }
+    try {
+        RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, stamped);
+    } catch (e) {
+        // Panel was disposed between the guard and the send — safe to ignore (buffer has the event).
+    }
 }
 
 /**

--- a/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -326,10 +326,23 @@ export function sendWebToolToggleNotification(active: boolean): void {
     );
 }
 
-export function sendAIPanelNotification(msg: ChatNotify): void {
-    // Stamp seq/generationId and buffer under the active run (for panel reconnection)
-    // before forwarding. No-op when no run is active.
-    const stamped = runEventStore.stampCurrent(msg);
+export interface AIPanelRunContext {
+    projectRootPath: string;
+    threadId: string;
+    generationId: string;
+}
+
+export function sendAIPanelNotification(msg: ChatNotify, runContext?: AIPanelRunContext): void {
+    // Only executor-owned handlers provide a run context. Unrelated AI-panel
+    // notifications must never be captured by another concurrently running turn.
+    const stamped = runContext
+        ? runEventStore.stamp(
+            runContext.projectRootPath,
+            runContext.threadId,
+            runContext.generationId,
+            msg
+        )
+        : msg;
     // The agent keeps running after the panel is closed (by design). The event is
     // already buffered above, so skipping the post loses nothing — reconnect replays
     // it on reopen. Guard on the live panel and swallow any late-dispose race.

--- a/packages/ballerina-extension/src/features/ai/utils/events.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/events.ts
@@ -14,10 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { ChatNotify, Command, onChatNotify } from "@wso2/ballerina-core";
+import { ChatNotify, Command } from "@wso2/ballerina-core";
 import { ModelUsage } from "./libs/function-registry";
-import { RPCLayer } from "../../../RPCLayer";
-import { AiPanelWebview } from "../../../views/ai-panel/webview";
 import {
     sendContentAppendNotification,
     sendContentReplaceNotification,
@@ -197,15 +195,15 @@ export function createWebviewEventHandler(command: Command): CopilotEventHandler
                 break;
             case "compaction_start":
                 console.log('[Compaction] Context compaction started');
-                RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, event);
+                sendAIPanelNotification(event);
                 break;
             case "compaction_end":
                 console.log('[Compaction] Context compaction completed');
-                RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, event);
+                sendAIPanelNotification(event);
                 break;
             case "compaction_disabled":
                 console.warn('[Compaction] Compaction disabled — codebase floor exceeds trigger threshold');
-                RPCLayer._messenger.sendNotification(onChatNotify, { type: "webview", webviewType: AiPanelWebview.viewType }, event);
+                sendAIPanelNotification(event);
                 break;
             default:
                 console.warn(`Unhandled event type: ${event}`);

--- a/packages/ballerina-extension/src/features/ai/utils/events.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/events.ts
@@ -17,29 +17,10 @@
 import { ChatNotify, Command } from "@wso2/ballerina-core";
 import { ModelUsage } from "./libs/function-registry";
 import {
-    sendContentAppendNotification,
-    sendContentReplaceNotification,
-    sendDiagnosticMessageNotification,
-    sendErrorNotification,
-    sendMessagesNotification,
-    sendMessageStartNotification,
-    sendMessageStopNotification,
-    sendIntermidateStateNotification,
-    sendToolCallNotification,
-    sendToolResultNotification,
-    sendTaskApprovalRequestNotification,
-    sendWebToolApprovalNotification,
-    sendAbortNotification,
-    sendSaveChatNotification,
-    sendConnectorGenerationNotification,
-    sendConfigurationCollectionNotification,
     sendMigrationPanelNotification,
     sendVisualizerMigrationNotification,
     sendAIPanelNotification,
-    sendClarifyNotification,
-    sendSkillEnableNotification,
-    sendChatComponentNotification,
-    sendUsageMetricsNotification,
+    AIPanelRunContext,
 } from "./ai-utils";
 
 export type CopilotEventHandler = (event: ChatNotify) => void;
@@ -119,96 +100,32 @@ export function updateAndSaveChat(messageId: string, command: Command, eventHand
 }
 
 // Event listener that handles events and sends notifications
-export function createWebviewEventHandler(command: Command): CopilotEventHandler {
+export function createWebviewEventHandler(
+    command: Command,
+    runContext?: AIPanelRunContext
+): CopilotEventHandler {
     return (event: ChatNotify) => {
-        switch (event.type) {
-            case "start":
-                sendMessageStartNotification();
-                break;
-            case "content_block":
-                sendContentAppendNotification(event.content);
-                break;
-            case "content_replace":
-                sendContentReplaceNotification(event.content);
-                break;
-            case "error":
-                sendErrorNotification(event);
-                break;
-            case "stop":
-                sendMessageStopNotification(command);
-                break;
-            case "abort":
-                sendAbortNotification(event.command);
-                break;
-            case "save_chat":
-                sendSaveChatNotification(event.command, event.messageId);
-                break;
-            case "intermediary_state":
-                sendIntermidateStateNotification(event.state);
-                break;
-            case "messages":
-                sendMessagesNotification(event.messages);
-                break;
-            case "tool_call":
-                sendToolCallNotification(event.toolName, event.toolInput, event.toolCallId);
-                break;
-            case "tool_result":
-                sendToolResultNotification(event.toolName, event.toolOutput, event.toolCallId, event.failed);
-                break;
-            case "task_approval_request":
-                console.log("[Event Handler] Task approval request received:", event);
-                sendTaskApprovalRequestNotification(
-                    event.approvalType,
-                    event.tasks,
-                    event.taskDescription,
-                    event.message,
-                    event.requestId,
-                    event.autoApproved
-                );
-                break;
-            case "evals_tool_result":
-                // Ignore evals-specific events in webview
-                break;
-            case "usage_metrics":
-                sendUsageMetricsNotification(event.usage, event.breakdown);
-                break;
-            case "diagnostics":
-                sendDiagnosticMessageNotification(event.diagnostics);
-                break;
-            case "connector_generation_notification":
-                sendConnectorGenerationNotification(event);
-                break;
-            case "configuration_collection_event":
-                sendConfigurationCollectionNotification(event);
-                break;
-            case "clarify_event":
-                sendClarifyNotification(event);
-                break;
-            case "skill_enable_event":
-                sendSkillEnableNotification(event);
-                break;
-            case "chat_component":
-                sendChatComponentNotification(event.componentType, event.data, event.id);
-                break;
-            case "web_tool_approval_request":
-                sendWebToolApprovalNotification(event.requestId, event.toolName, event.content);
-                break;
-            case "compaction_start":
-                console.log('[Compaction] Context compaction started');
-                sendAIPanelNotification(event);
-                break;
-            case "compaction_end":
-                console.log('[Compaction] Context compaction completed');
-                sendAIPanelNotification(event);
-                break;
-            case "compaction_disabled":
-                console.warn('[Compaction] Compaction disabled — codebase floor exceeds trigger threshold');
-                sendAIPanelNotification(event);
-                break;
-            default:
-                console.warn(`Unhandled event type: ${event}`);
-                break;
+        if (event.type === "evals_tool_result") {
+            return;
         }
+        if (event.type === "task_approval_request") {
+            console.log("[Event Handler] Task approval request received:", event);
+        } else if (event.type === "compaction_start") {
+            console.log("[Compaction] Context compaction started");
+        } else if (event.type === "compaction_end") {
+            console.log("[Compaction] Context compaction completed");
+        } else if (event.type === "compaction_disabled") {
+            console.warn("[Compaction] Compaction disabled — codebase floor exceeds trigger threshold");
+        }
+
+        // The executor event is already the public ChatNotify shape. Forward it
+        // unchanged so the run identity remains attached end-to-end.
+        sendAIPanelNotification(
+            event.type === "stop" && event.command === undefined
+                ? { ...event, command }
+                : event,
+            runContext
+        );
     };
 }
 

--- a/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
@@ -37,6 +37,8 @@ export interface RunStatus {
     events: ChatNotify[];
     /** Id of the buffered generation, if any. */
     generationId?: string;
+    /** True when the buffer overflowed and its earliest events were evicted (replay can't rebuild the full turn). */
+    truncated: boolean;
 }
 
 interface RunState {
@@ -51,6 +53,8 @@ interface RunState {
      */
     runBuffer: ChatNotify[];
     generationId?: string;
+    /** Set when the buffer cap evicted this run's earliest events. */
+    truncated: boolean;
 }
 
 /** Per-run buffer cap: beyond this, the oldest events are evicted (bounds memory on very long runs). */
@@ -70,7 +74,7 @@ class RunEventStore {
     private getOrCreate(key: string): RunState {
         let state = this.runs.get(key);
         if (!state) {
-            state = { isRunning: false, seqCounter: 0, runBuffer: [] };
+            state = { isRunning: false, seqCounter: 0, runBuffer: [], truncated: false };
             this.runs.set(key, state);
         }
         return state;
@@ -96,6 +100,7 @@ class RunEventStore {
         state.isRunning = true;
         state.seqCounter = 0;
         state.runBuffer = [];
+        state.truncated = false;
         state.generationId = generationId;
         this.currentKey = key;
         this.evictStaleRuns();
@@ -138,6 +143,7 @@ class RunEventStore {
         // only an initial reconnect to such a run loses its earliest transcript.
         if (state.runBuffer.length > MAX_BUFFERED_EVENTS) {
             state.runBuffer.shift();
+            state.truncated = true;
         }
         return event;
     }
@@ -156,12 +162,12 @@ class RunEventStore {
     getRunStatus(projectRootPath: string, threadId: string, sinceSeq?: number): RunStatus {
         const state = this.runs.get(this.key(projectRootPath, threadId));
         if (!state) {
-            return { isRunning: false, events: [] };
+            return { isRunning: false, events: [], truncated: false };
         }
         const events = sinceSeq !== undefined && sinceSeq >= 0
             ? state.runBuffer.filter(e => (e.seq ?? 0) > sinceSeq)
             : [...state.runBuffer];
-        return { isRunning: state.isRunning, events, generationId: state.generationId };
+        return { isRunning: state.isRunning, events, generationId: state.generationId, truncated: state.truncated };
     }
 
     /**
@@ -176,6 +182,7 @@ class RunEventStore {
             return;
         }
         state.runBuffer = [];
+        state.truncated = false;
         state.generationId = undefined;
     }
 }

--- a/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
@@ -35,25 +35,22 @@ import { ChatNotify } from "@wso2/ballerina-core";
 export interface RunStatus {
     isRunning: boolean;
     events: ChatNotify[];
+    /** Id of the buffered generation, if any. */
+    generationId?: string;
 }
 
 interface RunState {
     isRunning: boolean;
     /** Monotonic within the current run (reset on `beginRun`); stable under buffer eviction. */
     seqCounter: number;
-    /** Events of the current run. Reset on `beginRun`, kept after `endRun`. */
+    /**
+     * Events of the current run. Reset on `beginRun`. Kept after `endRun` until the
+     * turn's transcript is durably persisted as `uiResponse` (`clearBuffer`, driven by
+     * `updateChatMessage`) — so a run that finished while the panel was closed stays
+     * replayable across reopens until the replay's own `save_chat` round-trip lands.
+     */
     runBuffer: ChatNotify[];
     generationId?: string;
-    /**
-     * True when the run's terminal event (stop/abort/error) was emitted while no
-     * panel existed to receive it. The next initial `getRunStatus` (no `sinceSeq`)
-     * serves the full buffer once so the reopened panel can rebuild the finished
-     * turn — replaying `save_chat` also persists the final `uiResponse` that the
-     * closed panel never round-tripped. Cleared after being served (or on the
-     * next `beginRun`) so later reopens fall back to persisted history without
-     * duplication.
-     */
-    finishedUnseen: boolean;
 }
 
 /** Per-run buffer cap: beyond this, the oldest events are evicted (bounds memory on very long runs). */
@@ -73,7 +70,7 @@ class RunEventStore {
     private getOrCreate(key: string): RunState {
         let state = this.runs.get(key);
         if (!state) {
-            state = { isRunning: false, seqCounter: 0, runBuffer: [], finishedUnseen: false };
+            state = { isRunning: false, seqCounter: 0, runBuffer: [] };
             this.runs.set(key, state);
         }
         return state;
@@ -100,7 +97,6 @@ class RunEventStore {
         state.seqCounter = 0;
         state.runBuffer = [];
         state.generationId = generationId;
-        state.finishedUnseen = false;
         this.currentKey = key;
         this.evictStaleRuns();
     }
@@ -123,12 +119,8 @@ class RunEventStore {
      * ai-panel send chokepoint (`sendAIPanelNotification`). Returns the same
      * (mutated) event so the caller can forward it. No-op (returns event
      * unchanged) when no run is active — e.g. notifications sent outside a run.
-     *
-     * @param panelOpen whether an AI panel currently exists to receive the event.
-     *   When a terminal event is emitted with no panel open, the run is marked
-     *   `finishedUnseen` so the next reconnect replays the whole turn.
      */
-    stampCurrent(event: ChatNotify, panelOpen: boolean): ChatNotify {
+    stampCurrent(event: ChatNotify): ChatNotify {
         if (!this.currentKey) {
             return event;
         }
@@ -141,9 +133,6 @@ class RunEventStore {
             event.generationId = state.generationId;
         }
         state.runBuffer.push(event);
-        if (!panelOpen && (event.type === "stop" || event.type === "abort" || event.type === "error")) {
-            state.finishedUnseen = true;
-        }
         // Bound memory on pathologically long runs by dropping the oldest events.
         // `seq` stays monotonic (independent of array index), so polling still works;
         // only an initial reconnect to such a run loses its earliest transcript.
@@ -158,30 +147,36 @@ class RunEventStore {
      * - `sinceSeq` provided → polling mode: only events with `seq > sinceSeq`.
      *   Returned whether or not the run is still active, so a poll can pick up a
      *   terminal event that was dropped.
-     * - `sinceSeq` omitted → initial reconnect: the full current-run buffer while
-     *   the run is active, or — served exactly once — for a run that finished
-     *   while no panel was open (`finishedUnseen`), so the reopened panel can
-     *   rebuild the turn it never saw. Otherwise empty: a completed-and-seen
-     *   turn is already in the persisted chat history, and returning the buffer
-     *   again would duplicate it.
+     * - `sinceSeq` omitted → initial reconnect: the full buffer. A buffer only
+     *   exists while its turn's transcript is not yet durably persisted
+     *   (`clearBuffer` drops it once `uiResponse` is saved), so returning it is
+     *   never a duplicate of chat history — it is either a live run or a
+     *   finished-while-closed turn awaiting recovery.
      */
     getRunStatus(projectRootPath: string, threadId: string, sinceSeq?: number): RunStatus {
         const state = this.runs.get(this.key(projectRootPath, threadId));
         if (!state) {
             return { isRunning: false, events: [] };
         }
-        let events: ChatNotify[];
-        if (sinceSeq !== undefined && sinceSeq >= 0) {
-            events = state.runBuffer.filter(e => (e.seq ?? 0) > sinceSeq);
-        } else if (state.isRunning || state.finishedUnseen) {
-            events = [...state.runBuffer];
-            // Serve the finished-unseen buffer only once — after this replay the
-            // frontend re-fires save_chat, persisting the turn into chat history.
-            state.finishedUnseen = false;
-        } else {
-            events = [];
+        const events = sinceSeq !== undefined && sinceSeq >= 0
+            ? state.runBuffer.filter(e => (e.seq ?? 0) > sinceSeq)
+            : [...state.runBuffer];
+        return { isRunning: state.isRunning, events, generationId: state.generationId };
+    }
+
+    /**
+     * Drops the buffered events for a generation once its transcript has been
+     * durably persisted as `uiResponse` (replay is no longer needed). No-op if
+     * the buffer belongs to a different generation.
+     */
+    clearBuffer(projectRootPath: string, threadId: string, generationId: string): void {
+        const key = this.key(projectRootPath, threadId);
+        const state = this.runs.get(key);
+        if (!state || state.generationId !== generationId) {
+            return;
         }
-        return { isRunning: state.isRunning, events };
+        state.runBuffer = [];
+        state.generationId = undefined;
     }
 }
 

--- a/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
@@ -1,0 +1,188 @@
+// Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { ChatNotify } from "@wso2/ballerina-core";
+
+/**
+ * In-memory per-run event buffer that powers **AI panel reconnection**.
+ *
+ * The agent run lives on the extension host independently of the webview (it is
+ * tracked by the {@link chatStateStorage} singleton, keyed by
+ * `(projectRootPath, threadId)`), so it keeps executing when the panel is
+ * closed. But `ChatNotify` events are pushed to the webview fire-and-forget and
+ * are silently dropped while no panel is registered. This store buffers every
+ * emitted event (stamped with a monotonic `seq`) so that a panel which
+ * (re)mounts can call `getRunStatus` and replay whatever it missed.
+ *
+ * This is the BI analogue of MI Copilot's `AgentEventHandler`.
+ *
+ * Scope/limitation: the buffer is in-memory only. It survives panel
+ * close/reopen (the feature's requirement) but not an extension-host restart.
+ */
+export interface RunStatus {
+    isRunning: boolean;
+    events: ChatNotify[];
+}
+
+interface RunState {
+    isRunning: boolean;
+    /** Monotonic within the current run (reset on `beginRun`); stable under buffer eviction. */
+    seqCounter: number;
+    /** Events of the current run. Reset on `beginRun`, kept after `endRun`. */
+    runBuffer: ChatNotify[];
+    generationId?: string;
+    /**
+     * True when the run's terminal event (stop/abort/error) was emitted while no
+     * panel existed to receive it. The next initial `getRunStatus` (no `sinceSeq`)
+     * serves the full buffer once so the reopened panel can rebuild the finished
+     * turn — replaying `save_chat` also persists the final `uiResponse` that the
+     * closed panel never round-tripped. Cleared after being served (or on the
+     * next `beginRun`) so later reopens fall back to persisted history without
+     * duplication.
+     */
+    finishedUnseen: boolean;
+}
+
+/** Per-run buffer cap: beyond this, the oldest events are evicted (bounds memory on very long runs). */
+const MAX_BUFFERED_EVENTS = 5000;
+/** Retain buffers for at most this many distinct runs; evict the oldest beyond it. */
+const MAX_RETAINED_RUNS = 20;
+
+class RunEventStore {
+    private runs = new Map<string, RunState>();
+    /** The key of the run currently emitting events (set by `beginRun`, cleared by `endRun`). */
+    private currentKey: string | undefined;
+
+    private key(projectRootPath: string, threadId: string): string {
+        return `${projectRootPath}::${threadId}`;
+    }
+
+    private getOrCreate(key: string): RunState {
+        let state = this.runs.get(key);
+        if (!state) {
+            state = { isRunning: false, seqCounter: 0, runBuffer: [], finishedUnseen: false };
+            this.runs.set(key, state);
+        }
+        return state;
+    }
+
+    /** Evict the oldest non-active runs so the store doesn't grow unbounded across many workspaces. */
+    private evictStaleRuns(): void {
+        // Map preserves insertion order; delete oldest entries that aren't the current run.
+        for (const key of this.runs.keys()) {
+            if (this.runs.size <= MAX_RETAINED_RUNS) {
+                break;
+            }
+            if (key !== this.currentKey) {
+                this.runs.delete(key);
+            }
+        }
+    }
+
+    /** Marks the start of a run and clears its previous buffer. */
+    beginRun(projectRootPath: string, threadId: string, generationId: string): void {
+        const key = this.key(projectRootPath, threadId);
+        const state = this.getOrCreate(key);
+        state.isRunning = true;
+        state.seqCounter = 0;
+        state.runBuffer = [];
+        state.generationId = generationId;
+        state.finishedUnseen = false;
+        this.currentKey = key;
+        this.evictStaleRuns();
+    }
+
+    /** Marks the end of a run. Keeps the buffer so an in-flight poll can still pick up a terminal event. */
+    endRun(projectRootPath: string, threadId: string): void {
+        const key = this.key(projectRootPath, threadId);
+        const state = this.runs.get(key);
+        if (state) {
+            state.isRunning = false;
+        }
+        if (this.currentKey === key) {
+            this.currentKey = undefined;
+        }
+    }
+
+    /**
+     * Stamps `seq`/`generationId` on an event about to be sent to the panel and
+     * buffers it under the currently-running run. Called from the single
+     * ai-panel send chokepoint (`sendAIPanelNotification`). Returns the same
+     * (mutated) event so the caller can forward it. No-op (returns event
+     * unchanged) when no run is active — e.g. notifications sent outside a run.
+     *
+     * @param panelOpen whether an AI panel currently exists to receive the event.
+     *   When a terminal event is emitted with no panel open, the run is marked
+     *   `finishedUnseen` so the next reconnect replays the whole turn.
+     */
+    stampCurrent(event: ChatNotify, panelOpen: boolean): ChatNotify {
+        if (!this.currentKey) {
+            return event;
+        }
+        const state = this.runs.get(this.currentKey);
+        if (!state || !state.isRunning) {
+            return event;
+        }
+        event.seq = ++state.seqCounter;
+        if (state.generationId !== undefined && event.generationId === undefined) {
+            event.generationId = state.generationId;
+        }
+        state.runBuffer.push(event);
+        if (!panelOpen && (event.type === "stop" || event.type === "abort" || event.type === "error")) {
+            state.finishedUnseen = true;
+        }
+        // Bound memory on pathologically long runs by dropping the oldest events.
+        // `seq` stays monotonic (independent of array index), so polling still works;
+        // only an initial reconnect to such a run loses its earliest transcript.
+        if (state.runBuffer.length > MAX_BUFFERED_EVENTS) {
+            state.runBuffer.shift();
+        }
+        return event;
+    }
+
+    /**
+     * Returns the run status for a reconnecting panel.
+     * - `sinceSeq` provided → polling mode: only events with `seq > sinceSeq`.
+     *   Returned whether or not the run is still active, so a poll can pick up a
+     *   terminal event that was dropped.
+     * - `sinceSeq` omitted → initial reconnect: the full current-run buffer while
+     *   the run is active, or — served exactly once — for a run that finished
+     *   while no panel was open (`finishedUnseen`), so the reopened panel can
+     *   rebuild the turn it never saw. Otherwise empty: a completed-and-seen
+     *   turn is already in the persisted chat history, and returning the buffer
+     *   again would duplicate it.
+     */
+    getRunStatus(projectRootPath: string, threadId: string, sinceSeq?: number): RunStatus {
+        const state = this.runs.get(this.key(projectRootPath, threadId));
+        if (!state) {
+            return { isRunning: false, events: [] };
+        }
+        let events: ChatNotify[];
+        if (sinceSeq !== undefined && sinceSeq >= 0) {
+            events = state.runBuffer.filter(e => (e.seq ?? 0) > sinceSeq);
+        } else if (state.isRunning || state.finishedUnseen) {
+            events = [...state.runBuffer];
+            // Serve the finished-unseen buffer only once — after this replay the
+            // frontend re-fires save_chat, persisting the turn into chat history.
+            state.finishedUnseen = false;
+        } else {
+            events = [];
+        }
+        return { isRunning: state.isRunning, events };
+    }
+}
+
+export const runEventStore = new RunEventStore();

--- a/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
@@ -51,21 +51,45 @@ interface RunState {
      * `updateChatMessage`) — so a run that finished while the panel was closed stays
      * replayable across reopens until the replay's own `save_chat` round-trip lands.
      */
-    runBuffer: ChatNotify[];
+    runBuffer: BufferedRunEvent[];
+    /** Approximate serialized size used to bound buffers containing large tool payloads. */
+    bufferedBytes: number;
     generationId?: string;
     /** Set when the buffer cap evicted this run's earliest events. */
     truncated: boolean;
 }
 
-/** Per-run buffer cap: beyond this, the oldest events are evicted (bounds memory on very long runs). */
+interface BufferedRunEvent {
+    event: ChatNotify;
+    /** First and last raw sequence represented by this entry. */
+    firstSeq: number;
+    lastSeq: number;
+    /**
+     * Adjacent streamed text chunks are stored together. This keeps a long text
+     * stream from exhausting the event cap while still allowing an exact
+     * `sinceSeq` response without duplicating chunks already seen by the panel.
+     */
+    contentChunks?: Array<{ seq: number; content: string }>;
+    sizeBytes: number;
+}
+
+/** Per-run structured-event cap. Adjacent content deltas count as one entry. */
 const MAX_BUFFERED_EVENTS = 5000;
+/** Per-run approximate serialized byte cap. */
+const MAX_BUFFERED_BYTES = 8 * 1024 * 1024;
 /** Retain buffers for at most this many distinct runs; evict the oldest beyond it. */
 const MAX_RETAINED_RUNS = 20;
 
-class RunEventStore {
+export class RunEventStore {
     private runs = new Map<string, RunState>();
-    /** The key of the run currently emitting events (set by `beginRun`, cleared by `endRun`). */
-    private currentKey: string | undefined;
+
+    constructor(
+        private readonly limits = {
+            maxEvents: MAX_BUFFERED_EVENTS,
+            maxBytes: MAX_BUFFERED_BYTES,
+            maxRuns: MAX_RETAINED_RUNS,
+        }
+    ) {}
 
     private key(projectRootPath: string, threadId: string): string {
         return `${projectRootPath}::${threadId}`;
@@ -74,20 +98,28 @@ class RunEventStore {
     private getOrCreate(key: string): RunState {
         let state = this.runs.get(key);
         if (!state) {
-            state = { isRunning: false, seqCounter: 0, runBuffer: [], truncated: false };
+            state = { isRunning: false, seqCounter: 0, runBuffer: [], bufferedBytes: 0, truncated: false };
             this.runs.set(key, state);
         }
         return state;
     }
 
-    /** Evict the oldest non-active runs so the store doesn't grow unbounded across many workspaces. */
+    private eventSize(event: ChatNotify): number {
+        try {
+            return Buffer.byteLength(JSON.stringify(event), "utf8");
+        } catch {
+            return 1024;
+        }
+    }
+
+    /** Evict the oldest inactive runs so the store doesn't grow unbounded across many workspaces. */
     private evictStaleRuns(): void {
-        // Map preserves insertion order; delete oldest entries that aren't the current run.
+        // Map preserves insertion order; never evict a run that is still active.
         for (const key of this.runs.keys()) {
-            if (this.runs.size <= MAX_RETAINED_RUNS) {
+            if (this.runs.size <= this.limits.maxRuns) {
                 break;
             }
-            if (key !== this.currentKey) {
+            if (!this.runs.get(key)?.isRunning) {
                 this.runs.delete(key);
             }
         }
@@ -97,52 +129,81 @@ class RunEventStore {
     beginRun(projectRootPath: string, threadId: string, generationId: string): void {
         const key = this.key(projectRootPath, threadId);
         const state = this.getOrCreate(key);
+        if (state.isRunning && state.generationId === generationId) {
+            return;
+        }
         state.isRunning = true;
         state.seqCounter = 0;
         state.runBuffer = [];
+        state.bufferedBytes = 0;
         state.truncated = false;
         state.generationId = generationId;
-        this.currentKey = key;
         this.evictStaleRuns();
     }
 
     /** Marks the end of a run. Keeps the buffer so an in-flight poll can still pick up a terminal event. */
-    endRun(projectRootPath: string, threadId: string): void {
+    endRun(projectRootPath: string, threadId: string, generationId: string): void {
         const key = this.key(projectRootPath, threadId);
         const state = this.runs.get(key);
-        if (state) {
+        if (state?.generationId === generationId) {
             state.isRunning = false;
-        }
-        if (this.currentKey === key) {
-            this.currentKey = undefined;
         }
     }
 
     /**
      * Stamps `seq`/`generationId` on an event about to be sent to the panel and
-     * buffers it under the currently-running run. Called from the single
-     * ai-panel send chokepoint (`sendAIPanelNotification`). Returns the same
-     * (mutated) event so the caller can forward it. No-op (returns event
-     * unchanged) when no run is active — e.g. notifications sent outside a run.
+     * buffers it under the explicitly identified run. Returns the same (mutated)
+     * event so the caller can forward it. A stale or unrelated emitter is a
+     * no-op instead of being attributed to whichever run started most recently.
      */
-    stampCurrent(event: ChatNotify): ChatNotify {
-        if (!this.currentKey) {
+    stamp(
+        projectRootPath: string,
+        threadId: string,
+        generationId: string,
+        event: ChatNotify
+    ): ChatNotify {
+        const state = this.runs.get(this.key(projectRootPath, threadId));
+        if (!state || !state.isRunning || state.generationId !== generationId) {
             return event;
         }
-        const state = this.runs.get(this.currentKey);
-        if (!state || !state.isRunning) {
-            return event;
+
+        const seq = ++state.seqCounter;
+        event.seq = seq;
+        event.generationId = generationId;
+
+        const eventBytes = this.eventSize(event);
+        const last = state.runBuffer[state.runBuffer.length - 1];
+        if (event.type === "content_block" && last?.contentChunks) {
+            last.contentChunks.push({ seq, content: event.content });
+            last.lastSeq = seq;
+            last.sizeBytes += eventBytes;
+            state.bufferedBytes += eventBytes;
+        } else {
+            const storedEvent = { ...event } as ChatNotify;
+            state.runBuffer.push({
+                event: storedEvent,
+                firstSeq: seq,
+                lastSeq: seq,
+                contentChunks: event.type === "content_block"
+                    ? [{ seq, content: event.content }]
+                    : undefined,
+                sizeBytes: eventBytes,
+            });
+            state.bufferedBytes += eventBytes;
         }
-        event.seq = ++state.seqCounter;
-        if (state.generationId !== undefined && event.generationId === undefined) {
-            event.generationId = state.generationId;
-        }
-        state.runBuffer.push(event);
-        // Bound memory on pathologically long runs by dropping the oldest events.
-        // `seq` stays monotonic (independent of array index), so polling still works;
-        // only an initial reconnect to such a run loses its earliest transcript.
-        if (state.runBuffer.length > MAX_BUFFERED_EVENTS) {
-            state.runBuffer.shift();
+
+        // Bound memory on pathologically long runs by dropping the oldest grouped
+        // entries. `seq` remains monotonic and `truncated` prevents the client from
+        // treating the retained tail as a complete transcript.
+        while (
+            state.runBuffer.length > this.limits.maxEvents
+            || state.bufferedBytes > this.limits.maxBytes
+        ) {
+            const removed = state.runBuffer.shift();
+            if (!removed) {
+                break;
+            }
+            state.bufferedBytes = Math.max(0, state.bufferedBytes - removed.sizeBytes);
             state.truncated = true;
         }
         return event;
@@ -164,9 +225,33 @@ class RunEventStore {
         if (!state) {
             return { isRunning: false, events: [], truncated: false };
         }
-        const events = sinceSeq !== undefined && sinceSeq >= 0
-            ? state.runBuffer.filter(e => (e.seq ?? 0) > sinceSeq)
-            : [...state.runBuffer];
+        const events = state.runBuffer.flatMap((entry): ChatNotify[] => {
+            if (sinceSeq === undefined || sinceSeq < 0) {
+                if (entry.contentChunks) {
+                    return [{
+                        ...entry.event,
+                        content: entry.contentChunks.map(chunk => chunk.content).join(""),
+                        seq: entry.lastSeq,
+                    } as ChatNotify];
+                }
+                return [{ ...entry.event }];
+            }
+            if (entry.lastSeq <= sinceSeq) {
+                return [];
+            }
+            if (!entry.contentChunks) {
+                return [{ ...entry.event }];
+            }
+            const missedChunks = entry.contentChunks.filter(chunk => chunk.seq > sinceSeq);
+            if (missedChunks.length === 0) {
+                return [];
+            }
+            return [{
+                ...entry.event,
+                content: missedChunks.map(chunk => chunk.content).join(""),
+                seq: missedChunks[missedChunks.length - 1].seq,
+            } as ChatNotify];
+        });
         return { isRunning: state.isRunning, events, generationId: state.generationId, truncated: state.truncated };
     }
 
@@ -182,6 +267,7 @@ class RunEventStore {
             return;
         }
         state.runBuffer = [];
+        state.bufferedBytes = 0;
         state.truncated = false;
         state.generationId = undefined;
     }

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -46,6 +46,7 @@ import {
     generateContextTypes,
     generateOpenAPI,
     GenerateOpenAPIRequest,
+    HasPendingReviewRequest,
     getActiveTempDir,
     hasPendingReview,
     getRunStatus,
@@ -201,7 +202,7 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(clearChat, () => rpcManger.clearChat());
     messenger.onRequest(updateChatMessage, (args: UpdateChatMessageRequest) => rpcManger.updateChatMessage(args));
     messenger.onRequest(getActiveTempDir, () => rpcManger.getActiveTempDir());
-    messenger.onRequest(hasPendingReview, () => rpcManger.hasPendingReview());
+    messenger.onRequest(hasPendingReview, (args: HasPendingReviewRequest) => rpcManger.hasPendingReview(args));
     messenger.onRequest(getRunStatus, (args) => rpcManger.getRunStatus(args));
     messenger.onRequest(getUsage, () => rpcManger.getUsage());
     messenger.onRequest(requestQuota, (args: QuotaRequestParams) => rpcManger.requestQuota(args));

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -48,6 +48,7 @@ import {
     GenerateOpenAPIRequest,
     getActiveTempDir,
     hasPendingReview,
+    getRunStatus,
     getAIMachineSnapshot,
     getChatMessages,
     getCheckpoints,
@@ -201,6 +202,7 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(updateChatMessage, (args: UpdateChatMessageRequest) => rpcManger.updateChatMessage(args));
     messenger.onRequest(getActiveTempDir, () => rpcManger.getActiveTempDir());
     messenger.onRequest(hasPendingReview, () => rpcManger.hasPendingReview());
+    messenger.onRequest(getRunStatus, (args) => rpcManger.getRunStatus(args));
     messenger.onRequest(getUsage, () => rpcManger.getUsage());
     messenger.onRequest(requestQuota, (args: QuotaRequestParams) => rpcManger.requestQuota(args));
     messenger.onNotification(openFileDiff, (args: OpenFileDiffRequest) => rpcManger.openFileDiff(args));

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -806,7 +806,12 @@ User reverted the last made changes. The files have been restored to the state b
 
     async getRunStatus(params: GetRunStatusRequest): Promise<GetRunStatusResponse> {
         const projectRootPath = params?.projectRootPath || resolveProjectRootPath();
-        const threadId = params?.threadId || 'default';
+        // Runs execute (and buffer their events) under the active thread — resolve
+        // it the same way generateAgent does, or a reconnect on a non-default
+        // thread would look up an empty buffer.
+        const threadId = params?.threadId
+            || chatStateStorage.getActiveThread(projectRootPath)?.id
+            || 'default';
         const status = runEventStore.getRunStatus(projectRootPath, threadId, params?.sinceSeq);
         // Resolve plan mode from the active generation's persisted metadata (the
         // single source of truth) rather than duplicating it into the buffer.

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -720,6 +720,14 @@ User reverted the last made changes. The files have been restored to the state b
             return;
         }
 
+        // Once the transcript is durably saved as uiResponse and the run is no longer
+        // active, the reconnection event buffer is redundant — drop it so a future
+        // reopen serves the turn from persisted history instead of replaying it.
+        const active = chatStateStorage.getActiveExecution(projectRootPath, threadId);
+        if (active?.generationId !== params.messageId) {
+            runEventStore.clearBuffer(projectRootPath, threadId, params.messageId);
+        }
+
         // Update the UI response with the final formatted content
         chatStateStorage.updateGeneration(projectRootPath, threadId, params.messageId, {
             uiResponse: params.content
@@ -809,7 +817,13 @@ User reverted the last made changes. The files have been restored to the state b
                 isPlanMode = chatStateStorage.getGeneration(projectRootPath, threadId, generationId)?.metadata?.isPlanMode;
             }
         }
-        return { ...status, isPlanMode };
+        return {
+            ...status,
+            isPlanMode,
+            // Interactive prompts still awaiting an answer — lets the reopened panel
+            // re-surface only still-pending prompts during replay and skip resolved ones.
+            pendingRequestIds: approvalManager.getPendingRequestIds(),
+        };
     }
 
     async compactConversation(_params: CompactConversationRequest): Promise<CompactConversationResponse> {

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -26,6 +26,8 @@ import {
     AddFilesToProjectRequest,
     CheckpointInfo,
     Command,
+    GetRunStatusRequest,
+    GetRunStatusResponse,
     DocGenerationRequest,
     GenerateAgentCodeRequest,
     GenerateOpenAPIRequest,
@@ -148,6 +150,7 @@ import { ContextTypesExecutor } from '../../features/ai/executors/datamapper/Con
 import { approvalManager } from '../../features/ai/state/ApprovalManager';
 import { approvalViewManager } from '../../features/ai/state/ApprovalViewManager';
 import { chatStateStorage } from '../../views/ai-panel/chatStateStorage';
+import { runEventStore } from '../../features/ai/utils/run-event-store';
 import { restoreWorkspaceSnapshot } from '../../views/ai-panel/checkpoint/checkpointUtils';
 import { runningServicesManager } from '../../features/ai/agent/tools/running-service-manager';
 import { executeRun } from "../../features/ai/agent/tools/ballerina-run";
@@ -791,6 +794,22 @@ User reverted the last made changes. The files have been restored to the state b
     async hasPendingReview(): Promise<boolean> {
         const projectRootPath = resolveProjectRootPath();
         return !!chatStateStorage.getDoneGeneration(projectRootPath, 'default');
+    }
+
+    async getRunStatus(params: GetRunStatusRequest): Promise<GetRunStatusResponse> {
+        const projectRootPath = params?.projectRootPath || resolveProjectRootPath();
+        const threadId = params?.threadId || 'default';
+        const status = runEventStore.getRunStatus(projectRootPath, threadId, params?.sinceSeq);
+        // Resolve plan mode from the active generation's persisted metadata (the
+        // single source of truth) rather than duplicating it into the buffer.
+        let isPlanMode: boolean | undefined;
+        if (status.isRunning) {
+            const generationId = chatStateStorage.getActiveExecution(projectRootPath, threadId)?.generationId;
+            if (generationId) {
+                isPlanMode = chatStateStorage.getGeneration(projectRootPath, threadId, generationId)?.metadata?.isPlanMode;
+            }
+        }
+        return { ...status, isPlanMode };
     }
 
     async compactConversation(_params: CompactConversationRequest): Promise<CompactConversationResponse> {

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -82,6 +82,7 @@ import {
     ThreadSummary,
     SwitchThreadRequest,
     DeleteThreadRequest,
+    HasPendingReviewRequest,
     // TODO(auto-memory): temporarily disabled for this release.
     // ClearMemoryRequest,
     // OpenMemoryRequest,
@@ -708,30 +709,43 @@ User reverted the last made changes. The files have been restored to the state b
     // }
 
     async updateChatMessage(params: UpdateChatMessageRequest): Promise<void> {
-        const projectRootPath = resolveProjectRootPath();
-        const threadId = chatStateStorage.getActiveThread(resolveProjectRootPath())?.id ?? 'default';
+        const projectRootPath = params.projectRootPath || resolveProjectRootPath();
+        let threadId = params.threadId
+            || chatStateStorage.getActiveThread(projectRootPath)?.id
+            || 'default';
 
-        // The messageId is actually a generation ID
-        // This is called when streaming completes to save the final UI-formatted response
-        const generation = chatStateStorage.getGeneration(projectRootPath, threadId, params.messageId);
+        // The messageId is actually a generation ID. Legacy callers do not send
+        // a thread, so locate the generation by its stable ID rather than trusting
+        // the mutable active-thread pointer.
+        let generation = chatStateStorage.getGeneration(projectRootPath, threadId, params.messageId);
+        if (!generation && !params.threadId) {
+            const located = chatStateStorage.findGenerationScope(projectRootPath, params.messageId);
+            if (located) {
+                threadId = located.threadId;
+                generation = located.generation;
+            }
+        }
 
         if (!generation) {
-            console.warn(`[RPC] Generation ${params.messageId} not found in thread ${threadId}`);
-            return;
+            throw new Error(`[RPC] Generation ${params.messageId} not found in thread ${threadId}`);
         }
 
-        // Once the transcript is durably saved as uiResponse and the run is no longer
-        // active, the reconnection event buffer is redundant — drop it so a future
-        // reopen serves the turn from persisted history instead of replaying it.
-        const active = chatStateStorage.getActiveExecution(projectRootPath, threadId);
-        if (active?.generationId !== params.messageId) {
-            runEventStore.clearBuffer(projectRootPath, threadId, params.messageId);
-        }
-
-        // Update the UI response with the final formatted content
-        chatStateStorage.updateGeneration(projectRootPath, threadId, params.messageId, {
+        // Persist first. ChatStateStorage reports disk failures so the replay
+        // buffer remains available for another reconnect attempt.
+        const persisted = chatStateStorage.updateGeneration(projectRootPath, threadId, params.messageId, {
             uiResponse: params.content
         });
+        if (!persisted) {
+            throw new Error(`[RPC] Failed to persist generation ${params.messageId}`);
+        }
+
+        // Intermediate save_chat events encountered during a finished-run replay
+        // must not clear the only recovery source. The reconnect's final write
+        // explicitly clears it after the fully rebuilt transcript is durable.
+        const active = chatStateStorage.getActiveExecution(projectRootPath, threadId);
+        if (params.clearRunBuffer !== false && active?.generationId !== params.messageId) {
+            runEventStore.clearBuffer(projectRootPath, threadId, params.messageId);
+        }
 
         console.log(`[RPC] Updated generation ${params.messageId} UI response`);
     }
@@ -799,9 +813,12 @@ User reverted the last made changes. The files have been restored to the state b
         return projectPath;
     }
 
-    async hasPendingReview(): Promise<boolean> {
-        const projectRootPath = resolveProjectRootPath();
-        return !!chatStateStorage.getDoneGeneration(projectRootPath, 'default');
+    async hasPendingReview(params: HasPendingReviewRequest): Promise<boolean> {
+        const projectRootPath = params?.projectRootPath || resolveProjectRootPath();
+        const threadId = params?.threadId
+            || chatStateStorage.getActiveThread(projectRootPath)?.id
+            || 'default';
+        return !!chatStateStorage.getDoneGeneration(projectRootPath, threadId);
     }
 
     async getRunStatus(params: GetRunStatusRequest): Promise<GetRunStatusResponse> {
@@ -813,18 +830,17 @@ User reverted the last made changes. The files have been restored to the state b
             || chatStateStorage.getActiveThread(projectRootPath)?.id
             || 'default';
         const status = runEventStore.getRunStatus(projectRootPath, threadId, params?.sinceSeq);
-        // Resolve plan mode from the active generation's persisted metadata (the
-        // single source of truth) rather than duplicating it into the buffer.
-        let isPlanMode: boolean | undefined;
-        if (status.isRunning) {
-            const generationId = chatStateStorage.getActiveExecution(projectRootPath, threadId)?.generationId;
-            if (generationId) {
-                isPlanMode = chatStateStorage.getGeneration(projectRootPath, threadId, generationId)?.metadata?.isPlanMode;
-            }
-        }
+        // Generation storage is materialized before beginRun, so the prompt and
+        // mode are authoritative even when reconnect happens before the first event.
+        const generation = status.generationId
+            ? chatStateStorage.getGeneration(projectRootPath, threadId, status.generationId)
+            : undefined;
         return {
             ...status,
-            isPlanMode,
+            projectRootPath,
+            threadId,
+            isPlanMode: generation?.metadata?.isPlanMode,
+            userPrompt: generation?.userPrompt,
             // Interactive prompts still awaiting an answer — lets the reopened panel
             // re-surface only still-pending prompts during replay and skip resolved ones.
             pendingRequestIds: approvalManager.getPendingRequestIds(),

--- a/packages/ballerina-extension/src/test-support/runEventStore.test.ts
+++ b/packages/ballerina-extension/src/test-support/runEventStore.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ChatNotify } from "@wso2/ballerina-core";
+import { RunEventStore } from "../features/ai/utils/run-event-store";
+
+describe("RunEventStore", () => {
+    it("INVARIANT: attributes events only to their explicit run identity", () => {
+        const store = new RunEventStore();
+        store.beginRun("/workspace-a", "thread-a", "generation-a");
+        store.beginRun("/workspace-b", "thread-b", "generation-b");
+
+        const eventA = store.stamp("/workspace-a", "thread-a", "generation-a", {
+            type: "content_block",
+            content: "A",
+        });
+        const eventB = store.stamp("/workspace-b", "thread-b", "generation-b", {
+            type: "content_block",
+            content: "B",
+        });
+        const stale = store.stamp("/workspace-a", "thread-a", "old-generation", {
+            type: "content_block",
+            content: "stale",
+        });
+
+        expect(eventA).toMatchObject({ seq: 1, generationId: "generation-a" });
+        expect(eventB).toMatchObject({ seq: 1, generationId: "generation-b" });
+        expect(stale.seq).toBeUndefined();
+        expect(store.getRunStatus("/workspace-a", "thread-a").events).toHaveLength(1);
+        expect(store.getRunStatus("/workspace-b", "thread-b").events).toHaveLength(1);
+    });
+
+    it("coalesces adjacent text while returning an exact polling delta", () => {
+        const store = new RunEventStore();
+        store.beginRun("/workspace", "thread", "generation");
+        store.stamp("/workspace", "thread", "generation", { type: "content_block", content: "one" });
+        store.stamp("/workspace", "thread", "generation", { type: "content_block", content: "-two" });
+        store.stamp("/workspace", "thread", "generation", {
+            type: "tool_call",
+            toolName: "Read",
+            toolCallId: "tool-1",
+        });
+
+        expect(store.getRunStatus("/workspace", "thread").events).toEqual([
+            expect.objectContaining({ type: "content_block", content: "one-two", seq: 2 }),
+            expect.objectContaining({ type: "tool_call", seq: 3 }),
+        ]);
+        expect(store.getRunStatus("/workspace", "thread", 1).events).toEqual([
+            expect.objectContaining({ type: "content_block", content: "-two", seq: 2 }),
+            expect.objectContaining({ type: "tool_call", seq: 3 }),
+        ]);
+        expect(store.getRunStatus("/workspace", "thread", 2).events).toEqual([
+            expect.objectContaining({ type: "tool_call", seq: 3 }),
+        ]);
+    });
+
+    it("keeps startup events when the executor re-registers the same run", () => {
+        const store = new RunEventStore();
+        store.beginRun("/workspace", "thread", "generation");
+        store.stamp("/workspace", "thread", "generation", { type: "content_block", content: "startup" });
+
+        store.beginRun("/workspace", "thread", "generation");
+
+        expect(store.getRunStatus("/workspace", "thread").events).toEqual([
+            expect.objectContaining({ type: "content_block", content: "startup", seq: 1 }),
+        ]);
+    });
+
+    it("does not let a stale completion or clear mutate a replacement run", () => {
+        const store = new RunEventStore();
+        store.beginRun("/workspace", "thread", "generation-1");
+        store.beginRun("/workspace", "thread", "generation-2");
+        store.stamp("/workspace", "thread", "generation-2", { type: "content_block", content: "new" });
+
+        store.endRun("/workspace", "thread", "generation-1");
+        store.clearBuffer("/workspace", "thread", "generation-1");
+
+        const status = store.getRunStatus("/workspace", "thread");
+        expect(status.isRunning).toBe(true);
+        expect(status.generationId).toBe("generation-2");
+        expect(status.events).toHaveLength(1);
+    });
+
+    it("marks eviction as truncated instead of presenting the retained tail as complete", () => {
+        const store = new RunEventStore({ maxEvents: 2, maxBytes: 1024 * 1024, maxRuns: 20 });
+        store.beginRun("/workspace", "thread", "generation");
+
+        const structuralEvents: ChatNotify[] = [
+            { type: "start" },
+            { type: "tool_call", toolName: "Read", toolCallId: "tool-1" },
+            { type: "tool_result", toolName: "Read", toolCallId: "tool-1" },
+        ];
+        for (const event of structuralEvents) {
+            store.stamp("/workspace", "thread", "generation", event);
+        }
+
+        const status = store.getRunStatus("/workspace", "thread");
+        expect(status.truncated).toBe(true);
+        expect(status.events).toHaveLength(2);
+        expect(status.events[0].seq).toBe(2);
+    });
+});

--- a/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -272,19 +272,21 @@ export class ChatStateStorage {
      * Flush a thread to disk after mutation.
      * Called after every state change to keep files as the source of truth.
      */
-    private flushThread(projectRootPath: string, threadId: string): void {
+    private flushThread(projectRootPath: string, threadId: string): boolean {
         const workspace = this.storage.get(projectRootPath);
         if (!workspace) {
-            return;
+            return false;
         }
         const thread = workspace.threads.get(threadId);
         if (!thread) {
-            return;
+            return false;
         }
         try {
             this.persistenceStore.saveThread(projectRootPath, threadId, toPersistedThread(thread));
+            return true;
         } catch (err) {
             console.error(`[ChatStateStorage] Failed to persist thread ${threadId}:`, err);
+            return false;
         }
     }
 
@@ -710,13 +712,13 @@ export class ChatStateStorage {
         threadId: string,
         generationId: string,
         updates: Partial<Generation>
-    ): void {
+    ): boolean {
         const thread = this.getOrCreateThread(projectRootPath, threadId);
         const generation = thread.generations.find(g => g.id === generationId);
 
         if (!generation) {
             console.error(`[ChatStateStorage] Generation not found: ${generationId}`);
-            return;
+            return false;
         }
 
         // Apply updates
@@ -724,8 +726,9 @@ export class ChatStateStorage {
         thread.updatedAt = Date.now();
 
         // Persist immediately
-        this.flushThread(projectRootPath, threadId);
+        const persisted = this.flushThread(projectRootPath, threadId);
         console.log(`[ChatStateStorage] Updated generation: ${generationId}`);
+        return persisted;
     }
 
     /**
@@ -762,6 +765,24 @@ export class ChatStateStorage {
     ): Generation | undefined {
         const thread = this.getOrCreateThread(projectRootPath, threadId);
         return thread.generations.find(g => g.id === generationId);
+    }
+
+    /**
+     * Locate a generation without relying on the mutable active-thread pointer.
+     * Generation IDs are unique within a workspace.
+     */
+    findGenerationScope(
+        projectRootPath: string,
+        generationId: string
+    ): { threadId: string; generation: Generation } | undefined {
+        const workspace = this.initializeWorkspace(projectRootPath);
+        for (const [threadId, thread] of workspace.threads) {
+            const generation = thread.generations.find(candidate => candidate.id === generationId);
+            if (generation) {
+                return { threadId, generation };
+            }
+        }
+        return undefined;
     }
 
     /**
@@ -1178,6 +1199,14 @@ export class ChatStateStorage {
         threadId: string,
         execution: ActiveExecution
     ): void {
+        const existing = this.activeExecutions.get(projectRootPath)?.get(threadId);
+        if (
+            existing?.generationId === execution.generationId
+            && existing.abortController === execution.abortController
+        ) {
+            return;
+        }
+
         // Abort any existing execution for this thread first
         this.abortActiveExecution(projectRootPath, threadId);
 

--- a/packages/ballerina-extension/src/views/ai-panel/webview.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/webview.ts
@@ -25,6 +25,7 @@ import { extension } from '../../BalExtensionContext';
 import { AIStateMachine } from './aiMachine';
 import { AIMachineEventType } from '@wso2/ballerina-core';
 import { approvalManager } from '../../features/ai/state/ApprovalManager';
+import { chatStateStorage } from './chatStateStorage';
 
 export class AiPanelWebview {
     public static currentPanel: AiPanelWebview | undefined;
@@ -128,7 +129,13 @@ export class AiPanelWebview {
 
     public dispose() {
 
-        approvalManager.cancelAllPending("AI Panel closed");
+        // Keep pending approvals alive if a run is still in flight, so a
+        // reconnecting panel can re-render the approval and let the user
+        // respond (the run keeps executing on the extension host). Only cancel
+        // when nothing is running.
+        if (!chatStateStorage.hasAnyActiveExecution()) {
+            approvalManager.cancelAllPending("AI Panel closed");
+        }
 
         AiPanelWebview.currentPanel = undefined;
         AIStateMachine.sendEvent(AIMachineEventType.DISPOSE);

--- a/packages/ballerina-extension/src/views/ai-panel/webview.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/webview.ts
@@ -25,7 +25,6 @@ import { extension } from '../../BalExtensionContext';
 import { AIStateMachine } from './aiMachine';
 import { AIMachineEventType } from '@wso2/ballerina-core';
 import { approvalManager } from '../../features/ai/state/ApprovalManager';
-import { chatStateStorage } from './chatStateStorage';
 
 export class AiPanelWebview {
     public static currentPanel: AiPanelWebview | undefined;
@@ -129,13 +128,12 @@ export class AiPanelWebview {
 
     public dispose() {
 
-        // Keep pending approvals alive if a run is still in flight, so a
-        // reconnecting panel can re-render the approval and let the user
-        // respond (the run keeps executing on the extension host). Only cancel
-        // when nothing is running.
-        if (!chatStateStorage.hasAnyActiveExecution()) {
-            approvalManager.cancelAllPending("AI Panel closed");
-        }
+        // Closing the panel must not discard an in-progress run's pending question. The agent keeps
+        // running in the extension host, so leave in-chat prompts (clarify/approval/etc.) pending —
+        // they are re-surfaced from the event buffer on reopen and remain answerable. Only popup-based
+        // prompts that can't be replayed (configuration) are cancelled here. Explicit abort still
+        // cancels everything via chatStateStorage.abortActiveExecution → cancelAllPending.
+        approvalManager.cancelOnPanelClose("AI Panel closed");
 
         AiPanelWebview.currentPanel = undefined;
         AIStateMachine.sendEvent(AIMachineEventType.DISPOSE);

--- a/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -79,6 +79,9 @@ import {
     getActiveTempDir,
     getChatMessages,
     hasPendingReview,
+    getRunStatus,
+    GetRunStatusRequest,
+    GetRunStatusResponse,
     getCheckpoints,
     getDefaultPrompt,
     isScaffoldEnvActive,
@@ -353,6 +356,10 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     hasPendingReview(): Promise<boolean> {
         return this._messenger.sendRequest(hasPendingReview, HOST_EXTENSION);
+    }
+
+    getRunStatus(params: GetRunStatusRequest): Promise<GetRunStatusResponse> {
+        return this._messenger.sendRequest(getRunStatus, HOST_EXTENSION, params);
     }
 
     getUsage(): Promise<UsageResponse | undefined> {

--- a/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -82,6 +82,7 @@ import {
     getRunStatus,
     GetRunStatusRequest,
     GetRunStatusResponse,
+    HasPendingReviewRequest,
     getCheckpoints,
     getDefaultPrompt,
     isScaffoldEnvActive,
@@ -354,8 +355,8 @@ export class AiPanelRpcClient implements AIPanelAPI {
         return this._messenger.sendRequest(getActiveTempDir, HOST_EXTENSION);
     }
 
-    hasPendingReview(): Promise<boolean> {
-        return this._messenger.sendRequest(hasPendingReview, HOST_EXTENSION);
+    hasPendingReview(params: HasPendingReviewRequest): Promise<boolean> {
+        return this._messenger.sendRequest(hasPendingReview, HOST_EXTENSION, params);
     }
 
     getRunStatus(params: GetRunStatusRequest): Promise<GetRunStatusResponse> {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -322,6 +322,22 @@ const AIChat: React.FC = () => {
     const isErrorChunkReceivedRef = useRef(false);
     const activeScaffoldKeyRef = useRef<string | null>(null);
 
+    // --- Panel reconnection safeguards ---
+    // The agent run survives the panel closing; these let a reopened panel
+    // re-attach to an in-flight run, replay missed events, and poll for events
+    // that were dropped while no panel was listening.
+    const ENABLE_STREAM_SAFEGUARDS = true;
+    const ENABLE_STREAM_POLLING_FALLBACK = ENABLE_STREAM_SAFEGUARDS;
+    const POLL_STALE_THRESHOLD_MS = 5_000;
+    const POLL_INTERVAL_MS = 3_000;
+    const lastReceivedSeqRef = useRef<number>(0);          // highest seq seen (push or replay)
+    const lastEventTimeRef = useRef<number>(0);            // timestamp of last event (staleness)
+    const terminalEventReceivedRef = useRef<boolean>(false); // stop/abort/error seen
+    const pollInFlightRef = useRef<boolean>(false);        // prevents overlapping polls
+    const activeRunGenerationIdRef = useRef<string | undefined>(undefined); // drop stale-run events
+    const handleChatNotifyRef = useRef<(response: ChatNotify) => void>(() => {});
+    const [backendRequestTriggered, setBackendRequestTriggered] = useState(false);
+
     const messagesEndRef = React.useRef<HTMLDivElement>(null);
 
     /* REFACTORED CODE START [2] */
@@ -613,6 +629,52 @@ const AIChat: React.FC = () => {
     };
 
     /**
+     * Re-attach to an agent run after the panel was closed and reopened: fetch
+     * the buffered events, adopt the run, and replay what the closed panel
+     * missed. Covers both a run that is still executing (live re-attach) and a
+     * run that finished while the panel was closed — the backend serves the
+     * latter's buffer exactly once, and replaying its save_chat also persists
+     * the final transcript the closed panel never round-tripped. No-op when
+     * there is nothing to replay.
+     */
+    const reconnectToActiveRun = async () => {
+        try {
+            const runStatus = await rpcClient.getAiPanelRpcClient().getRunStatus({});
+            if (runStatus.events.length === 0) {
+                return;
+            }
+            // Adopt this run so any stray events from a prior run are dropped.
+            activeRunGenerationIdRef.current = runStatus.events.find(e => !!e.generationId)?.generationId;
+            if (ENABLE_STREAM_SAFEGUARDS) {
+                lastReceivedSeqRef.current = 0;
+                lastEventTimeRef.current = Date.now();
+                terminalEventReceivedRef.current = false;
+            }
+            if (runStatus.isPlanMode !== undefined) {
+                setAgentMode(runStatus.isPlanMode ? AgentMode.Plan : AgentMode.Edit);
+            }
+            // Rebuild the turn cleanly onto a fresh assistant message: drop any
+            // partial assistant message persisted mid-run (stale uiResponse), then
+            // append an empty one so the replay never lands on a previous turn's
+            // assistant message (ensureAssistantMessage targets the latest one).
+            setMessages(prev => {
+                const idx = getLatestAssistantMessageIndex(prev);
+                const base = idx >= 0 && idx === prev.length - 1 ? prev.slice(0, -1) : prev;
+                return [...base, { role: "Copilot", content: "", type: "assistant_message" }];
+            });
+            if (runStatus.isRunning) {
+                setIsLoading(true);
+                setBackendRequestTriggered(true);
+            }
+            for (const ev of runStatus.events) {
+                handleChatNotifyRef.current(ev);
+            }
+        } catch (error) {
+            console.error('[AIChat] Failed to restore in-flight run status:', error);
+        }
+    };
+
+    /**
      * Effect: Load initial chat history from aiChatMachine context
      */
     useEffect(function loadInitialChatHistory() {
@@ -638,10 +700,59 @@ const AIChat: React.FC = () => {
             } catch (error) {
                 console.error('[AIChat] Failed to check pending review state:', error);
             }
+
+            // Reconnect to an in-flight run: the run keeps executing on the
+            // extension host while the panel is closed, buffering the events we
+            // missed. Replay them so the reopened panel shows live progress.
+            await reconnectToActiveRun();
         };
 
         loadHistory();
     }, [rpcClient]);
+
+    /**
+     * Effect: Polling fallback for panel reconnection. When a run is active but
+     * live push events go stale (e.g. the panel was briefly closed, or a burst
+     * was dropped), poll `getRunStatus` for events since the last seen `seq` and
+     * replay them. Stops once a terminal event is seen or the run ends.
+     */
+    useEffect(() => {
+        if (!ENABLE_STREAM_POLLING_FALLBACK || !backendRequestTriggered || !rpcClient) {
+            return;
+        }
+        const intervalId = setInterval(async () => {
+            if (terminalEventReceivedRef.current || pollInFlightRef.current) {
+                return;
+            }
+            if (Date.now() - lastEventTimeRef.current < POLL_STALE_THRESHOLD_MS) {
+                return;
+            }
+            try {
+                pollInFlightRef.current = true;
+                const runStatus = await rpcClient.getAiPanelRpcClient().getRunStatus({
+                    sinceSeq: lastReceivedSeqRef.current,
+                });
+                for (const ev of runStatus.events) {
+                    // Race guard against a push arriving concurrently with the poll.
+                    if (typeof ev.seq === "number" && ev.seq <= lastReceivedSeqRef.current) {
+                        continue;
+                    }
+                    handleChatNotifyRef.current(ev);
+                }
+                if (!runStatus.isRunning && runStatus.events.length === 0 && !terminalEventReceivedRef.current) {
+                    setBackendRequestTriggered(false);
+                }
+            } catch {
+                // best-effort; try again next tick
+            } finally {
+                pollInFlightRef.current = false;
+            }
+        }, POLL_INTERVAL_MS);
+        return () => {
+            clearInterval(intervalId);
+            pollInFlightRef.current = false;
+        };
+    }, [backendRequestTriggered, rpcClient]);
 
     /**
      * Effect: Check for an active migration session that needs AI enhancement.
@@ -690,7 +801,28 @@ const AIChat: React.FC = () => {
         }
     });
 
-    rpcClient?.onChatNotify(async (response: ChatNotify) => {
+    const handleChatNotify = async (response: ChatNotify) => {
+        // Reconnection bookkeeping (runs even for events that get dropped below):
+        // track the seq high-water mark, staleness timestamp, and terminal state.
+        if (ENABLE_STREAM_SAFEGUARDS) {
+            if (typeof response.seq === "number" && response.seq > lastReceivedSeqRef.current) {
+                lastReceivedSeqRef.current = response.seq;
+            }
+            lastEventTimeRef.current = Date.now();
+            if (response.type === "stop" || response.type === "abort" || response.type === "error") {
+                terminalEventReceivedRef.current = true;
+            }
+        }
+        // Drop events belonging to a different (previously-interrupted) run once
+        // we have adopted a specific run on reconnect.
+        if (
+            response.generationId &&
+            activeRunGenerationIdRef.current &&
+            response.generationId !== activeRunGenerationIdRef.current
+        ) {
+            return;
+        }
+
         const type = response.type;
 
         if (type === "content_block") {
@@ -1027,6 +1159,7 @@ const AIChat: React.FC = () => {
             setIsCodeLoading(false);
             setIsLoading(false);
             setIsMigrationEnhancementRunning(false);
+            setBackendRequestTriggered(false);
             fetchUsage();
             setAgentMode(AgentMode.Edit);
             if (activeScaffoldKeyRef.current && !isErrorChunkReceivedRef.current) {
@@ -1052,6 +1185,7 @@ const AIChat: React.FC = () => {
             setIsCompacting(false);
             setIsCodeLoading(false);
             setIsLoading(false);
+            setBackendRequestTriggered(false);
             if (isMigrationEnhancementRunning) {
                 setIsMigrationEnhancementRunning(false);
                 // Re-fetch session so the Resume card appears
@@ -1065,11 +1199,18 @@ const AIChat: React.FC = () => {
 
         } else if (type === "save_chat") {
             console.log("Received save_chat signal");
-            const assistantIndex = getLatestAssistantMessageIndex(messages);
-            const contentToSave = assistantIndex >= 0 ? messages[assistantIndex]?.content : messages[messages.length - 1]?.content;
-            await rpcClient.getAiPanelRpcClient().updateChatMessage({
-                messageId: response.messageId,
-                content: contentToSave || "",
+            // Read the freshest committed messages via the functional updater so
+            // this works during a synchronous reconnect replay too (where the
+            // closed-over `messages` would otherwise be stale).
+            const messageId = response.messageId;
+            setMessages((prev) => {
+                const assistantIndex = getLatestAssistantMessageIndex(prev);
+                const contentToSave = assistantIndex >= 0 ? prev[assistantIndex]?.content : prev[prev.length - 1]?.content;
+                void rpcClient.getAiPanelRpcClient().updateChatMessage({
+                    messageId,
+                    content: contentToSave || "",
+                });
+                return prev;
             });
 
         } else if (type === "error") {
@@ -1121,9 +1262,16 @@ const AIChat: React.FC = () => {
             setIsCompacting(false);
             setIsCodeLoading(false);
             setIsLoading(false);
+            setBackendRequestTriggered(false);
             isErrorChunkReceivedRef.current = true;
         }
-    });
+    };
+
+    // Keep the subscription behaviour identical to before (fresh closure per
+    // render so `messages`-reading branches stay current), and expose the
+    // latest handler via a ref for the reconnect/poll replay paths.
+    handleChatNotifyRef.current = handleChatNotify;
+    rpcClient?.onChatNotify(handleChatNotify);
 
     function generateNaturalProgrammingTemplate(isReqFileExists: boolean) {
         if (isReqFileExists) {
@@ -1293,6 +1441,16 @@ const AIChat: React.FC = () => {
         setMessages((prevMessages) => prevMessages.filter((message) => message.type !== "question"));
         setIsLoading(true);
         isErrorChunkReceivedRef.current = false;
+        // Reset reconnection safeguards for the new run and arm the polling
+        // fallback. The generationId is server-assigned, so we clear the adopted
+        // run id (accept all events) until a reconnect adopts a specific run.
+        if (ENABLE_STREAM_SAFEGUARDS) {
+            lastReceivedSeqRef.current = 0;
+            lastEventTimeRef.current = Date.now();
+            terminalEventReceivedRef.current = false;
+            activeRunGenerationIdRef.current = undefined;
+        }
+        setBackendRequestTriggered(true);
         setMessages((prevMessages) =>
             prevMessages.filter((message, index) => index <= lastQuestionIndex || message.type !== "question")
         );

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -371,10 +371,6 @@ const AIChat: React.FC = () => {
     // True while replaying buffered events on reopen — lets the notify handler skip
     // interactive prompts that were already resolved earlier in the run.
     const replayingRef = useRef(false);
-    // Always-fresh mirror of `messages`, used to read the rebuilt transcript after a replay
-    // (the notify handler's own closure would be stale inside an async replay loop).
-    const latestMessagesRef = useRef<typeof messages>([]);
-    useEffect(() => { latestMessagesRef.current = messages; }, [messages]);
     // Ensures the reconnect/replay runs at most once for this panel mount
     // (guards StrictMode double-effects and rpcClient identity churn).
     const didReconnectRef = useRef(false);
@@ -760,21 +756,25 @@ const AIChat: React.FC = () => {
                 replayingRef.current = false;
             }
             if (!runStatus.isRunning && generationId) {
-                // Finished while the panel was closed. Persist the rebuilt transcript
-                // once (after React commits the replayed messages) so it's durable,
-                // the backend drops the buffer, and later reopens serve from history.
-                // (The replayed save_chat usually does this already; this covers
-                // buffers whose run ended without one, e.g. an error turn.)
-                setTimeout(() => {
-                    const msgs = latestMessagesRef.current;
-                    const idx = getLatestAssistantMessageIndex(msgs);
-                    const content = idx >= 0 ? msgs[idx]?.content : "";
+                // Finished while the panel was closed. Persist the rebuilt transcript so
+                // it's durable, the backend drops the buffer, and later reopens serve from
+                // history. (The replayed save_chat usually does this already; this covers
+                // buffers whose run ended without one, e.g. an error turn.) Read the
+                // transcript via a functional updater: it is queued AFTER every replay
+                // update, so `prev` is the fully rebuilt state and the RPC is ordered
+                // after the replayed save_chat writes. A detached read (ref/timeout)
+                // would race React's commit and could persist a stale pre-replay
+                // snapshot as the LAST write, clobbering the correct transcript.
+                setMessages((prev) => {
+                    const idx = getLatestAssistantMessageIndex(prev);
+                    const content = idx >= 0 ? prev[idx]?.content : "";
                     if (content) {
                         rpcClient.getAiPanelRpcClient()
                             .updateChatMessage({ messageId: generationId, content })
                             .catch((e) => console.error('[AIChat] Failed to persist recovered transcript:', e));
                     }
-                }, 0);
+                    return prev;
+                });
             }
         } catch (error) {
             console.error('[AIChat] Failed to restore in-flight run status:', error);

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -384,6 +384,18 @@ const AIChat: React.FC = () => {
     // replay's high-water mark) and opens the gate once replay is done.
     const liveGateClosedRef = useRef(true);
     const liveQueueRef = useRef<ChatNotify[]>([]);
+    // Resolved once the mount-time reconnect (history load + buffer replay + recovery
+    // persist) has settled. Sends await this before hitting the backend: a new run's
+    // beginRun resets the event buffer, so a send racing the replay (e.g. an
+    // auto-submitted initial prompt) would wipe a finished run's not-yet-persisted
+    // tail — review chip and final transcript included.
+    const reconnectSettledResolveRef = useRef<(() => void) | null>(null);
+    const reconnectSettledRef = useRef<Promise<void> | null>(null);
+    if (reconnectSettledRef.current === null) {
+        reconnectSettledRef.current = new Promise<void>((resolve) => {
+            reconnectSettledResolveRef.current = resolve;
+        });
+    }
 
     const messagesEndRef = React.useRef<HTMLDivElement>(null);
 
@@ -697,20 +709,22 @@ const AIChat: React.FC = () => {
             // (per-step save_chat writes partial uiResponses mid-run, so a history bubble
             // for this generation does NOT imply completeness) — whenever one exists,
             // rebuild the turn from it; the persist that follows clears it, so this
-            // converges. Exception: a truncated (overflowed) buffer can't rebuild the
-            // whole turn, so prefer a persisted partial when one exists. A live run always
-            // proceeds, even with an empty buffer, to arm the spinner and polling fallback.
+            // converges. A live run always proceeds, even with an empty buffer, to arm
+            // the spinner and polling fallback.
             const assistantAlreadyLoaded = !!generationId &&
                 historyMessages.some((m) => m.role === "Copilot" && m.messageId === generationId);
-            if (!runStatus.isRunning &&
-                (runStatus.events.length === 0 || (runStatus.truncated && assistantAlreadyLoaded))) {
+            if (!runStatus.isRunning && runStatus.events.length === 0) {
                 return;
             }
-            // Truncated buffer on a LIVE run with a persisted partial: the partial covers
-            // the turn's beginning, which the buffer has already evicted — keep it, skip
-            // the replay, and fast-forward the seq watermark past the buffered events so
-            // only newer live/polled events append after it.
-            const keepPartialSkipReplay = runStatus.isRunning && runStatus.truncated && assistantAlreadyLoaded;
+            // Truncated (overflowed) buffer with a persisted partial: the partial covers
+            // the turn's beginning, which the buffer has already evicted, so a full replay
+            // can't rebuild the turn — keep the partial instead of dropping it, skip the
+            // bulk replay, and fast-forward the seq watermark past the buffered events so
+            // only newer live/polled events append after it. Structural tail events
+            // (review chip, diagnostics, a final error) are still replayed selectively
+            // below: they are emitted after the last mid-run persist, so the partial
+            // cannot contain them, and unlike text deltas they graft onto it safely.
+            const keepPartialSkipReplay = runStatus.truncated && assistantAlreadyLoaded;
 
             // Adopt this run so any stray events from a prior run are dropped.
             activeRunGenerationIdRef.current = generationId;
@@ -744,10 +758,14 @@ const AIChat: React.FC = () => {
                     }
                 } else {
                     // The run may be blocked on a prompt whose event is in the skipped
-                    // buffer — re-surface still-pending prompts so it stays answerable.
+                    // buffer — re-surface still-pending prompts so it stays answerable —
+                    // and replay the structural tail events the kept partial can't contain.
                     for (const ev of runStatus.events) {
                         const reqId = (ev as any).requestId;
-                        if (reqId && pendingRequestIdsRef.current.has(reqId)) {
+                        const stillPendingPrompt = !!reqId && pendingRequestIdsRef.current.has(reqId);
+                        const structuralTail = ev.type === "chat_component" || ev.type === "diagnostics"
+                            || (!runStatus.isRunning && ev.type === "error");
+                        if (stillPendingPrompt || structuralTail) {
                             await handleChatNotifyRef.current(ev);
                         }
                     }
@@ -842,6 +860,7 @@ const AIChat: React.FC = () => {
                     }
                 }
                 liveGateClosedRef.current = false;
+                reconnectSettledResolveRef.current?.();
             }
         };
 
@@ -1609,6 +1628,11 @@ const AIChat: React.FC = () => {
      * triggers the auto-submit effect.
      */
     async function handleSend(content: { input: Input[]; attachments: Attachment[]; metadata?: Record<string, any> }) {
+        // A new run's beginRun resets the backend event buffer — wait for the
+        // mount-time reconnect to finish replaying/persisting any buffered run
+        // first, so an auto-submitted prompt can't wipe a finished run's
+        // not-yet-persisted tail (review chip and final transcript included).
+        await reconnectSettledRef.current;
         setCurrentGeneratingPromptIndex(otherMessages.length);
         setIsPromptExecutedInCurrentWindow(true);
         setFeedbackGiven(null);

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -224,6 +224,26 @@ function scaffoldKeyHash(text: string, hiddenContext: string | undefined): strin
 const AIChat: React.FC = () => {
     const { rpcClient } = useRpcContext();
     const [messages, setMessages] = useState<Array<{ role: string; content: string; type: string; checkpointId?: string; messageId?: string }>>([]);
+    const renderedMessagesRef = useRef(messages);
+    const messagesCommitWaitersRef = useRef<Array<() => void>>([]);
+    const [messagesCommitSignal, setMessagesCommitSignal] = useState(0);
+
+    React.useLayoutEffect(() => {
+        renderedMessagesRef.current = messages;
+        const waiters = messagesCommitWaitersRef.current.splice(0);
+        for (const resolve of waiters) {
+            resolve();
+        }
+    }, [messages, messagesCommitSignal]);
+
+    const waitForMessagesCommit = useCallback((): Promise<void> => {
+        return new Promise((resolve) => {
+            messagesCommitWaitersRef.current.push(resolve);
+            // This marker is queued after all preceding message updates. The
+            // layout effect therefore observes their final committed state.
+            setMessagesCommitSignal((value) => value + 1);
+        });
+    }, []);
 
     const getLatestAssistantMessageIndex = (chatMessages: Array<{ role: string }>): number => {
         for (let i = chatMessages.length - 1; i >= 0; i--) {
@@ -255,9 +275,20 @@ const AIChat: React.FC = () => {
         // Without this, replaying a follow-up turn's events on reopen merges them into the previous
         // turn's bubble and the follow-up prompt is pushed below its own response.
         if (targetIndex !== -1 && targetIndex > getLatestUserMessageIndex(chatMessages)) {
+            if (!chatMessages[targetIndex].messageId && activeRunGenerationIdRef.current) {
+                chatMessages[targetIndex] = {
+                    ...chatMessages[targetIndex],
+                    messageId: activeRunGenerationIdRef.current,
+                };
+            }
             return targetIndex;
         }
-        chatMessages.push({ role: "Copilot", content: "", type: "assistant_message" });
+        chatMessages.push({
+            role: "Copilot",
+            content: "",
+            type: "assistant_message",
+            messageId: activeRunGenerationIdRef.current,
+        });
         return chatMessages.length - 1;
     };
 
@@ -366,6 +397,9 @@ const AIChat: React.FC = () => {
     const terminalEventReceivedRef = useRef<boolean>(false); // stop/abort/error seen
     const pollInFlightRef = useRef<boolean>(false);        // prevents overlapping polls
     const activeRunGenerationIdRef = useRef<string | undefined>(undefined); // drop stale-run events
+    const activeRunScopeRef = useRef<{ projectRootPath: string; threadId: string } | undefined>(undefined);
+    const runEpochRef = useRef(0);                         // invalidates old in-flight poll responses
+    const runAcknowledgedRef = useRef(false);              // backend has exposed/evented the expected run
     const handleChatNotifyRef = useRef<(response: ChatNotify) => void | Promise<void>>(() => {});
     const [backendRequestTriggered, setBackendRequestTriggered] = useState(false);
     // True while replaying buffered events on reopen — lets the notify handler skip
@@ -699,6 +733,10 @@ const AIChat: React.FC = () => {
     const reconnectToActiveRun = async (historyMessages: ReturnType<typeof convertToUIMessages>) => {
         try {
             const runStatus = await rpcClient.getAiPanelRpcClient().getRunStatus({});
+            activeRunScopeRef.current = {
+                projectRootPath: runStatus.projectRootPath,
+                threadId: runStatus.threadId,
+            };
             // Prompts still awaiting an answer — used by the replay skip guard to
             // re-show only still-pending interactive prompts.
             pendingRequestIdsRef.current = new Set(runStatus.pendingRequestIds ?? []);
@@ -711,25 +749,37 @@ const AIChat: React.FC = () => {
             // rebuild the turn from it; the persist that follows clears it, so this
             // converges. A live run always proceeds, even with an empty buffer, to arm
             // the spinner and polling fallback.
-            const assistantAlreadyLoaded = !!generationId &&
-                historyMessages.some((m) => m.role === "Copilot" && m.messageId === generationId);
             if (!runStatus.isRunning && runStatus.events.length === 0) {
                 return;
             }
-            // Truncated (overflowed) buffer with a persisted partial: the partial covers
-            // the turn's beginning, which the buffer has already evicted, so a full replay
-            // can't rebuild the turn — keep the partial instead of dropping it, skip the
-            // bulk replay, and fast-forward the seq watermark past the buffered events so
-            // only newer live/polled events append after it. Structural tail events
-            // (review chip, diagnostics, a final error) are still replayed selectively
-            // below: they are emitted after the last mid-run persist, so the partial
-            // cannot contain them, and unlike text deltas they graft onto it safely.
-            const keepPartialSkipReplay = runStatus.truncated && assistantAlreadyLoaded;
+
+            // Older extension versions could expose a run before its generation
+            // was persisted. Repair such a history defensively from the backend's
+            // authoritative prompt so streamed content cannot attach to the prior turn.
+            if (
+                generationId
+                && runStatus.userPrompt
+                && !historyMessages.some((message) =>
+                    message.role === "User" && message.messageId === generationId
+                )
+            ) {
+                setMessages((previous) => [
+                    ...previous,
+                    {
+                        role: "User",
+                        content: runStatus.userPrompt!,
+                        type: "user_message",
+                        messageId: generationId,
+                    },
+                ]);
+            }
 
             // Adopt this run so any stray events from a prior run are dropped.
             activeRunGenerationIdRef.current = generationId;
+            runAcknowledgedRef.current = !!generationId;
+            runEpochRef.current += 1;
             if (ENABLE_STREAM_SAFEGUARDS) {
-                lastReceivedSeqRef.current = keepPartialSkipReplay
+                lastReceivedSeqRef.current = runStatus.truncated
                     ? (runStatus.events[runStatus.events.length - 1]?.seq ?? 0)
                     : 0;
                 lastEventTimeRef.current = Date.now();
@@ -738,13 +788,26 @@ const AIChat: React.FC = () => {
             if (runStatus.isPlanMode !== undefined) {
                 setAgentMode(runStatus.isPlanMode ? AgentMode.Plan : AgentMode.Edit);
             }
-            if (!keepPartialSkipReplay) {
+            if (!runStatus.truncated) {
                 // Drop any assistant bubble already loaded for this generation (stale
                 // partial uiResponse) — the replay rebuilds the full turn from scratch,
                 // and turn-aware ensureAssistantMessage starts a fresh bubble for it.
                 setMessages(prev => prev.filter(
                     (m) => !(m.type === "assistant_message" && m.messageId === generationId)
                 ));
+            } else {
+                // Never present or persist a retained tail as though it were the
+                // complete turn. Keep any durable partial and make the gap explicit.
+                setMessages((previous) => {
+                    const next = [...previous];
+                    const targetIndex = ensureAssistantMessage(next);
+                    const current = next[targetIndex];
+                    const warning = "\n\n*[Some output streamed while this panel was closed could not be recovered. The transcript below may be incomplete.]*";
+                    if (!current.content.includes(warning.trim())) {
+                        next[targetIndex] = { ...current, content: `${current.content}${warning}` };
+                    }
+                    return next;
+                });
             }
             if (runStatus.isRunning) {
                 setIsLoading(true);
@@ -752,18 +815,18 @@ const AIChat: React.FC = () => {
             }
             replayingRef.current = true;
             try {
-                if (!keepPartialSkipReplay) {
+                if (!runStatus.truncated) {
                     for (const ev of runStatus.events) {
                         await handleChatNotifyRef.current(ev);
                     }
                 } else {
-                    // The run may be blocked on a prompt whose event is in the skipped
-                    // buffer — re-surface still-pending prompts so it stays answerable —
-                    // and replay the structural tail events the kept partial can't contain.
+                    // The retained tail is not a complete transcript. Re-surface only
+                    // still-answerable prompts and safe structural state.
                     for (const ev of runStatus.events) {
                         const reqId = (ev as any).requestId;
                         const stillPendingPrompt = !!reqId && pendingRequestIdsRef.current.has(reqId);
                         const structuralTail = ev.type === "chat_component" || ev.type === "diagnostics"
+                            || ev.type === "plan_approval_resolved"
                             || (!runStatus.isRunning && ev.type === "error");
                         if (stillPendingPrompt || structuralTail) {
                             await handleChatNotifyRef.current(ev);
@@ -773,26 +836,30 @@ const AIChat: React.FC = () => {
             } finally {
                 replayingRef.current = false;
             }
-            if (!runStatus.isRunning && generationId) {
+            if (!runStatus.isRunning && generationId && !runStatus.truncated) {
                 // Finished while the panel was closed. Persist the rebuilt transcript so
                 // it's durable, the backend drops the buffer, and later reopens serve from
                 // history. (The replayed save_chat usually does this already; this covers
                 // buffers whose run ended without one, e.g. an error turn.) Read the
-                // transcript via a functional updater: it is queued AFTER every replay
-                // update, so `prev` is the fully rebuilt state and the RPC is ordered
-                // after the replayed save_chat writes. A detached read (ref/timeout)
-                // would race React's commit and could persist a stale pre-replay
-                // snapshot as the LAST write, clobbering the correct transcript.
-                setMessages((prev) => {
-                    const idx = getLatestAssistantMessageIndex(prev);
-                    const content = idx >= 0 ? prev[idx]?.content : "";
-                    if (content) {
-                        rpcClient.getAiPanelRpcClient()
-                            .updateChatMessage({ messageId: generationId, content })
-                            .catch((e) => console.error('[AIChat] Failed to persist recovered transcript:', e));
-                    }
-                    return prev;
-                });
+                // Wait for React to commit every replay update, then perform one
+                // explicit, awaited final write. This is the only recovery write
+                // allowed to clear the backend buffer.
+                await waitForMessagesCommit();
+                const recoveredMessage = [...renderedMessagesRef.current]
+                    .reverse()
+                    .find((message) =>
+                        (message.role === "Copilot" || message.role === "assistant")
+                        && message.messageId === generationId
+                    );
+                if (recoveredMessage?.content) {
+                    await rpcClient.getAiPanelRpcClient().updateChatMessage({
+                        messageId: generationId,
+                        content: recoveredMessage.content,
+                        projectRootPath: runStatus.projectRootPath,
+                        threadId: runStatus.threadId,
+                        clearRunBuffer: true,
+                    });
+                }
             }
         } catch (error) {
             console.error('[AIChat] Failed to restore in-flight run status:', error);
@@ -828,7 +895,7 @@ const AIChat: React.FC = () => {
                 // event, so a webview reload would leave a pending review inactive
                 // (ReviewBar unclickable, auto-accept-on-send skipped).
                 try {
-                    const pending = await rpcClient.getAiPanelRpcClient().hasPendingReview();
+                    const pending = await rpcClient.getAiPanelRpcClient().hasPendingReview({});
                     if (pending) {
                         setHasActiveReview(true);
                     }
@@ -886,15 +953,44 @@ const AIChat: React.FC = () => {
             }
             try {
                 pollInFlightRef.current = true;
+                const requestedEpoch = runEpochRef.current;
+                const requestedGenerationId = activeRunGenerationIdRef.current;
                 const runStatus = await rpcClient.getAiPanelRpcClient().getRunStatus({
                     sinceSeq: lastReceivedSeqRef.current,
                 });
+                // A new send/reconnect happened while this request was in flight,
+                // or the response belongs to a different server-side run.
+                if (
+                    requestedEpoch !== runEpochRef.current
+                    || (
+                        requestedGenerationId
+                        && runStatus.generationId
+                        && requestedGenerationId !== runStatus.generationId
+                    )
+                    || (
+                        requestedGenerationId
+                        && !runStatus.generationId
+                        && !runAcknowledgedRef.current
+                    )
+                ) {
+                    return;
+                }
+                if (
+                    requestedGenerationId
+                    && runStatus.generationId === requestedGenerationId
+                ) {
+                    runAcknowledgedRef.current = true;
+                }
+                activeRunScopeRef.current = {
+                    projectRootPath: runStatus.projectRootPath,
+                    threadId: runStatus.threadId,
+                };
                 for (const ev of runStatus.events) {
                     // Race guard against a push arriving concurrently with the poll.
                     if (typeof ev.seq === "number" && ev.seq <= lastReceivedSeqRef.current) {
                         continue;
                     }
-                    handleChatNotifyRef.current(ev);
+                    await handleChatNotifyRef.current(ev);
                 }
                 if (!runStatus.isRunning && runStatus.events.length === 0 && !terminalEventReceivedRef.current) {
                     // Watchdog: the run is genuinely gone but its terminal event never
@@ -976,6 +1072,19 @@ const AIChat: React.FC = () => {
             response.generationId &&
             activeRunGenerationIdRef.current &&
             response.generationId !== activeRunGenerationIdRef.current
+        ) {
+            return;
+        }
+        if (
+            response.generationId
+            && response.generationId === activeRunGenerationIdRef.current
+        ) {
+            runAcknowledgedRef.current = true;
+        }
+        if (
+            !replayingRef.current
+            && typeof response.seq === "number"
+            && response.seq <= lastReceivedSeqRef.current
         ) {
             return;
         }
@@ -1146,6 +1255,37 @@ const AIChat: React.FC = () => {
                 taskDescription: response.taskDescription,
                 message: response.message,
             });
+
+        } else if (type === "plan_approval_resolved") {
+            setMessages((previous) => {
+                const next = [...previous];
+                const assistantIndex = getLatestAssistantMessageIndex(next);
+                if (assistantIndex === -1) {
+                    return previous;
+                }
+                const assistant = next[assistantIndex];
+                const entries = parseStream(assistant.content);
+                const updated = entries.map((entry) => ({
+                    ...entry,
+                    items: entry.items.map((item) =>
+                        item.kind === "plan" && item.requestId === response.requestId
+                            ? {
+                                ...item,
+                                approvalStatus: response.approved ? "approved" as const : "revised" as const,
+                                approvalComment: response.approved ? undefined : response.comment,
+                            }
+                            : item
+                    ),
+                }));
+                next[assistantIndex] = {
+                    ...assistant,
+                    content: serializeStream(updated, assistant.content),
+                };
+                return next;
+            });
+            setApprovalRequest((pending) =>
+                pending?.requestId === response.requestId ? null : pending
+            );
 
         } else if (type === "web_tool_approval_request") {
             // Banner-only event (no transcript item) — nothing to rebuild for a resolved one.
@@ -1394,19 +1534,36 @@ const AIChat: React.FC = () => {
 
         } else if (type === "save_chat") {
             console.log("Received save_chat signal");
-            // Read the freshest committed messages via the functional updater so
-            // this works during a synchronous reconnect replay too (where the
-            // closed-over `messages` would otherwise be stale).
             const messageId = response.messageId;
-            setMessages((prev) => {
-                const assistantIndex = getLatestAssistantMessageIndex(prev);
-                const contentToSave = assistantIndex >= 0 ? prev[assistantIndex]?.content : prev[prev.length - 1]?.content;
-                rpcClient.getAiPanelRpcClient().updateChatMessage({
+            const isRecoveryIntermediateWrite = replayingRef.current;
+            await waitForMessagesCommit();
+            const scopedAssistant = [...renderedMessagesRef.current]
+                .reverse()
+                .find((message) =>
+                    (message.role === "Copilot" || message.role === "assistant")
+                    && message.messageId === messageId
+                );
+            const fallbackAssistant = (
+                response.generationId === undefined
+                || activeRunGenerationIdRef.current === messageId
+            )
+                ? renderedMessagesRef.current[getLatestAssistantMessageIndex(renderedMessagesRef.current)]
+                : undefined;
+            const contentToSave = scopedAssistant?.content || fallbackAssistant?.content || "";
+            try {
+                await rpcClient.getAiPanelRpcClient().updateChatMessage({
                     messageId,
-                    content: contentToSave || "",
-                }).catch((e: unknown) => console.error('[AIChat] Failed to persist chat message:', e));
-                return prev;
-            });
+                    content: contentToSave,
+                    projectRootPath: activeRunScopeRef.current?.projectRootPath,
+                    threadId: activeRunScopeRef.current?.threadId,
+                    clearRunBuffer: !isRecoveryIntermediateWrite,
+                });
+            } catch (error) {
+                console.error("[AIChat] Failed to persist chat message:", error);
+                if (isRecoveryIntermediateWrite) {
+                    throw error;
+                }
+            }
 
         } else if (type === "error") {
             console.log("Received error signal");
@@ -1644,6 +1801,11 @@ const AIChat: React.FC = () => {
             await rpcClient.getAiPanelRpcClient().acceptChanges().catch((e: unknown) => console.warn("[AIChat] auto-accept failed:", e));
             setHasActiveReview(false);
         }
+        const generationId = `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+        activeRunGenerationIdRef.current = generationId;
+        activeRunScopeRef.current = undefined;
+        runEpochRef.current += 1;
+        runAcknowledgedRef.current = false;
         // Clear until onCheckpointCaptured repopulates with the new set
         setAvailableCheckpointIds(new Set());
         rpcClient.getAiPanelRpcClient().clearInitialPrompt();
@@ -1651,14 +1813,12 @@ const AIChat: React.FC = () => {
         setMessages((prevMessages) => prevMessages.filter((message) => message.type !== "question"));
         setIsLoading(true);
         isErrorChunkReceivedRef.current = false;
-        // Reset reconnection safeguards for the new run and arm the polling
-        // fallback. The generationId is server-assigned, so we clear the adopted
-        // run id (accept all events) until a reconnect adopts a specific run.
+        // Reset reconnection safeguards for the explicitly identified new run
+        // and arm the polling fallback.
         if (ENABLE_STREAM_SAFEGUARDS) {
             lastReceivedSeqRef.current = 0;
             lastEventTimeRef.current = Date.now();
             terminalEventReceivedRef.current = false;
-            activeRunGenerationIdRef.current = undefined;
         }
         setBackendRequestTriggered(true);
         setMessages((prevMessages) =>
@@ -1669,8 +1829,8 @@ const AIChat: React.FC = () => {
         const uerMessage = getUserMessage([stringifiedContent, content.attachments]);
         setMessages((prevMessages) => [
             ...prevMessages,
-            { role: "User", content: uerMessage, type: "user_message" },
-            { role: "Copilot", content: "", type: "assistant_message" }, // Add a new message for the assistant
+            { role: "User", content: uerMessage, type: "user_message", messageId: generationId },
+            { role: "Copilot", content: "", type: "assistant_message", messageId: generationId },
         ]);
 
         await handleSendQuery(content);
@@ -1948,9 +2108,10 @@ const AIChat: React.FC = () => {
         const currentHiddenContext = hiddenContextRef.current;
         hiddenContextRef.current = undefined;
         console.log("Submitting agent prompt:", { useCase, agentMode: agentModeRef.current, codeContext: currentCodeContext, operationType, fileAttatchments });
-        rpcClient.getAiPanelRpcClient().generateAgent({
+        await rpcClient.getAiPanelRpcClient().generateAgent({
+            generationId: activeRunGenerationIdRef.current,
             usecase: useCase, hiddenContext: currentHiddenContext, isPlanMode: agentModeRef.current === AgentMode.Plan, codeContext: currentCodeContext, operationType, fileAttachmentContents: fileAttatchments, webSearchEnabled: isWebToolsEnabled
-        })
+        });
     }
 
     async function handleStop() {
@@ -2156,22 +2317,6 @@ const AIChat: React.FC = () => {
                 requestId: approvalRequest.requestId,
                 comment: undefined
             });
-            // Collapse TodoSection into approval summary — mark plan items as approved
-            setMessages(prevMessages => {
-                const msgs = [...prevMessages];
-                const lastIdx = [...msgs].map(m => m.role).lastIndexOf("Copilot");
-                if (lastIdx === -1) return prevMessages;
-                const last = msgs[lastIdx];
-                const entries = parseStream(last.content);
-                const updated = entries.map(entry => ({
-                    ...entry,
-                    items: entry.items.map(item =>
-                        item.kind === "plan" && item.requestId === approvalRequest.requestId ? { ...item, approvalStatus: "approved" as const } : item
-                    )
-                }));
-                msgs[lastIdx] = { ...last, content: serializeStream(updated, last.content) };
-                return msgs;
-            });
         } else if (approvalRequest.approvalType === "completion") {
             const reviewTasks = approvalRequest.tasks.filter(t => t.status === "review");
             const lastReviewTask = reviewTasks[reviewTasks.length - 1];
@@ -2192,22 +2337,6 @@ const AIChat: React.FC = () => {
             await rpcClient.getAiPanelRpcClient().declinePlan({
                 requestId: approvalRequest.requestId,
                 comment
-            });
-            // Collapse TodoSection into revision summary — mark plan items as revised
-            setMessages(prevMessages => {
-                const msgs = [...prevMessages];
-                const lastIdx = [...msgs].map(m => m.role).lastIndexOf("Copilot");
-                if (lastIdx === -1) return prevMessages;
-                const last = msgs[lastIdx];
-                const entries = parseStream(last.content);
-                const updated = entries.map(entry => ({
-                    ...entry,
-                    items: entry.items.map(item =>
-                        item.kind === "plan" && item.requestId === approvalRequest.requestId ? { ...item, approvalStatus: "revised" as const, approvalComment: comment } : item
-                    )
-                }));
-                msgs[lastIdx] = { ...last, content: serializeStream(updated, last.content) };
-                return msgs;
             });
         } else if (approvalRequest.approvalType === "completion") {
             await rpcClient.getAiPanelRpcClient().declineTask({

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -919,8 +919,20 @@ const AIChat: React.FC = () => {
     });
 
     const handleChatNotify = async (response: ChatNotify) => {
-        // Reconnection bookkeeping (runs even for events that get dropped below):
-        // track the seq high-water mark, staleness timestamp, and terminal state.
+        // Drop events belonging to a different (previously-interrupted) run once we
+        // have adopted a specific run on reconnect — BEFORE any bookkeeping. seq is
+        // per-run, so a stale run's event must not advance the adopted run's seq
+        // high-water mark (it would poison sinceSeq polling) or set the terminal
+        // flag (it would stop polling for the still-live adopted run).
+        if (
+            response.generationId &&
+            activeRunGenerationIdRef.current &&
+            response.generationId !== activeRunGenerationIdRef.current
+        ) {
+            return;
+        }
+        // Reconnection bookkeeping: track the seq high-water mark, staleness
+        // timestamp, and terminal state for the accepted event.
         if (ENABLE_STREAM_SAFEGUARDS) {
             if (typeof response.seq === "number" && response.seq > lastReceivedSeqRef.current) {
                 lastReceivedSeqRef.current = response.seq;
@@ -929,15 +941,6 @@ const AIChat: React.FC = () => {
             if (response.type === "stop" || response.type === "abort" || response.type === "error") {
                 terminalEventReceivedRef.current = true;
             }
-        }
-        // Drop events belonging to a different (previously-interrupted) run once
-        // we have adopted a specific run on reconnect.
-        if (
-            response.generationId &&
-            activeRunGenerationIdRef.current &&
-            response.generationId !== activeRunGenerationIdRef.current
-        ) {
-            return;
         }
 
         const type = response.type;
@@ -1337,10 +1340,10 @@ const AIChat: React.FC = () => {
             setMessages((prev) => {
                 const assistantIndex = getLatestAssistantMessageIndex(prev);
                 const contentToSave = assistantIndex >= 0 ? prev[assistantIndex]?.content : prev[prev.length - 1]?.content;
-                void rpcClient.getAiPanelRpcClient().updateChatMessage({
+                rpcClient.getAiPanelRpcClient().updateChatMessage({
                     messageId,
                     content: contentToSave || "",
-                });
+                }).catch((e: unknown) => console.error('[AIChat] Failed to persist chat message:', e));
                 return prev;
             });
 

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -193,6 +193,17 @@ function appendToLastEntry(entries: StreamEntry[], item: StreamItem): StreamEntr
     return [...entries.slice(0, -1), { ...last, items: [...last.items, item] }];
 }
 
+// Interactive-prompt event types skipped while replaying buffered events on reopen (their live
+// interaction is already resolved/cancelled; only the passive transcript should be rebuilt).
+// A prompt whose requestId is still pending in the backend IS re-surfaced so it can be answered.
+const REPLAY_SKIP_EVENT_TYPES = new Set<string>([
+    "task_approval_request",
+    "web_tool_approval_request",
+    "configuration_collection_event",
+    "clarify_event",
+    "skill_enable_event",
+]);
+
 const SCAFFOLD_DONE_PREFIX = "ballerina.scaffold.done:";
 
 // Stable, non-crypto hash for keying scaffold runs by (prompt + steps).
@@ -219,15 +230,30 @@ const AIChat: React.FC = () => {
         return -1;
     };
 
+    const getLatestUserMessageIndex = (chatMessages: Array<{ role: string }>): number => {
+        for (let i = chatMessages.length - 1; i >= 0; i--) {
+            const role = chatMessages[i]?.role;
+            if (role === "User" || role === "user") {
+                return i;
+            }
+        }
+        return -1;
+    };
+
     const ensureAssistantMessage = (
         chatMessages: Array<{ role: string; content: string; type: string; checkpointId?: string; messageId?: string }>
     ): number => {
-        let targetIndex = getLatestAssistantMessageIndex(chatMessages);
-        if (targetIndex === -1) {
-            chatMessages.push({ role: "Copilot", content: "", type: "assistant_message" });
-            targetIndex = chatMessages.length - 1;
+        const targetIndex = getLatestAssistantMessageIndex(chatMessages);
+        // Reuse the trailing assistant bubble only if it belongs to the CURRENT turn — i.e. it
+        // comes after the most recent user message. Otherwise (a newer user prompt exists, or there
+        // is no assistant yet) start a fresh bubble so streamed content lands under the right turn.
+        // Without this, replaying a follow-up turn's events on reopen merges them into the previous
+        // turn's bubble and the follow-up prompt is pushed below its own response.
+        if (targetIndex !== -1 && targetIndex > getLatestUserMessageIndex(chatMessages)) {
+            return targetIndex;
         }
-        return targetIndex;
+        chatMessages.push({ role: "Copilot", content: "", type: "assistant_message" });
+        return chatMessages.length - 1;
     };
 
     const updateLastMessage = (updater: (content: string) => string) => {
@@ -335,8 +361,28 @@ const AIChat: React.FC = () => {
     const terminalEventReceivedRef = useRef<boolean>(false); // stop/abort/error seen
     const pollInFlightRef = useRef<boolean>(false);        // prevents overlapping polls
     const activeRunGenerationIdRef = useRef<string | undefined>(undefined); // drop stale-run events
-    const handleChatNotifyRef = useRef<(response: ChatNotify) => void>(() => {});
+    const handleChatNotifyRef = useRef<(response: ChatNotify) => void | Promise<void>>(() => {});
     const [backendRequestTriggered, setBackendRequestTriggered] = useState(false);
+    // True while replaying buffered events on reopen — lets the notify handler skip
+    // interactive prompts that were already resolved earlier in the run.
+    const replayingRef = useRef(false);
+    // Always-fresh mirror of `messages`, used to read the rebuilt transcript after a replay
+    // (the notify handler's own closure would be stale inside an async replay loop).
+    const latestMessagesRef = useRef<typeof messages>([]);
+    useEffect(() => { latestMessagesRef.current = messages; }, [messages]);
+    // Ensures the reconnect/replay runs at most once for this panel mount
+    // (guards StrictMode double-effects and rpcClient identity churn).
+    const didReconnectRef = useRef(false);
+    // Request ids of interactive prompts still awaiting a response, captured at reconnect.
+    // During replay, a buffered prompt is re-shown only if its id is in here (still pending).
+    const pendingRequestIdsRef = useRef<Set<string>>(new Set());
+    // Live-event gate. The onChatNotify subscription is active from the first render, but
+    // reconnect (history load + buffer replay) happens later and asynchronously. While the gate
+    // is CLOSED, incoming live events are queued instead of processed, so they can't interleave
+    // with the replay. The reconnect effect drains the queue in order (seq-deduped against the
+    // replay's high-water mark) and opens the gate once replay is done.
+    const liveGateClosedRef = useRef(true);
+    const liveQueueRef = useRef<ChatNotify[]>([]);
 
     const messagesEndRef = React.useRef<HTMLDivElement>(null);
 
@@ -637,14 +683,27 @@ const AIChat: React.FC = () => {
      * the final transcript the closed panel never round-tripped. No-op when
      * there is nothing to replay.
      */
-    const reconnectToActiveRun = async () => {
+    const reconnectToActiveRun = async (historyMessages: ReturnType<typeof convertToUIMessages>) => {
         try {
             const runStatus = await rpcClient.getAiPanelRpcClient().getRunStatus({});
-            if (runStatus.events.length === 0) {
+            // Prompts still awaiting an answer — used by the replay skip guard to
+            // re-show only still-pending interactive prompts.
+            pendingRequestIdsRef.current = new Set(runStatus.pendingRequestIds ?? []);
+
+            const generationId = runStatus.generationId
+                ?? runStatus.events.find(e => !!e.generationId)?.generationId;
+            // The persisted transcript already covers a finished turn once its
+            // uiResponse is saved (belt-and-braces on top of the backend clearing
+            // the buffer at that point). Only replay when a run is genuinely live,
+            // or when the last turn's transcript is missing (finished while closed).
+            const assistantAlreadyLoaded = !!generationId &&
+                historyMessages.some((m) => m.role === "Copilot" && m.messageId === generationId);
+            if (runStatus.events.length === 0 || (!runStatus.isRunning && assistantAlreadyLoaded)) {
                 return;
             }
+
             // Adopt this run so any stray events from a prior run are dropped.
-            activeRunGenerationIdRef.current = runStatus.events.find(e => !!e.generationId)?.generationId;
+            activeRunGenerationIdRef.current = generationId;
             if (ENABLE_STREAM_SAFEGUARDS) {
                 lastReceivedSeqRef.current = 0;
                 lastEventTimeRef.current = Date.now();
@@ -653,21 +712,40 @@ const AIChat: React.FC = () => {
             if (runStatus.isPlanMode !== undefined) {
                 setAgentMode(runStatus.isPlanMode ? AgentMode.Plan : AgentMode.Edit);
             }
-            // Rebuild the turn cleanly onto a fresh assistant message: drop any
-            // partial assistant message persisted mid-run (stale uiResponse), then
-            // append an empty one so the replay never lands on a previous turn's
-            // assistant message (ensureAssistantMessage targets the latest one).
-            setMessages(prev => {
-                const idx = getLatestAssistantMessageIndex(prev);
-                const base = idx >= 0 && idx === prev.length - 1 ? prev.slice(0, -1) : prev;
-                return [...base, { role: "Copilot", content: "", type: "assistant_message" }];
-            });
+            // Drop any assistant bubble already loaded for this generation (stale
+            // partial uiResponse) — the replay rebuilds the full turn from scratch,
+            // and turn-aware ensureAssistantMessage starts a fresh bubble for it.
+            setMessages(prev => prev.filter(
+                (m) => !(m.type === "assistant_message" && m.messageId === generationId)
+            ));
             if (runStatus.isRunning) {
                 setIsLoading(true);
                 setBackendRequestTriggered(true);
             }
-            for (const ev of runStatus.events) {
-                handleChatNotifyRef.current(ev);
+            replayingRef.current = true;
+            try {
+                for (const ev of runStatus.events) {
+                    await handleChatNotifyRef.current(ev);
+                }
+            } finally {
+                replayingRef.current = false;
+            }
+            if (!runStatus.isRunning && generationId) {
+                // Finished while the panel was closed. Persist the rebuilt transcript
+                // once (after React commits the replayed messages) so it's durable,
+                // the backend drops the buffer, and later reopens serve from history.
+                // (The replayed save_chat usually does this already; this covers
+                // buffers whose run ended without one, e.g. an error turn.)
+                setTimeout(() => {
+                    const msgs = latestMessagesRef.current;
+                    const idx = getLatestAssistantMessageIndex(msgs);
+                    const content = idx >= 0 ? msgs[idx]?.content : "";
+                    if (content) {
+                        rpcClient.getAiPanelRpcClient()
+                            .updateChatMessage({ messageId: generationId, content })
+                            .catch((e) => console.error('[AIChat] Failed to persist recovered transcript:', e));
+                    }
+                }, 0);
             }
         } catch (error) {
             console.error('[AIChat] Failed to restore in-flight run status:', error);
@@ -679,32 +757,63 @@ const AIChat: React.FC = () => {
      */
     useEffect(function loadInitialChatHistory() {
         const loadHistory = async () => {
-            try {
-                const historyMessages = await rpcClient.getAiPanelRpcClient().getChatMessages();
-                if (historyMessages && historyMessages.length > 0) {
-                    const uiMessages = convertToUIMessages(historyMessages);
-                    setMessages((prevMessages) => (prevMessages.length > 0 ? prevMessages : uiMessages));
-                }
-            } catch (error) {
-                console.error('[AIChat] Failed to load initial chat history:', error);
-                // Continue with empty messages - don't block the UI
+            // Duplicate/concurrent mount (React StrictMode, or an rpcClient identity
+            // change): the primary run owns history load, gate and replay. Bail so we
+            // never replay twice or double-open the gate.
+            if (didReconnectRef.current) {
+                return;
             }
-            // Re-derive the review flag: it is otherwise only set by the live stream
-            // event, so a webview reload would leave a pending review inactive
-            // (ReviewBar unclickable, auto-accept-on-send skipped).
-            try {
-                const pending = await rpcClient.getAiPanelRpcClient().hasPendingReview();
-                if (pending) {
-                    setHasActiveReview(true);
-                }
-            } catch (error) {
-                console.error('[AIChat] Failed to check pending review state:', error);
-            }
+            didReconnectRef.current = true;
 
-            // Reconnect to an in-flight run: the run keeps executing on the
-            // extension host while the panel is closed, buffering the events we
-            // missed. Replay them so the reopened panel shows live progress.
-            await reconnectToActiveRun();
+            try {
+                let uiMessages: ReturnType<typeof convertToUIMessages> = [];
+                try {
+                    const historyMessages = await rpcClient.getAiPanelRpcClient().getChatMessages();
+                    if (historyMessages && historyMessages.length > 0) {
+                        uiMessages = convertToUIMessages(historyMessages);
+                        setMessages((prevMessages) => (prevMessages.length > 0 ? prevMessages : uiMessages));
+                    }
+                } catch (error) {
+                    console.error('[AIChat] Failed to load initial chat history:', error);
+                    // Continue with empty messages - don't block the UI
+                }
+                // Re-derive the review flag: it is otherwise only set by the live stream
+                // event, so a webview reload would leave a pending review inactive
+                // (ReviewBar unclickable, auto-accept-on-send skipped).
+                try {
+                    const pending = await rpcClient.getAiPanelRpcClient().hasPendingReview();
+                    if (pending) {
+                        setHasActiveReview(true);
+                    }
+                } catch (error) {
+                    console.error('[AIChat] Failed to check pending review state:', error);
+                }
+
+                // Reconnect to an in-flight run: the run keeps executing on the
+                // extension host while the panel is closed, buffering the events we
+                // missed. Replay them so the reopened panel shows live progress.
+                await reconnectToActiveRun(uiMessages);
+            } finally {
+                // Open the gate: replay is done (or was skipped). Drain live events
+                // that arrived meanwhile, in order, deduped against the replay's seq
+                // high-water mark; then resume direct dispatch. Events arriving during
+                // the drain re-queue and are picked up by the loop, so opening the
+                // gate right after the loop (synchronously) can't drop anything.
+                const q = liveQueueRef.current;
+                while (q.length > 0) {
+                    const ev = q.shift();
+                    if (!ev) { continue; }
+                    if (typeof ev.seq === "number" && ev.seq <= lastReceivedSeqRef.current) {
+                        continue; // already applied by the replay
+                    }
+                    try {
+                        await handleChatNotifyRef.current(ev);
+                    } catch (e) {
+                        console.error('[AIChat] live drain failed:', e);
+                    }
+                }
+                liveGateClosedRef.current = false;
+            }
         };
 
         loadHistory();
@@ -740,6 +849,14 @@ const AIChat: React.FC = () => {
                     handleChatNotifyRef.current(ev);
                 }
                 if (!runStatus.isRunning && runStatus.events.length === 0 && !terminalEventReceivedRef.current) {
+                    // Watchdog: the run is genuinely gone but its terminal event never
+                    // reached us (and there's nothing left to replay) — release the
+                    // spinner instead of stranding it. The transcript on screen is
+                    // whatever streamed/replayed; only the loading state is stuck.
+                    console.warn('[AIChat] Polling watchdog clearing a stuck spinner (missed terminal signal).');
+                    setIsLoading(false);
+                    setIsCodeLoading(false);
+                    setIsCompacting(false);
                     setBackendRequestTriggered(false);
                 }
             } catch {
@@ -824,6 +941,20 @@ const AIChat: React.FC = () => {
         }
 
         const type = response.type;
+
+        // When replaying buffered events on reopen, an interactive prompt is only re-shown
+        // if it's still awaiting a response (its requestId is pending in the backend).
+        // Prompts resolved earlier in the run are skipped so their banner doesn't reappear —
+        // the transcript around them is still rebuilt from their tool_call/tool_result/text
+        // events. A pending prompt is re-surfaced so the user can answer it (the backend
+        // keeps it alive across panel close).
+        if (replayingRef.current && REPLAY_SKIP_EVENT_TYPES.has(type)) {
+            const reqId = (response as any).requestId;
+            if (!reqId || !pendingRequestIdsRef.current.has(reqId)) {
+                return;
+            }
+            // still pending → fall through and render the live prompt
+        }
 
         if (type === "content_block") {
             const content = response.content;
@@ -1271,7 +1402,17 @@ const AIChat: React.FC = () => {
     // render so `messages`-reading branches stay current), and expose the
     // latest handler via a ref for the reconnect/poll replay paths.
     handleChatNotifyRef.current = handleChatNotify;
-    rpcClient?.onChatNotify(handleChatNotify);
+    // Live subscription. While the reconnect gate is closed (mount → replay done),
+    // queue events so they can't interleave with the async replay; the reconnect
+    // effect drains them in order (seq-deduped) and opens the gate.
+    const onLiveChatNotify = (response: ChatNotify) => {
+        if (liveGateClosedRef.current) {
+            liveQueueRef.current.push(response);
+            return;
+        }
+        return handleChatNotify(response);
+    };
+    rpcClient?.onChatNotify(onLiveChatNotify);
 
     function generateNaturalProgrammingTemplate(isReqFileExists: boolean) {
         if (isReqFileExists) {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -52,7 +52,8 @@ import { StreamEntry, StreamItem } from "../AgentStreamView/types";
 import { ConnectorGeneratorSegment } from "../ConnectorGeneratorSegment";
 import { ConfigurationCollectorSegment, ConfigurationCollectionData } from "../ConfigurationCollectorSegment";
 import CheckpointSeparator from "../CheckpointSeparator";
-import { Attachment, AttachmentStatus, SkillEntry, TaskApprovalRequest } from "@wso2/ballerina-core";
+import { Attachment, AttachmentStatus, SkillEnableStage, SkillEntry, TaskApprovalRequest } from "@wso2/ballerina-core";
+import type { ClarifyEvent, ConfigurationCollectionEvent, ConnectorGenerationNotification } from "@wso2/ballerina-core";
 
 import { AIChatView, Header, HeaderButtons, ChatMessage, TurnGroup, AuthProviderChip, UsageBadge, ApprovalOverlay, OverlayMessage, OverlayCloseButton } from "../../styles";
 import { SessionHistoryDropdown } from "../SessionHistory";
@@ -193,16 +194,20 @@ function appendToLastEntry(entries: StreamEntry[], item: StreamItem): StreamEntr
     return [...entries.slice(0, -1), { ...last, items: [...last.items, item] }];
 }
 
-// Interactive-prompt event types skipped while replaying buffered events on reopen (their live
-// interaction is already resolved/cancelled; only the passive transcript should be rebuilt).
-// A prompt whose requestId is still pending in the backend IS re-surfaced so it can be answered.
-const REPLAY_SKIP_EVENT_TYPES = new Set<string>([
-    "task_approval_request",
-    "web_tool_approval_request",
-    "configuration_collection_event",
-    "clarify_event",
-    "skill_enable_event",
-]);
+// Interactive-prompt events need care while replaying buffered events on reopen: their
+// transcript cards must be rebuilt (they are part of the turn), but a "waiting for user"
+// state may only be re-surfaced when the backend still has the request pending (in-chat
+// prompts survive panel close and stay answerable). For card-driven prompts — whose waiting
+// UI derives from the card's `stage` — the pending-stage event of an already-resolved
+// request is dropped; its resolution event later in the buffer rebuilds the card in its
+// final state. Banner-driven prompts (task/web-tool approval) are handled inside their
+// branches instead: transcript items are always rebuilt, only the banner is suppressed.
+const REPLAY_PENDING_STAGES: Record<string, string> = {
+    clarify_event: "asking" satisfies ClarifyEvent["stage"],
+    skill_enable_event: SkillEnableStage.PROMPTING,
+    configuration_collection_event: "collecting" satisfies ConfigurationCollectionEvent["stage"],
+    connector_generation_notification: "requesting_input" satisfies ConnectorGenerationNotification["stage"],
+};
 
 const SCAFFOLD_DONE_PREFIX = "ballerina.scaffold.done:";
 
@@ -692,40 +697,64 @@ const AIChat: React.FC = () => {
 
             const generationId = runStatus.generationId
                 ?? runStatus.events.find(e => !!e.generationId)?.generationId;
-            // The persisted transcript already covers a finished turn once its
-            // uiResponse is saved (belt-and-braces on top of the backend clearing
-            // the buffer at that point). Only replay when a run is genuinely live,
-            // or when the last turn's transcript is missing (finished while closed).
+            // A buffer only exists while the turn's FINAL transcript is not yet persisted
+            // (per-step save_chat writes partial uiResponses mid-run, so a history bubble
+            // for this generation does NOT imply completeness) — whenever one exists,
+            // rebuild the turn from it; the persist that follows clears it, so this
+            // converges. Exception: a truncated (overflowed) buffer can't rebuild the
+            // whole turn, so prefer a persisted partial when one exists. A live run always
+            // proceeds, even with an empty buffer, to arm the spinner and polling fallback.
             const assistantAlreadyLoaded = !!generationId &&
                 historyMessages.some((m) => m.role === "Copilot" && m.messageId === generationId);
-            if (runStatus.events.length === 0 || (!runStatus.isRunning && assistantAlreadyLoaded)) {
+            if (!runStatus.isRunning &&
+                (runStatus.events.length === 0 || (runStatus.truncated && assistantAlreadyLoaded))) {
                 return;
             }
+            // Truncated buffer on a LIVE run with a persisted partial: the partial covers
+            // the turn's beginning, which the buffer has already evicted — keep it, skip
+            // the replay, and fast-forward the seq watermark past the buffered events so
+            // only newer live/polled events append after it.
+            const keepPartialSkipReplay = runStatus.isRunning && runStatus.truncated && assistantAlreadyLoaded;
 
             // Adopt this run so any stray events from a prior run are dropped.
             activeRunGenerationIdRef.current = generationId;
             if (ENABLE_STREAM_SAFEGUARDS) {
-                lastReceivedSeqRef.current = 0;
+                lastReceivedSeqRef.current = keepPartialSkipReplay
+                    ? (runStatus.events[runStatus.events.length - 1]?.seq ?? 0)
+                    : 0;
                 lastEventTimeRef.current = Date.now();
                 terminalEventReceivedRef.current = false;
             }
             if (runStatus.isPlanMode !== undefined) {
                 setAgentMode(runStatus.isPlanMode ? AgentMode.Plan : AgentMode.Edit);
             }
-            // Drop any assistant bubble already loaded for this generation (stale
-            // partial uiResponse) — the replay rebuilds the full turn from scratch,
-            // and turn-aware ensureAssistantMessage starts a fresh bubble for it.
-            setMessages(prev => prev.filter(
-                (m) => !(m.type === "assistant_message" && m.messageId === generationId)
-            ));
+            if (!keepPartialSkipReplay) {
+                // Drop any assistant bubble already loaded for this generation (stale
+                // partial uiResponse) — the replay rebuilds the full turn from scratch,
+                // and turn-aware ensureAssistantMessage starts a fresh bubble for it.
+                setMessages(prev => prev.filter(
+                    (m) => !(m.type === "assistant_message" && m.messageId === generationId)
+                ));
+            }
             if (runStatus.isRunning) {
                 setIsLoading(true);
                 setBackendRequestTriggered(true);
             }
             replayingRef.current = true;
             try {
-                for (const ev of runStatus.events) {
-                    await handleChatNotifyRef.current(ev);
+                if (!keepPartialSkipReplay) {
+                    for (const ev of runStatus.events) {
+                        await handleChatNotifyRef.current(ev);
+                    }
+                } else {
+                    // The run may be blocked on a prompt whose event is in the skipped
+                    // buffer — re-surface still-pending prompts so it stays answerable.
+                    for (const ev of runStatus.events) {
+                        const reqId = (ev as any).requestId;
+                        if (reqId && pendingRequestIdsRef.current.has(reqId)) {
+                            await handleChatNotifyRef.current(ev);
+                        }
+                    }
                 }
             } finally {
                 replayingRef.current = false;
@@ -945,18 +974,21 @@ const AIChat: React.FC = () => {
 
         const type = response.type;
 
-        // When replaying buffered events on reopen, an interactive prompt is only re-shown
-        // if it's still awaiting a response (its requestId is pending in the backend).
-        // Prompts resolved earlier in the run are skipped so their banner doesn't reappear —
-        // the transcript around them is still rebuilt from their tool_call/tool_result/text
-        // events. A pending prompt is re-surfaced so the user can answer it (the backend
-        // keeps it alive across panel close).
-        if (replayingRef.current && REPLAY_SKIP_EVENT_TYPES.has(type)) {
-            const reqId = (response as any).requestId;
-            if (!reqId || !pendingRequestIdsRef.current.has(reqId)) {
-                return;
-            }
-            // still pending → fall through and render the live prompt
+        // True only while replaying a buffered event whose request the backend no longer has
+        // pending — its live interaction was already resolved and must not be re-surfaced.
+        // A still-pending prompt falls through and renders live (answerable after reopen).
+        const isResolvedReplayedPrompt = (reqId?: string) =>
+            replayingRef.current && (!reqId || !pendingRequestIdsRef.current.has(reqId));
+
+        // Card-driven prompts: drop the pending-stage event of an already-resolved request;
+        // its resolution event later in the buffer rebuilds the card in its final state.
+        const pendingStage = REPLAY_PENDING_STAGES[type];
+        if (
+            pendingStage &&
+            (response as any).stage === pendingStage &&
+            isResolvedReplayedPrompt((response as any).requestId)
+        ) {
+            return;
         }
 
         if (type === "content_block") {
@@ -1071,6 +1103,12 @@ const AIChat: React.FC = () => {
                 });
             }
 
+            // Replayed, already-resolved approval: the plan transcript item above is still
+            // rebuilt; only the interactive banner / auto-approve side effects are skipped.
+            if (isResolvedReplayedPrompt(response.requestId)) {
+                return;
+            }
+
             // Skip approval UI when auto-approved from backend (scaffold mode)
             if (response.autoApproved) {
                 return;
@@ -1091,6 +1129,10 @@ const AIChat: React.FC = () => {
             });
 
         } else if (type === "web_tool_approval_request") {
+            // Banner-only event (no transcript item) — nothing to rebuild for a resolved one.
+            if (isResolvedReplayedPrompt(response.requestId)) {
+                return;
+            }
             setWebToolApprovalRequest({
                 requestId: response.requestId,
                 toolName: response.toolName,

--- a/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
+++ b/packages/ballerina-visualizer/src/views/ReviewMode/ReadonlyFlowDiagram.tsx
@@ -301,8 +301,12 @@ export function ReadonlyFlowDiagram(props: ReadonlyFlowDiagramProps): JSX.Elemen
             return null;
         }
         if (!metadataMatchesExpected(newFlow, expectedMetadata)) {
+            // The new version resolved to a different function than the diff recorded —
+            // rendering it would show the wrong function. Return null to match the
+            // "new" branch's verdict for the same flow, so the fallback re-render
+            // shows the unavailable message instead of flashing the wrong diagram.
             onDiffUnavailableRef.current?.();
-            return newFlow;
+            return null;
         }
         if (!oldFlow || !isSameExpectedFunction(oldFlow, newFlow, expectedMetadata)) {
             onDiffUnavailableRef.current?.();


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1862

The agent run already executes independently of the webview (it is tracked by the `chatStateStorage` singleton, not the panel), so it keeps running when the Copilot panel is closed. But all `ChatNotify` events were pushed fire-and-forget and silently dropped while no panel was registered, and a remounting panel had no way to re-attach to an in-flight run. So on reopen the user saw a blank/partial reply with no indication a generation was (or had been) running.

This ports MI Copilot's panel-reconnection design (`AgentEventHandler` + `getAgentRunStatus` + polling fallback) to the BI Copilot.

## Approach

**Backend**
- New `RunEventStore` singleton (`features/ai/utils/run-event-store.ts`) buffers every emitted `ChatNotify` per `(projectRootPath, threadId)`, stamped with a monotonic `seq` + `generationId` at the single send chokepoint (`sendAIPanelNotification`). Bounded: 5000 events/run, 20 retained runs. The 3 `compaction_*` events that previously bypassed the chokepoint are now routed through it.
- Run lifecycle (`beginRun`/`endRun`) is wired into `AICommandExecutor.run()`, gated by a `trackForReconnection` flag so only agent-chat runs are buffered (migration/data-mapper runs sharing the base class are unaffected).
- New `ai-panel` RPC `getRunStatus({ threadId?, sinceSeq? }) → { isRunning, events, isPlanMode }`. Without `sinceSeq` it returns the full current-run buffer; with `sinceSeq` it returns only newer events (polling dedup). Plan mode is resolved from the active generation's persisted metadata.
- **Finished-while-closed**: a terminal event (`stop`/`abort`/`error`) emitted with no panel open marks the run `finishedUnseen`; the next initial `getRunStatus` serves the buffer exactly once so the reopened panel can rebuild the turn it never saw — replaying `save_chat` also persists the final `uiResponse` that the closed panel never round-tripped (self-healing the stored transcript).
- `AiPanelWebview.dispose()` now keeps pending approvals alive while a run is active, so closing the panel no longer derails a run paused on a plan/task/clarify approval gate.

**Frontend (`AIChat`)**
- The `onChatNotify` handler tracks the `seq` high-water mark, staleness timestamp, and terminal events, and drops stale-run events by `generationId`.
- `reconnectToActiveRun()` on mount replays buffered events onto a fresh assistant message (covers both live re-attach and finished-while-closed; also fixes replay landing on a previous turn's assistant message when the in-flight turn had no persisted assistant entry).
- Polling fallback (5s stale threshold / 3s interval, in-flight guard) fetches missed events via `sinceSeq` until a terminal event or run end.

**Shared types**
- `ChatNotifyMeta { seq?; generationId? }` intersected onto the `ChatNotify` union (optional fields — existing emitters/consumers unaffected).

## Known limitations

- The event buffer is in-memory: it survives panel close/reopen but not an extension-host restart (after a window reload, an unfinished turn's transcript is lost even though its code changes/review integrated server-side).
- Single-thread scope (`threadId = 'default'`), matching all current call sites.

## Testing

- `rush build` clean for `@wso2/ballerina-core`, `@wso2/ballerina-rpc-client`, `@wso2/ballerina-visualizer`, and the `ballerina` extension.
- Manual (F5): close/reopen mid-generation → in-flight turn (tool calls + streamed text) is rebuilt and streaming continues; close, let the run finish, reopen → the completed turn renders and is persisted (a further close/reopen shows it from history with no duplication); a normal run with the panel kept open is unchanged.