### PR TITLE
Add tree view for visualizing multi-agent flows in trace-visualizer

### DIFF
--- a/packages/trace-visualizer/src/TraceDetails.tsx
+++ b/packages/trace-visualizer/src/TraceDetails.tsx
@@ -26,10 +26,12 @@ import { TraceEmptyState } from "./components/TraceEmptyState";
 import { SpanTree, AISpanTreeContainer } from "./components/SpanTree";
 import { SearchInput } from "./components/SearchInput";
 import { ExportDropdown } from "./components/ExportDropdown";
+import { AgentFlow } from "./components/AgentFlow";
 import {
     timeContainsSpan,
     sortSpansByUmbrellaFirst,
-    isAISpan
+    isAISpan,
+    getAttributeValue
 } from "./utils";
 
 // ============================================================================
@@ -251,6 +253,32 @@ const ActionButton = styled.button`
     }
 `;
 
+const AgentFlowEntryButton = styled.button`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: 8px;
+    padding: 8px 12px;
+    background-color: transparent;
+    border: 1px solid var(--vscode-focusBorder);
+    border-radius: 6px;
+    color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--vscode-font-family);
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+        background-color: var(--vscode-list-hoverBackground);
+    }
+
+    &:active {
+        transform: scale(0.99);
+    }
+`;
+
 // ============================================================================
 // COMPONENT DEFINITIONS
 // ============================================================================
@@ -262,7 +290,8 @@ export function TraceDetails({ traceData, isAgentChat, focusSpanId, onViewSessio
     // Rename state to capture user preference specifically
     const [userAdvancedModePreference, setUserAdvancedModePreference] = useState<boolean>(false);
 
-    const [viewMode, setViewMode] = useState<'tree' | 'timeline'>('tree');
+    const [viewMode, setViewMode] = useState<'tree' | 'timeline' | 'agents'>('tree');
+    const [preAgentMode, setPreAgentMode] = useState<'tree' | 'timeline'>('tree');
     const [isSidebarVisible, setIsSidebarVisible] = useState<boolean>(
         showSidebar !== undefined ? showSidebar : !(isAgentChat && focusSpanId !== undefined)
     );
@@ -298,6 +327,14 @@ export function TraceDetails({ traceData, isAgentChat, focusSpanId, onViewSessio
     //   - If there ARE AI spans, use the user's preference
     const hasAISpans = totalSpanCounts.aiCount > 0;
     const isAdvancedMode = !isAgentChat || !hasAISpans || userAdvancedModePreference;
+
+    // Show the Agents mode when the trace has at least two agent invocations.
+    const hasMultiAgent = useMemo(() => {
+        const invokeCount = traceData.spans.filter(span =>
+            (getAttributeValue(span.attributes, 'gen_ai.operation.name') || '').startsWith('invoke_agent')
+        ).length;
+        return invokeCount >= 2;
+    }, [traceData.spans]);
 
     // Helper to get immediate AI children of a span (defined early for reuse)
     const getAIChildSpans = (spanId: string): SpanData[] => {
@@ -501,6 +538,13 @@ export function TraceDetails({ traceData, isAgentChat, focusSpanId, onViewSessio
             resizeObserver.disconnect();
         };
     }, [spanViewWidth, isSidebarVisible]);
+
+    // Fall back to Tree if Agents mode is active but the trace isn't multi-agent.
+    useEffect(() => {
+        if (viewMode === 'agents' && !hasMultiAgent) {
+            setViewMode('tree');
+        }
+    }, [viewMode, hasMultiAgent]);
 
     const toggleSpanExpansion = (spanId: string) => {
         const newExpanded = new Set(expandedSpans);
@@ -861,6 +905,23 @@ export function TraceDetails({ traceData, isAgentChat, focusSpanId, onViewSessio
         // isAdvancedMode is now a calculated value based on content + user preference
         const shouldShowAdvancedView = isAdvancedMode;
 
+        // Agents mode: dedicated multi-agent flow canvas + shared inspector.
+        if (viewMode === 'agents' && hasMultiAgent) {
+            return (
+                <AgentFlow
+                    traceData={traceData}
+                    selectedSpanId={selectedSpanId}
+                    onSelectSpan={selectSpan}
+                    totalInputTokens={totalInputTokens}
+                    totalOutputTokens={totalOutputTokens}
+                    showInternalSpans={userAdvancedModePreference}
+                    onClose={() => setViewMode(preAgentMode)}
+                    onExportJson={handleExportTrace}
+                    onExportEvalset={handleExportAsEvalset}
+                />
+            );
+        }
+
         return (
             <TraceLogsContainer>
                 <SpanViewContainer width={isSidebarVisible ? spanViewWidth : 48} isResizing={isResizing} onMouseDown={isSidebarVisible ? handleMouseDown : undefined}>
@@ -925,6 +986,23 @@ export function TraceDetails({ traceData, isAgentChat, focusSpanId, onViewSessio
                                     />
                                 </ActionButton>
                             </SearchInputWrapper>
+
+                            {hasMultiAgent && (
+                                <AgentFlowEntryButton
+                                    onClick={() => {
+                                        setPreAgentMode(viewMode === 'timeline' ? 'timeline' : 'tree');
+                                        setViewMode('agents');
+                                    }}
+                                    title="Visualize how agents delegate work across this trace"
+                                >
+                                    <Icon
+                                        name="bi-ai-agent"
+                                        sx={{ fontSize: '16px', width: '16px', height: '16px' }}
+                                        iconSx={{ fontSize: '16px' }}
+                                    />
+                                    View Agent Flow
+                                </AgentFlowEntryButton>
+                            )}
 
                             {viewMode === 'tree' && (
                                 <AISpanTreeContainer>

--- a/packages/trace-visualizer/src/TraceDetails.tsx
+++ b/packages/trace-visualizer/src/TraceDetails.tsx
@@ -914,7 +914,7 @@ export function TraceDetails({ traceData, isAgentChat, focusSpanId, onViewSessio
                     onSelectSpan={selectSpan}
                     totalInputTokens={totalInputTokens}
                     totalOutputTokens={totalOutputTokens}
-                    showInternalSpans={userAdvancedModePreference}
+                    showInternalSpans={shouldShowAdvancedView}
                     onClose={() => setViewMode(preAgentMode)}
                     onExportJson={handleExportTrace}
                     onExportEvalset={handleExportAsEvalset}

--- a/packages/trace-visualizer/src/components/AgentFlow.tsx
+++ b/packages/trace-visualizer/src/components/AgentFlow.tsx
@@ -1,0 +1,661 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import styled from "@emotion/styled";
+import { Icon, ThemeColors } from "@wso2/ui-toolkit";
+import { TraceData } from "../index";
+import { SpanDetails } from "./SpanDetails";
+import { SearchInput } from "./SearchInput";
+import { ExportDropdown } from "./ExportDropdown";
+import { AgentRun, buildAgentFlowModel } from "./agentflow/model";
+import { GraphView, GraphViewHandle } from "./agentflow/GraphView";
+
+interface AgentFlowProps {
+    traceData: TraceData;
+    selectedSpanId: string | null;
+    onSelectSpan: (spanId: string) => void;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    showInternalSpans: boolean;
+    onClose: () => void;
+    onExportJson: () => void;
+    onExportEvalset: () => void;
+}
+
+const PANEL_DEFAULT_W = 600;
+const PANEL_MIN_W = 360;
+const PANEL_MAX_W = 900;
+const REPLAY_STEP_MS = 1500;
+const REPLAY_CYAN = "var(--vscode-terminal-ansiCyan)";
+
+const Root = styled.div`
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    background-color: ${ThemeColors.SURFACE_BRIGHT};
+`;
+
+const Toolbar = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 12px 16px;
+    border-bottom: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    flex-shrink: 0;
+`;
+
+const SideGroup = styled.div<{ align: "left" | "right" }>`
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+    justify-content: ${(p: { align: "left" | "right" }) => (p.align === "right" ? "flex-end" : "flex-start")};
+`;
+
+const BackButton = styled.button`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 11px;
+    background: transparent;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-radius: 5px;
+    color: ${ThemeColors.ON_SURFACE};
+    cursor: pointer;
+    font-size: 13px;
+    font-family: var(--vscode-font-family);
+    flex-shrink: 0;
+
+    &:hover {
+        background-color: ${ThemeColors.SURFACE_CONTAINER};
+        border-color: ${ThemeColors.PRIMARY};
+    }
+`;
+
+const Title = styled.span`
+    font-size: 15px;
+    font-weight: 600;
+    color: ${ThemeColors.ON_SURFACE};
+    flex-shrink: 0;
+`;
+
+const SearchWrap = styled.div`
+    width: 260px;
+    flex-shrink: 1;
+    min-width: 120px;
+`;
+
+// Floating playback dock over the canvas (top-left), keeps the toolbar uncluttered.
+const ReplayDock = styled.div`
+    position: absolute;
+    top: 14px;
+    left: 14px;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+`;
+
+// Shared compact button for Replay / Call order (opaque so it reads over the canvas).
+const ToolButton = styled.button<{ active?: boolean }>`
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    height: 30px;
+    padding: 0 12px;
+    flex-shrink: 0;
+    border: 1px solid ${(p: { active?: boolean }) => (p.active ? ThemeColors.PRIMARY : ThemeColors.OUTLINE_VARIANT)};
+    border-radius: 5px;
+    background-color: ${(p: { active?: boolean }) => (p.active ? ThemeColors.SURFACE_CONTAINER : ThemeColors.SURFACE)};
+    color: ${ThemeColors.ON_SURFACE};
+    cursor: pointer;
+    font-family: var(--vscode-font-family);
+    font-size: 13px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+
+    &:hover:not(:disabled) {
+        border-color: ${ThemeColors.PRIMARY};
+        background-color: ${ThemeColors.SURFACE_CONTAINER};
+    }
+
+    &:disabled {
+        cursor: default;
+        opacity: 0.5;
+    }
+`;
+
+// Small count pill inside the Call order button (and replay progress).
+const CountPill = styled.span`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 16px;
+    padding: 0 5px;
+    border-radius: 8px;
+    background-color: ${ThemeColors.SURFACE_CONTAINER};
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    font-size: 10.5px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+`;
+
+// Live "now running" chip shown while a call-order replay is playing.
+const ReplayStatus = styled.div`
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 30px;
+    padding: 0 12px;
+    flex-shrink: 1;
+    min-width: 0;
+    max-width: 240px;
+    border-radius: 5px;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    background-color: ${ThemeColors.SURFACE};
+    color: ${ThemeColors.ON_SURFACE};
+    font-size: 13px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+`;
+
+const ReplayStatusName = styled.span`
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-weight: 500;
+`;
+
+const ReplayStatusStep = styled.span`
+    flex-shrink: 0;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    font-variant-numeric: tabular-nums;
+`;
+
+const CallOrderAnchor = styled.div`
+    position: relative;
+    flex-shrink: 0;
+`;
+
+const Popover = styled.div`
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    z-index: 40;
+    width: 280px;
+    max-height: min(60vh, 460px);
+    overflow-y: auto;
+    padding: 6px;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-radius: 8px;
+    background-color: ${ThemeColors.SURFACE_BRIGHT};
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.3);
+`;
+
+const PopoverCaption = styled.div`
+    padding: 4px 8px 6px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+`;
+
+const StepItem = styled.button<{ active: boolean }>`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-height: 34px;
+    padding: 5px 8px;
+    border: none;
+    border-radius: 6px;
+    background-color: ${(p: { active: boolean }) => (p.active ? ThemeColors.SURFACE_CONTAINER : "transparent")};
+    color: ${ThemeColors.ON_SURFACE};
+    cursor: pointer;
+    font-family: var(--vscode-font-family);
+    font-size: 12.5px;
+    text-align: left;
+
+    &:hover {
+        background-color: ${ThemeColors.SURFACE_CONTAINER};
+    }
+`;
+
+const StepNum = styled.span<{ active: boolean }>`
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: ${(p: { active: boolean }) => (p.active ? "var(--vscode-button-foreground)" : ThemeColors.ON_SURFACE)};
+    background-color: ${(p: { active: boolean }) => (p.active ? REPLAY_CYAN : ThemeColors.SURFACE_CONTAINER)};
+    border: 1px solid ${(p: { active: boolean }) => (p.active ? REPLAY_CYAN : ThemeColors.OUTLINE_VARIANT)};
+`;
+
+const StepDot = styled.span<{ color: string }>`
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: ${(p: { color: string }) => p.color};
+`;
+
+const StepName = styled.span`
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+const Stage = styled.div`
+    position: relative;
+    flex: 1;
+    overflow: hidden;
+`;
+
+// Floating zoom controls, integrator style.
+const Controls = styled.div`
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+`;
+
+const ControlGroup = styled.div`
+    display: flex;
+    flex-direction: column;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-radius: 5px;
+    overflow: hidden;
+
+    & > *:not(:last-child) {
+        border-bottom: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    }
+`;
+
+const ControlButton = styled.button`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    background-color: ${ThemeColors.SURFACE};
+    color: ${ThemeColors.ON_SURFACE};
+    border: none;
+    cursor: pointer;
+
+    &:hover {
+        background-color: ${ThemeColors.SURFACE_CONTAINER};
+    }
+`;
+
+const Backdrop = styled.div<{ open: boolean }>`
+    position: absolute;
+    inset: 0;
+    z-index: 25;
+    background-color: rgba(0, 0, 0, 0.35);
+    opacity: ${(p: { open: boolean }) => (p.open ? 1 : 0)};
+    visibility: ${(p: { open: boolean }) => (p.open ? "visible" : "hidden")};
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+`;
+
+const Panel = styled.div<{ open: boolean; width: number }>`
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: ${(p: { width: number }) => p.width}px;
+    max-width: 90%;
+    display: flex;
+    flex-direction: column;
+    background-color: ${ThemeColors.SURFACE_BRIGHT};
+    border-left: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    box-shadow: ${(p: { open: boolean }) => (p.open ? "-8px 0 24px rgba(0, 0, 0, 0.28)" : "none")};
+    transform: translate3d(${(p: { open: boolean }) => (p.open ? "0, 0, 0" : "101%, 0, 0")});
+    transition: transform 0.22s cubic-bezier(0.22, 0.61, 0.36, 1);
+    /* Promote to its own compositor layer so the slide is a pure GPU transform
+       (avoids repainting the blurred shadow each frame — janky on Retina). */
+    will-change: transform;
+    backface-visibility: hidden;
+    z-index: 30;
+`;
+
+const PanelResizer = styled.div<{ active: boolean }>`
+    position: absolute;
+    top: 0;
+    left: -3px;
+    bottom: 0;
+    width: 7px;
+    cursor: col-resize;
+    z-index: 31;
+    background-color: ${(p: { active: boolean }) => (p.active ? ThemeColors.PRIMARY : "transparent")};
+    opacity: ${(p: { active: boolean }) => (p.active ? 0.5 : 1)};
+
+    &:hover {
+        background-color: ${ThemeColors.PRIMARY};
+        opacity: 0.4;
+    }
+`;
+
+const PanelHeader = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 8px 10px;
+    border-bottom: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    flex-shrink: 0;
+`;
+
+const CloseButton = styled.button`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    cursor: pointer;
+
+    &:hover {
+        background-color: ${ThemeColors.SURFACE_CONTAINER};
+        color: ${ThemeColors.ON_SURFACE};
+    }
+`;
+
+const PanelBody = styled.div`
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 16px;
+`;
+
+export function AgentFlow({
+    traceData,
+    selectedSpanId,
+    onSelectSpan,
+    totalInputTokens,
+    totalOutputTokens,
+    showInternalSpans,
+    onClose,
+    onExportJson,
+    onExportEvalset,
+}: AgentFlowProps) {
+    const model = useMemo(() => buildAgentFlowModel(traceData), [traceData]);
+    const [searchQuery, setSearchQuery] = useState("");
+    const [expandedRuns, setExpandedRuns] = useState<Set<string>>(new Set());
+    const [panelOpen, setPanelOpen] = useState(false);
+    const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_W);
+    const [isResizing, setIsResizing] = useState(false);
+    const [isReplaying, setIsReplaying] = useState(false);
+    const [replayIndex, setReplayIndex] = useState(-1);
+    const [callOrderOpen, setCallOrderOpen] = useState(false);
+    const stageRef = useRef<HTMLDivElement>(null);
+    const graphRef = useRef<GraphViewHandle>(null);
+    const callOrderRef = useRef<HTMLDivElement>(null);
+    const orderedCalls = useMemo(
+        () => model.runs
+            .filter((run): run is AgentRun & { seq: number } => run.seq != null)
+            .sort((a, b) => a.seq - b.seq),
+        [model.runs]
+    );
+    const currentReplayRun = isReplaying && replayIndex >= 0 ? orderedCalls[replayIndex] ?? null : null;
+    const replayRunId = currentReplayRun?.runId ?? null;
+
+    useEffect(() => {
+        if (!callOrderOpen) return;
+        const closeOnOutsideClick = (event: MouseEvent) => {
+            if (callOrderRef.current && !callOrderRef.current.contains(event.target as Node)) {
+                setCallOrderOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", closeOnOutsideClick);
+        return () => document.removeEventListener("mousedown", closeOnOutsideClick);
+    }, [callOrderOpen]);
+
+    const selectedSpan = useMemo(
+        () => traceData.spans.find((s) => s.spanId === selectedSpanId) || null,
+        [traceData.spans, selectedSpanId]
+    );
+
+    // The canvas only reflects a selection while the details panel is open.
+    const activeSelection = panelOpen ? selectedSpanId : null;
+
+    const handleSelect = (spanId: string) => {
+        // Any manual inspection takes over from the guided replay.
+        setIsReplaying(false);
+        setReplayIndex(-1);
+        onSelectSpan(spanId);
+        setPanelOpen(true);
+    };
+
+    const startReplay = () => {
+        if (isReplaying) {
+            setIsReplaying(false);
+            setReplayIndex(-1);
+            return;
+        }
+        setPanelOpen(false);
+        setReplayIndex(0);
+        setIsReplaying(true);
+    };
+
+    // Advance one call at a time, leaving each delegation highlighted long enough
+    // to read the card and its incoming edge before moving to the next step.
+    useEffect(() => {
+        if (!isReplaying || orderedCalls.length === 0) return;
+        const timer = window.setTimeout(() => {
+            if (replayIndex >= orderedCalls.length - 1) {
+                setIsReplaying(false);
+                setReplayIndex(-1);
+            } else {
+                setReplayIndex((index) => index + 1);
+            }
+        }, REPLAY_STEP_MS);
+        return () => window.clearTimeout(timer);
+    }, [isReplaying, replayIndex, orderedCalls.length]);
+
+    // Panel resize (drag the left edge).
+    useEffect(() => {
+        if (!isResizing) return;
+        const move = (e: MouseEvent) => {
+            const rect = stageRef.current?.getBoundingClientRect();
+            if (!rect) return;
+            const fromRight = rect.right - e.clientX;
+            setPanelWidth(Math.max(PANEL_MIN_W, Math.min(fromRight, PANEL_MAX_W, rect.width - 120)));
+        };
+        const up = () => setIsResizing(false);
+        document.addEventListener("mousemove", move);
+        document.addEventListener("mouseup", up);
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
+        return () => {
+            document.removeEventListener("mousemove", move);
+            document.removeEventListener("mouseup", up);
+            document.body.style.cursor = "";
+            document.body.style.userSelect = "";
+        };
+    }, [isResizing]);
+
+    const toggleExpand = (runId: string) => {
+        setExpandedRuns((prev) => {
+            const next = new Set(prev);
+            if (next.has(runId)) next.delete(runId);
+            else next.add(runId);
+            return next;
+        });
+    };
+
+    return (
+        <Root>
+            <Toolbar>
+                <SideGroup align="left">
+                    <BackButton onClick={onClose} title="Back to trace">
+                        <Icon name="bi-arrow-back" sx={{ fontSize: "14px", width: "14px", height: "14px" }} iconSx={{ fontSize: "14px" }} />
+                        Back
+                    </BackButton>
+                    <Title>Agent Flow</Title>
+                </SideGroup>
+
+                <SideGroup align="right">
+                    <SearchWrap>
+                        <SearchInput value={searchQuery} onChange={setSearchQuery} placeholder="Filter agents and tools…" />
+                    </SearchWrap>
+                    <ExportDropdown
+                        onExportJson={onExportJson}
+                        onExportEvalset={onExportEvalset}
+                        buttonText=""
+                        showIcon={true}
+                        compact={true}
+                    />
+                </SideGroup>
+            </Toolbar>
+
+            <Stage ref={stageRef}>
+                <GraphView
+                    ref={graphRef}
+                    model={model}
+                    selectedSpanId={activeSelection}
+                    onSelectSpan={handleSelect}
+                    expandedRuns={expandedRuns}
+                    onToggleExpand={toggleExpand}
+                    searchQuery={searchQuery}
+                    showInternalSpans={showInternalSpans}
+                    replayRunId={replayRunId}
+                />
+
+                {orderedCalls.length > 0 && (
+                    <ReplayDock>
+                        <ToolButton
+                            active={isReplaying}
+                            onClick={startReplay}
+                            title={isReplaying ? "Stop call-order replay" : "Replay agent calls in order"}
+                        >
+                            <Icon
+                                isCodicon
+                                name={isReplaying ? "debug-stop" : "play"}
+                                sx={{ fontSize: "13px", width: "13px", height: "13px" }}
+                                iconSx={{ fontSize: "13px" }}
+                            />
+                            {isReplaying ? "Stop" : "Replay"}
+                        </ToolButton>
+
+                        {currentReplayRun && (
+                            <ReplayStatus title={`Running: ${currentReplayRun.agentName}`}>
+                                <StepDot color={currentReplayRun.color} />
+                                <ReplayStatusName>{currentReplayRun.agentName}</ReplayStatusName>
+                                <ReplayStatusStep>{replayIndex + 1}/{orderedCalls.length}</ReplayStatusStep>
+                            </ReplayStatus>
+                        )}
+
+                        <CallOrderAnchor ref={callOrderRef}>
+                            <ToolButton
+                                active={callOrderOpen}
+                                onClick={() => setCallOrderOpen((open) => !open)}
+                                title="Show agent call order"
+                                aria-expanded={callOrderOpen}
+                            >
+                                <Icon isCodicon name="list-ordered" sx={{ fontSize: "13px", width: "13px", height: "13px" }} iconSx={{ fontSize: "13px" }} />
+                                Call order
+                                <CountPill>{orderedCalls.length}</CountPill>
+                                <Icon isCodicon name="chevron-down" sx={{ fontSize: "12px" }} iconSx={{ fontSize: "12px" }} />
+                            </ToolButton>
+
+                            {callOrderOpen && (
+                                <Popover role="menu" aria-label="Agent call order">
+                                    <PopoverCaption>Call order</PopoverCaption>
+                                    {orderedCalls.map((run) => {
+                                        const active = replayRunId === run.runId || activeSelection === run.span.spanId;
+                                        return (
+                                            <StepItem
+                                                key={run.runId}
+                                                role="menuitem"
+                                                active={active}
+                                                title={`Step ${run.seq}: ${run.agentName}`}
+                                                onClick={() => {
+                                                    setCallOrderOpen(false);
+                                                    handleSelect(run.span.spanId);
+                                                }}
+                                            >
+                                                <StepNum active={active}>{run.seq}</StepNum>
+                                                <StepDot color={run.color} />
+                                                <StepName>{run.agentName}</StepName>
+                                            </StepItem>
+                                        );
+                                    })}
+                                </Popover>
+                            )}
+                        </CallOrderAnchor>
+                    </ReplayDock>
+                )}
+
+                <Controls>
+                    <ControlGroup>
+                        <ControlButton title="Fit to canvas" onClick={() => graphRef.current?.fit()}>
+                            <Icon name="bi-fit-screen" sx={{ fontSize: "16px", width: "16px", height: "16px" }} iconSx={{ fontSize: "16px" }} />
+                        </ControlButton>
+                    </ControlGroup>
+                    <ControlGroup>
+                        <ControlButton title="Zoom in" onClick={() => graphRef.current?.zoomIn()}>
+                            <Icon name="bi-plus" sx={{ fontSize: "16px", width: "16px", height: "16px" }} iconSx={{ fontSize: "16px" }} />
+                        </ControlButton>
+                        <ControlButton title="Zoom out" onClick={() => graphRef.current?.zoomOut()}>
+                            <Icon name="bi-minus" sx={{ fontSize: "16px", width: "16px", height: "16px" }} iconSx={{ fontSize: "16px" }} />
+                        </ControlButton>
+                    </ControlGroup>
+                </Controls>
+
+                <Backdrop open={panelOpen} onClick={() => setPanelOpen(false)} />
+
+                <Panel open={panelOpen} width={panelWidth}>
+                    <PanelResizer active={isResizing} onMouseDown={() => setIsResizing(true)} />
+                    <PanelHeader>
+                        <CloseButton title="Close details" onClick={() => setPanelOpen(false)}>
+                            <Icon name="bi-close" sx={{ fontSize: "16px", width: "16px", height: "16px" }} iconSx={{ fontSize: "16px" }} />
+                        </CloseButton>
+                    </PanelHeader>
+                    <PanelBody>
+                        {selectedSpan && (
+                            <SpanDetails
+                                spanData={selectedSpan}
+                                spanName={selectedSpan.name}
+                                totalInputTokens={totalInputTokens}
+                                totalOutputTokens={totalOutputTokens}
+                            />
+                        )}
+                    </PanelBody>
+                </Panel>
+            </Stage>
+        </Root>
+    );
+}

--- a/packages/trace-visualizer/src/components/agentflow/GraphView.tsx
+++ b/packages/trace-visualizer/src/components/agentflow/GraphView.tsx
@@ -1,0 +1,933 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useMemo, useRef, useState, useCallback, useImperativeHandle, forwardRef, useEffect } from "react";
+import styled from "@emotion/styled";
+import { keyframes } from "@emotion/react";
+import { Codicon, Icon, ThemeColors } from "@wso2/ui-toolkit";
+import { AgentFlowModel, AgentNode, InternalOp, NodeEdge, summarizeInternal, nodeMatchesQuery, visibleOps } from "./model";
+import { formatDuration, getSpanIconName, getSpanColor, formatNumber } from "../../utils";
+
+// --- Layout constants ---
+const CARD_W = 264;
+const CARD_BASE_H = 86;
+const OP_ROW_H = 26;
+const OPS_HEADER_H = 1;
+const H_GAP = 44;
+const V_GAP = 150;
+const TOP_PAD = 32;
+const REPLAY_CYAN = "var(--vscode-terminal-ansiCyan)";
+// The initial view favours legible cards over showing every wide branch at once.
+// Users can still use Fit to see the complete graph.
+const READABLE_INITIAL_SCALE = 0.62;
+
+export interface GraphViewHandle {
+    zoomIn: () => void;
+    zoomOut: () => void;
+    fit: () => void;
+    reset: () => void;
+}
+
+interface GraphViewProps {
+    model: AgentFlowModel;
+    selectedSpanId: string | null;
+    onSelectSpan: (spanId: string) => void;
+    /** ids of expanded nodes. */
+    expandedRuns: Set<string>;
+    onToggleExpand: (nodeId: string) => void;
+    searchQuery: string;
+    showInternalSpans: boolean;
+    /** The delegation currently being replayed in chronological call order. */
+    replayRunId: string | null;
+}
+
+interface PositionedNode {
+    node: AgentNode;
+    x: number;
+    y: number;
+    height: number;
+}
+
+// --- Cascade-in intro animations ---
+const CASCADE_STEP = 120; // ms between depth levels
+const nodeIn = keyframes`
+    from { opacity: 0; transform: translateY(-12px); }
+    to { opacity: 1; transform: translateY(0); }
+`;
+const fadeIn = keyframes`
+    from { opacity: 0; }
+    to { opacity: 1; }
+`;
+// Mirrors the active-agent treatment in AgentCallNodeWidget: a separate, soft
+// breathing outline plus a travelling dash on the active connection. Keeping
+// these overlays separate avoids fighting the layout and intro animations.
+const replayGlow = keyframes`
+    0% { box-shadow: 0 0 3px color-mix(in srgb, ${REPLAY_CYAN} 20%, transparent); }
+    100% { box-shadow: 0 0 10px color-mix(in srgb, ${REPLAY_CYAN} 50%, transparent), 0 0 20px color-mix(in srgb, ${REPLAY_CYAN} 20%, transparent); }
+`;
+const replayFlowDash = keyframes`
+    to { stroke-dashoffset: -18; }
+`;
+
+// --- Styled ---
+
+const Viewport = styled.div`
+    position: absolute;
+    inset: 0;
+    overflow: visible;
+    background-color: ${ThemeColors.SURFACE_BRIGHT};
+    background-image: radial-gradient(${ThemeColors.SURFACE_CONTAINER} 1px, transparent 1px);
+    background-size: 20px 20px;
+    cursor: grab;
+
+    &.panning {
+        cursor: grabbing;
+    }
+`;
+
+const World = styled.div`
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform-origin: 0 0;
+`;
+
+const Card = styled.div<{ selected: boolean; error: boolean; dim: boolean; introDelay: number | null }>`
+    position: absolute;
+    width: ${CARD_W}px;
+    box-sizing: border-box;
+    border-radius: 10px;
+    border: 1.5px solid ${(p: { error: boolean; selected: boolean }) =>
+        p.error ? ThemeColors.ERROR : p.selected ? ThemeColors.PRIMARY : ThemeColors.OUTLINE_VARIANT};
+    background-color: ${ThemeColors.SURFACE_DIM};
+    color: ${ThemeColors.ON_SURFACE};
+    box-shadow: ${(p: { selected: boolean }) => (p.selected ? `0 0 0 1px ${ThemeColors.PRIMARY}` : "none")};
+    opacity: ${(p: { dim: boolean }) => (p.dim ? 0.32 : 1)};
+    transition: opacity 0.15s ease, box-shadow 0.1s ease, border-color 0.1s ease,
+        top 0.2s ease, left 0.2s ease;
+    overflow: hidden;
+    cursor: pointer;
+
+    animation-name: ${(p: { introDelay: number | null }) => (p.introDelay != null ? nodeIn : "none")};
+    animation-duration: 0.34s;
+    animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
+    animation-fill-mode: both;
+    animation-delay: ${(p: { introDelay: number | null }) => p.introDelay ?? 0}ms;
+
+    &:hover {
+        border-color: ${(p: { error: boolean }) => (p.error ? ThemeColors.ERROR : ThemeColors.PRIMARY)};
+        box-shadow: 0 0 4px 1px ${ThemeColors.PRIMARY};
+    }
+`;
+
+const ReplayCardPulse = styled.div<{ active: boolean }>`
+    position: absolute;
+    inset: 0;
+    border: 2px solid ${REPLAY_CYAN};
+    border-radius: 10px;
+    opacity: ${(p: { active: boolean }) => (p.active ? 1 : 0)};
+    transition: opacity 0.24s ease-out;
+    animation: ${(p: { active: boolean }) => (p.active ? `${replayGlow} 1.35s ease-in-out infinite alternate` : "none")};
+    pointer-events: none;
+    z-index: 3;
+`;
+
+const EdgePath = styled.path<{ introDelay: number | null }>`
+    animation-name: ${(p: { introDelay: number | null }) => (p.introDelay != null ? fadeIn : "none")};
+    animation-duration: 0.3s;
+    animation-timing-function: ease;
+    animation-fill-mode: both;
+    animation-delay: ${(p: { introDelay: number | null }) => p.introDelay ?? 0}ms;
+`;
+
+const ReplayEdgePath = styled.path`
+    pointer-events: none;
+    animation: ${replayFlowDash} 0.9s linear infinite;
+`;
+
+const CardHeader = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px 2px;
+    cursor: pointer;
+`;
+
+const IconBox = styled.span<{ color: string }>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    flex-shrink: 0;
+    border-radius: 8px;
+    line-height: 0;
+    color: ${(p: { color: string }) => p.color};
+    background-color: color-mix(in srgb, ${(p: { color: string }) => p.color} 3%, transparent);
+    border: 1px solid color-mix(in srgb, ${(p: { color: string }) => p.color} 38%, transparent);
+`;
+
+const AgentName = styled.span`
+    font-size: 13px;
+    font-weight: 600;
+    color: ${ThemeColors.ON_SURFACE};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+`;
+
+const CountBadge = styled.span<{ color: string }>`
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 9px;
+    font-size: 10.5px;
+    font-weight: 700;
+    color: ${(p: { color: string }) => p.color};
+    background-color: color-mix(in srgb, ${(p: { color: string }) => p.color} 16%, transparent);
+    border: 1px solid color-mix(in srgb, ${(p: { color: string }) => p.color} 40%, transparent);
+`;
+
+const MetaRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 12px 10px 50px;
+    font-size: 11.5px;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+`;
+
+const MetaItem = styled.span`
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+`;
+
+const ErrorText = styled.span`
+    color: ${ThemeColors.ERROR};
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+`;
+
+const SummaryRow = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 6px 12px;
+    border-top: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    font-size: 11px;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    cursor: pointer;
+
+    &:hover {
+        color: ${ThemeColors.ON_SURFACE};
+    }
+`;
+
+const Chevron = styled.span<{ expanded: boolean }>`
+    display: flex;
+    align-items: center;
+    transition: transform 0.2s ease;
+    transform: rotate(${(p: { expanded: boolean }) => (p.expanded ? "180deg" : "0deg")});
+`;
+
+const OpsReveal = styled.div<{ expanded: boolean }>`
+    display: grid;
+    grid-template-rows: ${(p: { expanded: boolean }) => (p.expanded ? "1fr" : "0fr")};
+    transition: grid-template-rows 0.2s ease;
+`;
+
+const OpsInner = styled.div`
+    overflow: hidden;
+    min-height: 0;
+`;
+
+const OpsList = styled.div`
+    border-top: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+`;
+
+const OpRow = styled.div<{ selected: boolean }>`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: ${OP_ROW_H}px;
+    padding: 0 12px;
+    font-size: 11.5px;
+    cursor: pointer;
+    background-color: ${(p: { selected: boolean }) => (p.selected ? ThemeColors.SURFACE_CONTAINER : "transparent")};
+
+    &:hover {
+        background-color: ${ThemeColors.SURFACE_CONTAINER};
+    }
+`;
+
+const OpLabel = styled.span`
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: ${ThemeColors.ON_SURFACE};
+`;
+
+const OpTarget = styled.span`
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    flex-shrink: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+const OpDuration = styled.span`
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+`;
+
+const EdgeLabel = styled.div<{ dim: boolean; highlight: boolean; replay: boolean; introDelay: number | null }>`
+    position: absolute;
+    transform: translate(-50%, -50%);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 10.5px;
+    white-space: nowrap;
+    max-width: 190px;
+    background-color: ${ThemeColors.SURFACE_DIM};
+    border: 1px solid ${(p: { highlight: boolean; replay: boolean }) => p.replay ? REPLAY_CYAN : p.highlight ? ThemeColors.PRIMARY : ThemeColors.OUTLINE_VARIANT};
+    color: ${(p: { highlight: boolean }) => (p.highlight ? ThemeColors.ON_SURFACE : ThemeColors.ON_SURFACE_VARIANT)};
+    opacity: ${(p: { dim: boolean }) => (p.dim ? 0.25 : 1)};
+    cursor: pointer;
+    z-index: 2;
+    transition: left 0.2s ease, top 0.2s ease, opacity 0.15s ease, border-color 0.1s ease;
+
+    animation-name: ${(p: { introDelay: number | null }) => (p.introDelay != null ? fadeIn : "none")};
+    animation-duration: 0.3s;
+    animation-timing-function: ease;
+    animation-fill-mode: both;
+    animation-delay: ${(p: { introDelay: number | null }) => p.introDelay ?? 0}ms;
+`;
+
+const EdgeToolName = styled.span`
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+const EmptyHint = styled.div`
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    font-size: 13px;
+`;
+
+// --- Layout ---
+
+// Number of content rows currently visible below the card header, given which
+// nodes/calls are expanded. Multi-call nodes show one row per call, plus that
+// call's internal ops when the call itself is expanded.
+function visibleRowCount(node: AgentNode, showInternalSpans: boolean, expanded: Set<string>): number {
+    if (!expanded.has(node.nodeId)) return 0;
+    if (node.callCount > 1) {
+        let rows = node.callCount;
+        node.runs.forEach((r) => {
+            if (expanded.has(r.runId)) rows += visibleOps(r, showInternalSpans).length;
+        });
+        return rows;
+    }
+    return visibleOps(node.runs[0], showInternalSpans).length;
+}
+
+function layoutNodes(model: AgentFlowModel, expanded: Set<string>, showInternalSpans: boolean): {
+    positioned: Map<string, PositionedNode>;
+    width: number;
+    height: number;
+} {
+    const { nodesById } = model;
+    const positioned = new Map<string, PositionedNode>();
+
+    const cardHeight = (node: AgentNode): number => {
+        const rows = visibleRowCount(node, showInternalSpans, expanded);
+        if (rows > 0) {
+            return CARD_BASE_H + OPS_HEADER_H + rows * OP_ROW_H;
+        }
+        return CARD_BASE_H;
+    };
+
+    const roots = model.nodes.filter((n) => !n.parentNodeId || !nodesById.has(n.parentNodeId));
+
+    // Tidy-tree horizontal slots.
+    let nextLeaf = 0;
+    const slotOf = new Map<string, number>();
+    const assignSlot = (nodeId: string, seen: Set<string>): number => {
+        if (seen.has(nodeId)) return nextLeaf++;
+        seen.add(nodeId);
+        const node = nodesById.get(nodeId)!;
+        const kids = node.childNodeIds.filter((c) => nodesById.has(c));
+        if (kids.length === 0) {
+            const slot = nextLeaf++;
+            slotOf.set(nodeId, slot);
+            return slot;
+        }
+        const kidSlots = kids.map((c) => assignSlot(c, seen));
+        const slot = (Math.min(...kidSlots) + Math.max(...kidSlots)) / 2;
+        slotOf.set(nodeId, slot);
+        return slot;
+    };
+    roots.forEach((r) => assignSlot(r.nodeId, new Set()));
+
+    const maxDepth = Math.max(0, ...model.nodes.map((n) => n.depth));
+    const layerHeight: number[] = new Array(maxDepth + 1).fill(0);
+    model.nodes.forEach((n) => {
+        layerHeight[n.depth] = Math.max(layerHeight[n.depth], cardHeight(n));
+    });
+    const layerY: number[] = [];
+    let acc = TOP_PAD;
+    for (let d = 0; d <= maxDepth; d++) {
+        layerY[d] = acc;
+        acc += layerHeight[d] + V_GAP;
+    }
+
+    const colStep = CARD_W + H_GAP;
+    let maxX = 0;
+    model.nodes.forEach((node) => {
+        const slot = slotOf.get(node.nodeId) ?? 0;
+        const x = slot * colStep;
+        positioned.set(node.nodeId, { node, x, y: layerY[node.depth], height: cardHeight(node) });
+        maxX = Math.max(maxX, x + CARD_W);
+    });
+
+    const width = Math.max(maxX, CARD_W) + TOP_PAD;
+    const height = acc - V_GAP + TOP_PAD;
+    return { positioned, width, height };
+}
+
+// Orthogonal link with rounded elbows, top-to-bottom.
+function orthPath(x1: number, y1: number, x2: number, y2: number): string {
+    if (Math.abs(x1 - x2) < 1) return `M ${x1} ${y1} L ${x2} ${y2}`;
+    const midY = (y1 + y2) / 2;
+    const r = 10;
+    const dir = x2 > x1 ? 1 : -1;
+    return [
+        `M ${x1} ${y1}`,
+        `L ${x1} ${midY - r}`,
+        `Q ${x1} ${midY} ${x1 + dir * r} ${midY}`,
+        `L ${x2 - dir * r} ${midY}`,
+        `Q ${x2} ${midY} ${x2} ${midY + r}`,
+        `L ${x2} ${y2}`,
+    ].join(" ");
+}
+
+// --- Component ---
+
+export const GraphView = forwardRef<GraphViewHandle, GraphViewProps>(function GraphView(
+    { model, selectedSpanId, onSelectSpan, expandedRuns, onToggleExpand, searchQuery, showInternalSpans, replayRunId },
+    ref
+) {
+    const viewportRef = useRef<HTMLDivElement>(null);
+    const [scale, setScale] = useState(1);
+    const [tx, setTx] = useState(24);
+    const [ty, setTy] = useState(16);
+    const [panning, setPanning] = useState(false);
+    const [introing, setIntroing] = useState(false);
+    const [cascading, setCascading] = useState(false);
+    const [ready, setReady] = useState(false);
+    const panState = useRef<{ startX: number; startY: number; ox: number; oy: number } | null>(null);
+    const didFitRef = useRef(false);
+    // Mirror of the current transform so the native (non-passive) wheel handler
+    // always reads live values without being re-bound every render.
+    const viewRef = useRef({ scale, tx, ty });
+    viewRef.current = { scale, tx, ty };
+
+    const { positioned, width, height } = useMemo(
+        () => layoutNodes(model, expandedRuns, showInternalSpans),
+        [model, expandedRuns, showInternalSpans]
+    );
+
+    const edgeByTo = useMemo(() => {
+        const m = new Map<string, NodeEdge>();
+        model.nodeEdges.forEach((e) => m.set(e.toNodeId, e));
+        return m;
+    }, [model.nodeEdges]);
+
+    // Map any span id (run or internal op) to the node it belongs to.
+    const spanToNodeId = useMemo(() => {
+        const m = new Map<string, string>();
+        model.nodes.forEach((node) => {
+            node.runs.forEach((run) => {
+                m.set(run.span.spanId, node.nodeId);
+                run.internalOps.forEach((op) => m.set(op.span.spanId, node.nodeId));
+            });
+        });
+        return m;
+    }, [model.nodes]);
+
+    // Map a delegation's execute_tool span -> the CHILD node it delegates to, so
+    // selecting a handoff highlights that specific edge (not the whole caller).
+    const toolSpanToChildNode = useMemo(() => {
+        const m = new Map<string, string>();
+        model.handoffs.forEach((h) => {
+            if (!h.toolSpan) return;
+            const child = model.runsById.get(h.toRunId);
+            if (child) m.set(h.toolSpan.spanId, child.nodeId);
+        });
+        return m;
+    }, [model.handoffs, model.runsById]);
+
+    const query = searchQuery.trim();
+    // A selected handoff (edge) takes precedence over node selection.
+    const selectedEdgeChildId = selectedSpanId ? toolSpanToChildNode.get(selectedSpanId) ?? null : null;
+    const selectedNodeId = selectedEdgeChildId
+        ? null
+        : selectedSpanId ? spanToNodeId.get(selectedSpanId) ?? null : null;
+    const replayNodeId = replayRunId ? model.runsById.get(replayRunId)?.nodeId ?? null : null;
+    const replaySourceNodeId = replayNodeId ? model.nodesById.get(replayNodeId)?.parentNodeId ?? null : null;
+
+    const isNodeActive = useCallback(
+        (node: AgentNode): boolean => {
+            if (query) return nodeMatchesQuery(node, edgeByTo.get(node.nodeId), query);
+            if (replayNodeId) return node.nodeId === replayNodeId || node.nodeId === replaySourceNodeId;
+            if (selectedEdgeChildId) {
+                const child = model.nodesById.get(selectedEdgeChildId);
+                return node.nodeId === selectedEdgeChildId || node.nodeId === child?.parentNodeId;
+            }
+            // Plain node selection does not dim anything — only the clicked node is
+            // visually marked (via its selected border).
+            return true;
+        },
+        [query, selectedEdgeChildId, replayNodeId, replaySourceNodeId, model, edgeByTo]
+    );
+
+    // Dimming applies for search and edge selection only, not plain node selection.
+    const anyFocus = !!query || !!selectedEdgeChildId || !!replayNodeId;
+
+    const computeFit = useCallback((minScale = 0.2): { scale: number; tx: number; ty: number } | null => {
+        const vp = viewportRef.current;
+        if (!vp || width === 0 || height === 0 || vp.clientWidth === 0 || vp.clientHeight === 0) return null;
+        const pad = 48;
+        const s = Math.min((vp.clientWidth - pad) / width, (vp.clientHeight - pad) / height, 1.15);
+        const scale = Math.max(minScale, s);
+        return {
+            scale,
+            tx: (vp.clientWidth - width * scale) / 2,
+            ty: Math.max(16, (vp.clientHeight - height * scale) / 2),
+        };
+    }, [width, height]);
+
+    const applyView = useCallback((v: { scale: number; tx: number; ty: number }) => {
+        viewRef.current = v;
+        setScale(v.scale);
+        setTx(v.tx);
+        setTy(v.ty);
+        setReady(true);
+    }, []);
+
+    const doFit = useCallback(() => {
+        const f = computeFit();
+        if (f) {
+            setIntroing(false);
+            setCascading(false);
+            applyView(f);
+        }
+    }, [computeFit, applyView]);
+
+    // Cinematic first open: start zoomed in on the root, then ease out to the fitted
+    // view so the crew "unfolds" beneath the top-level agent.
+    const runIntro = useCallback(() => {
+        const vp = viewportRef.current;
+        const target = computeFit(READABLE_INITIAL_SCALE);
+        if (!vp || !target) return;
+        const root = model.nodes.find((n) => !n.parentNodeId) ?? model.nodes[0];
+        const rp = root && positioned.get(root.nodeId);
+        if (!rp) {
+            doFit();
+            return;
+        }
+        const startScale = Math.min(2, Math.max(target.scale * 2.2, 1.4));
+        const rcx = rp.x + CARD_W / 2;
+        const rcy = rp.y + rp.height / 2;
+        const start = {
+            scale: startScale,
+            tx: vp.clientWidth / 2 - rcx * startScale,
+            ty: vp.clientHeight * 0.42 - rcy * startScale,
+        };
+        const maxDepth = Math.max(0, ...model.nodes.map((n) => n.depth));
+        setIntroing(false);
+        setCascading(true);
+        applyView(start);
+        requestAnimationFrame(() =>
+            requestAnimationFrame(() => {
+                setIntroing(true);
+                applyView(target);
+            })
+        );
+        window.setTimeout(() => setIntroing(false), 720);
+        window.setTimeout(() => setCascading(false), maxDepth * CASCADE_STEP + 500);
+    }, [computeFit, applyView, doFit, model.nodes, positioned]);
+
+    useImperativeHandle(ref, () => ({
+        zoomIn: () => { setIntroing(false); setCascading(false); setScale((s) => Math.min(2.5, s + 0.15)); },
+        zoomOut: () => { setIntroing(false); setCascading(false); setScale((s) => Math.max(0.2, s - 0.15)); },
+        fit: doFit,
+        reset: () => {
+            setIntroing(false);
+            setCascading(false);
+            applyView({ scale: 1, tx: 24, ty: 16 });
+        },
+    }), [doFit, applyView]);
+
+    useEffect(() => {
+        if (didFitRef.current) return;
+        const vp = viewportRef.current;
+        if (width > 0 && height > 0 && vp && vp.clientWidth > 0 && vp.clientHeight > 0) {
+            runIntro();
+            didFitRef.current = true;
+            return;
+        }
+        const t = setTimeout(() => {
+            const v = viewportRef.current;
+            if (!didFitRef.current && v && v.clientWidth > 0 && v.clientHeight > 0) {
+                runIntro();
+                didFitRef.current = true;
+            }
+        }, 60);
+        return () => clearTimeout(t);
+    }, [width, height, runIntro]);
+
+    const onMouseDown = (e: React.MouseEvent) => {
+        if (e.target !== viewportRef.current && !(e.target as HTMLElement).dataset?.canvas) return;
+        setIntroing(false);
+        setCascading(false);
+        setPanning(true);
+        panState.current = { startX: e.clientX, startY: e.clientY, ox: tx, oy: ty };
+    };
+
+    useEffect(() => {
+        if (!panning) return;
+        const move = (e: MouseEvent) => {
+            if (!panState.current) return;
+            setTx(panState.current.ox + (e.clientX - panState.current.startX));
+            setTy(panState.current.oy + (e.clientY - panState.current.startY));
+        };
+        const up = () => setPanning(false);
+        document.addEventListener("mousemove", move);
+        document.addEventListener("mouseup", up);
+        return () => {
+            document.removeEventListener("mousemove", move);
+            document.removeEventListener("mouseup", up);
+        };
+    }, [panning]);
+
+    // Trackpad/wheel navigation matching the BI flow diagram: plain two-finger
+    // scroll pans (dominant axis), pinch / ctrl+cmd wheel zooms cursor-anchored.
+    // Uses a native non-passive listener so preventDefault stops the webview from
+    // scrolling the page.
+    useEffect(() => {
+        const vp = viewportRef.current;
+        if (!vp) return;
+        const onWheelNative = (e: WheelEvent) => {
+            e.preventDefault();
+            setIntroing(false);
+            setCascading(false);
+            const { scale: s, tx: cx, ty: cy } = viewRef.current;
+            if (e.ctrlKey || e.metaKey) {
+                const rect = vp.getBoundingClientRect();
+                const px = e.clientX - rect.left;
+                const py = e.clientY - rect.top;
+                const next = Math.max(0.2, Math.min(2.5, s + -e.deltaY / 300));
+                if (next === s) return;
+                const worldX = (px - cx) / s;
+                const worldY = (py - cy) / s;
+                const ntx = px - worldX * next;
+                const nty = py - worldY * next;
+                viewRef.current = { scale: next, tx: ntx, ty: nty };
+                setScale(next);
+                setTx(ntx);
+                setTy(nty);
+            } else {
+                const ax = Math.abs(e.deltaX);
+                const ay = Math.abs(e.deltaY);
+                if (ay < ax && ax > 8) {
+                    const ntx = cx - e.deltaX;
+                    viewRef.current = { ...viewRef.current, tx: ntx };
+                    setTx(ntx);
+                } else {
+                    const nty = cy - e.deltaY;
+                    viewRef.current = { ...viewRef.current, ty: nty };
+                    setTy(nty);
+                }
+            }
+        };
+        vp.addEventListener("wheel", onWheelNative, { passive: false });
+        return () => vp.removeEventListener("wheel", onWheelNative);
+    }, []);
+
+    const renderOpRow = (op: InternalOp, indent: boolean) => (
+        <OpRow
+            key={op.span.spanId}
+            selected={selectedSpanId === op.span.spanId}
+            style={indent ? { paddingLeft: "34px" } : undefined}
+            onClick={(ev) => { ev.stopPropagation(); onSelectSpan(op.span.spanId); }}
+        >
+            {op.isDelegation ? (
+                <span style={{ display: "flex", color: ThemeColors.ON_SURFACE_VARIANT }}>
+                    <Icon
+                        name="bi-ai-agent"
+                        sx={{ fontSize: "12px", width: "12px", height: "12px" }}
+                        iconSx={{ fontSize: "12px" }}
+                    />
+                </span>
+            ) : (
+                <span style={{ display: "flex", color: op.hasError ? ThemeColors.ERROR : getSpanColor(op.kind) }}>
+                    <Icon
+                        name={op.hasError ? "bi-error" : getSpanIconName(op.kind)}
+                        sx={{ fontSize: "12px", width: "12px", height: "12px" }}
+                        iconSx={{ fontSize: "12px" }}
+                    />
+                </span>
+            )}
+            <OpLabel title={op.label}>{op.label}</OpLabel>
+            {op.isDelegation && op.targetAgentName && (
+                <OpTarget title={op.targetAgentName}>→ {op.targetAgentName}</OpTarget>
+            )}
+            {op.durationMs != null && <OpDuration>{formatDuration(op.durationMs)}</OpDuration>}
+        </OpRow>
+    );
+
+    return (
+        <Viewport
+            ref={viewportRef}
+            className={panning ? "panning" : ""}
+            onMouseDown={onMouseDown}
+            data-canvas="true"
+        >
+            {model.nodes.length === 0 && <EmptyHint>No agent runs in this trace.</EmptyHint>}
+            <World
+                style={{
+                    transform: `translate(${tx}px, ${ty}px) scale(${scale})`,
+                    width,
+                    height,
+                    opacity: ready ? 1 : 0,
+                    transition: introing
+                        ? "transform 0.6s cubic-bezier(0.22, 0.61, 0.36, 1), opacity 0.25s ease"
+                        : "opacity 0.2s ease",
+                }}
+                data-canvas="true"
+            >
+                <svg
+                    width={width}
+                    height={height}
+                    style={{ position: "absolute", top: 0, left: 0, pointerEvents: "none", overflow: "visible" }}
+                >
+                    <defs>
+                        <marker id="af-arrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3" orient="auto">
+                            <polygon points="0,0 6,3 0,6" fill={ThemeColors.ON_SURFACE_VARIANT} />
+                        </marker>
+                        <marker id="af-arrow-hl" markerWidth="7" markerHeight="7" refX="5.5" refY="3" orient="auto">
+                            <polygon points="0,0 6,3 0,6" fill={ThemeColors.PRIMARY} />
+                        </marker>
+                        <marker id="af-arrow-replay" markerWidth="7" markerHeight="7" refX="5.5" refY="3" orient="auto">
+                            <polygon points="0,0 6,3 0,6" fill={REPLAY_CYAN} />
+                        </marker>
+                    </defs>
+
+                    {model.nodeEdges.map((e) => {
+                        if (!e.fromNodeId) return null;
+                        const from = positioned.get(e.fromNodeId);
+                        const to = positioned.get(e.toNodeId);
+                        if (!from || !to) return null;
+                        const isSelectedEdge = selectedEdgeChildId === e.toNodeId;
+                        const isReplayedEdge = replayNodeId === e.toNodeId;
+                        const active =
+                            !anyFocus ||
+                            isSelectedEdge ||
+                            (isNodeActive(from.node) && isNodeActive(to.node)) ||
+                            selectedNodeId === e.fromNodeId ||
+                            selectedNodeId === e.toNodeId;
+                        // Strong highlight only for an explicitly selected handoff.
+                        const highlight = isSelectedEdge || isReplayedEdge;
+                        return (
+                            <React.Fragment key={e.id}>
+                                <EdgePath
+                                    introDelay={cascading ? to.node.depth * CASCADE_STEP + 60 : null}
+                                    d={orthPath(from.x + CARD_W / 2, from.y + from.height, to.x + CARD_W / 2, to.y)}
+                                    fill="none"
+                                stroke={isReplayedEdge ? REPLAY_CYAN : highlight ? ThemeColors.PRIMARY : ThemeColors.ON_SURFACE_VARIANT}
+                                strokeWidth={highlight ? 2 : 1.5}
+                                markerEnd={isReplayedEdge ? "url(#af-arrow-replay)" : highlight ? "url(#af-arrow-hl)" : "url(#af-arrow)"}
+                                    opacity={active ? 1 : 0.18}
+                                    style={{ transition: "d 0.2s ease, opacity 0.15s ease" }}
+                                />
+                                {isReplayedEdge && (
+                                    <ReplayEdgePath
+                                        d={orthPath(from.x + CARD_W / 2, from.y + from.height, to.x + CARD_W / 2, to.y)}
+                                        fill="none"
+                                        stroke={REPLAY_CYAN}
+                                        strokeWidth={2.5}
+                                        strokeDasharray="6 6"
+                                        markerEnd="url(#af-arrow-replay)"
+                                    />
+                                )}
+                            </React.Fragment>
+                        );
+                    })}
+                </svg>
+
+                {/* Tool label on the child's vertical drop. Call order is kept in the toolbar strip. */}
+                {model.nodeEdges.map((e) => {
+                    if (!e.fromNodeId) return null;
+                    const from = positioned.get(e.fromNodeId);
+                    const to = positioned.get(e.toNodeId);
+                    if (!from || !to) return null;
+                    const mx = to.x + CARD_W / 2;
+                    const midY = (from.y + from.height + to.y) / 2;
+                    const my = (midY + to.y) / 2;
+                    const isSelectedEdge = selectedEdgeChildId === e.toNodeId;
+                    const isReplayedEdge = replayNodeId === e.toNodeId;
+                    const active =
+                        !anyFocus || isSelectedEdge || (isNodeActive(from.node) && isNodeActive(to.node)) ||
+                        selectedNodeId === e.fromNodeId || selectedNodeId === e.toNodeId;
+                    return (
+                        <EdgeLabel
+                            key={`lbl-${e.id}`}
+                            style={{ left: mx, top: my }}
+                            dim={!active}
+                            highlight={isSelectedEdge || isReplayedEdge}
+                            replay={isReplayedEdge}
+                            introDelay={cascading ? to.node.depth * CASCADE_STEP + 60 : null}
+                            title={`${e.toolLabel}${e.callCount > 1 ? ` (×${e.callCount})` : ""}`}
+                            onClick={(ev) => {
+                                ev.stopPropagation();
+                                onSelectSpan(e.toolSpan ? e.toolSpan.spanId : e.targetSpan.spanId);
+                            }}
+                        >
+                            <EdgeToolName>{e.toolLabel}</EdgeToolName>
+                        </EdgeLabel>
+                    );
+                })}
+
+                {/* Agent nodes */}
+                {model.nodes.map((node) => {
+                    const p = positioned.get(node.nodeId);
+                    if (!p) return null;
+                    const expanded = expandedRuns.has(node.nodeId);
+                    const multi = node.callCount > 1;
+                    const rep = node.runs[0];
+                    const summary = multi ? `${node.callCount} calls` : summarizeInternal(rep);
+                    const ops = multi ? [] : visibleOps(rep, showInternalSpans);
+                    const hasExpandable = multi ? node.callCount > 0 : ops.length > 0;
+                    const dim = anyFocus && !isNodeActive(node);
+                    const selected = selectedNodeId === node.nodeId || selectedEdgeChildId === node.nodeId;
+                    return (
+                        <Card
+                            key={node.nodeId}
+                            selected={selected}
+                            error={node.hasError}
+                            dim={dim}
+                            introDelay={cascading ? node.depth * CASCADE_STEP : null}
+                            style={{ left: p.x, top: p.y }}
+                            onClick={() => onSelectSpan(rep.span.spanId)}
+                        >
+                            <ReplayCardPulse active={replayNodeId === node.nodeId} />
+                            <CardHeader>
+                                <IconBox color={node.color}>
+                                    <Icon
+                                        name="bi-ai-agent"
+                                        sx={{ fontSize: "16px", width: "16px", height: "16px", display: "flex", alignItems: "center", justifyContent: "center" }}
+                                        iconSx={{ fontSize: "16px", display: "flex", alignItems: "center", justifyContent: "center", lineHeight: 1 }}
+                                    />
+                                </IconBox>
+                                <AgentName title={node.agentName}>{node.agentName}</AgentName>
+                                {multi && <CountBadge color={node.color}>×{node.callCount}</CountBadge>}
+                            </CardHeader>
+                            <MetaRow>
+                                <MetaItem>
+                                    <Icon name="bi-clock" sx={{ fontSize: "11px", width: "11px", height: "11px" }} iconSx={{ fontSize: "11px" }} />
+                                    {node.totalDurationMs != null
+                                        ? `${formatDuration(node.totalDurationMs)}${multi ? " total" : ""}`
+                                        : node.status === "running" ? "running" : "time unavailable"}
+                                </MetaItem>
+                                {node.totalTokens > 0 && <MetaItem>{formatNumber(node.totalTokens)} tokens</MetaItem>}
+                                {node.hasError && (
+                                    <ErrorText>
+                                        <Icon name="bi-error" sx={{ fontSize: "11px", width: "11px", height: "11px" }} iconSx={{ fontSize: "11px" }} />
+                                        error
+                                    </ErrorText>
+                                )}
+                            </MetaRow>
+                            {hasExpandable && (
+                                <>
+                                    <SummaryRow onClick={(ev) => { ev.stopPropagation(); onToggleExpand(node.nodeId); }}>
+                                        <span>{summary || `${node.callCount} calls`}</span>
+                                        <Chevron expanded={expanded}>
+                                            <Codicon name="chevron-down" sx={{ fontSize: "12px" }} />
+                                        </Chevron>
+                                    </SummaryRow>
+                                    <OpsReveal expanded={expanded}>
+                                        <OpsInner>
+                                            <OpsList>
+                                                {multi
+                                                    ? node.runs.map((run, i) => {
+                                                        const callExpanded = expandedRuns.has(run.runId);
+                                                        const callOps = visibleOps(run, showInternalSpans);
+                                                        return (
+                                                            <React.Fragment key={run.runId}>
+                                                                <OpRow
+                                                                    selected={selectedSpanId === run.span.spanId}
+                                                                    onClick={(ev) => { ev.stopPropagation(); onSelectSpan(run.span.spanId); }}
+                                                                >
+                                                                    <OpLabel>Call {i + 1}</OpLabel>
+                                                                    <OpTarget>{summarizeInternal(run)}</OpTarget>
+                                                                    {run.durationMs != null && <OpDuration>{formatDuration(run.durationMs)}</OpDuration>}
+                                                                    {callOps.length > 0 && (
+                                                                        <Chevron
+                                                                            expanded={callExpanded}
+                                                                            style={{ cursor: "pointer" }}
+                                                                            onClick={(ev) => { ev.stopPropagation(); onToggleExpand(run.runId); }}
+                                                                        >
+                                                                            <Codicon name="chevron-down" sx={{ fontSize: "11px" }} />
+                                                                        </Chevron>
+                                                                    )}
+                                                                </OpRow>
+                                                                <OpsReveal expanded={callExpanded}>
+                                                                    <OpsInner>
+                                                                        {callOps.map((op) => renderOpRow(op, true))}
+                                                                    </OpsInner>
+                                                                </OpsReveal>
+                                                            </React.Fragment>
+                                                        );
+                                                    })
+                                                    : ops.map((op) => renderOpRow(op, false))}
+                                            </OpsList>
+                                        </OpsInner>
+                                    </OpsReveal>
+                                </>
+                            )}
+                        </Card>
+                    );
+                })}
+            </World>
+        </Viewport>
+    );
+});

--- a/packages/trace-visualizer/src/components/agentflow/model.ts
+++ b/packages/trace-visualizer/src/components/agentflow/model.ts
@@ -1,0 +1,544 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Derived, UI-only model for the multi-agent Agents view.
+ *
+ * This builds an agent-run / handoff graph from raw `TraceData.spans`.
+ * Parentage is taken from `parentSpanId` ancestry only (never timestamps),
+ * so this stays a reliable semantic source for both Graph and Sequence views.
+ *
+ * The name/ancestry inference lives entirely here so future explicit agent
+ * telemetry (ballerina.agent.*) can replace it without touching the views.
+ */
+
+import { SpanData, TraceData } from "../../index";
+import {
+    getAttributeValue,
+    getSpanTypeBadge,
+    getSpanTimeRange,
+    getSpanTokens,
+    isAISpan,
+    spanHasError,
+    stripSpanPrefix,
+} from "../../utils";
+
+const ROOT_PARENT = "0000000000000000";
+
+export type OpKind = ReturnType<typeof getSpanTypeBadge>;
+
+export type RunStatus = "success" | "error" | "running";
+
+/** A non-agent span (model/tool/retrieval/...) owned by an agent run. */
+export interface InternalOp {
+    span: SpanData;
+    kind: OpKind;
+    label: string;
+    durationMs: number | null;
+    startMs: number | null;
+    hasError: boolean;
+    /** true for AI-instrumented spans; false for raw internal spans (http, etc.). */
+    isAI: boolean;
+    /** true when this tool span is actually an agent delegation (wraps invoke_agent). */
+    isDelegation: boolean;
+    /** for delegation ops: the invoked agent's display name. */
+    targetAgentName: string | null;
+    /** for delegation ops: the global call sequence number of the invocation. */
+    seq: number | null;
+}
+
+/** One `invoke_agent` span. Each invocation is a distinct run. */
+export interface AgentRun {
+    runId: string;
+    span: SpanData;
+    agentName: string;
+    /** Delegation depth: root runs are 0. */
+    depth: number;
+    startMs: number | null;
+    endMs: number | null;
+    durationMs: number | null;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    status: RunStatus;
+    hasError: boolean;
+    /** Caller run id, or null for a root / unknown-origin run. */
+    parentRunId: string | null;
+    childRunIds: string[];
+    internalOps: InternalOp[];
+    /** color assigned to the agent identity (same name -> same color). */
+    color: string;
+    /** global chronological order of this invocation among all delegations (1-based); null for roots. */
+    seq: number | null;
+    /** id of the AgentNode this run is grouped under. */
+    nodeId: string;
+}
+
+/**
+ * A graph node: all invocations of one agent identity under one caller.
+ * The same agent invoked N times by the same parent is a single node with
+ * N runs (rendered with a ×N badge and an expandable per-call list).
+ */
+export interface AgentNode {
+    nodeId: string;
+    agentName: string;
+    color: string;
+    depth: number;
+    parentNodeId: string | null;
+    childNodeIds: string[];
+    /** invocations of this agent under this parent, sorted by start time. */
+    runs: AgentRun[];
+    callCount: number;
+    /** summed duration across all runs (time spent in this agent); null if unknown. */
+    totalDurationMs: number | null;
+    totalTokens: number;
+    hasError: boolean;
+    status: RunStatus;
+}
+
+/** A graph edge: one caller node delegating to one child node (possibly N calls). */
+export interface NodeEdge {
+    id: string;
+    fromNodeId: string | null;
+    toNodeId: string;
+    /** tool label (from the representative run's execute_tool), or "Delegate". */
+    toolLabel: string;
+    callCount: number;
+    /** global sequence numbers of the calls this edge represents, ascending. */
+    seqNumbers: number[];
+    /** representative execute_tool span for inspector selection. */
+    toolSpan: SpanData | null;
+    /** representative target invoke_agent span. */
+    targetSpan: SpanData;
+}
+
+/** Connects a caller run to an invoked child run. */
+export interface Handoff {
+    id: string;
+    fromRunId: string | null;
+    toRunId: string;
+    /** The intervening execute_tool span, if any. */
+    toolSpan: SpanData | null;
+    /** Target invoke_agent span (inspector fallback when no tool span). */
+    targetSpan: SpanData;
+    label: string;
+}
+
+export interface AgentFlowModel {
+    runs: AgentRun[];
+    runsById: Map<string, AgentRun>;
+    handoffs: Handoff[];
+    /** graph nodes (agent identity grouped per caller). */
+    nodes: AgentNode[];
+    nodesById: Map<string, AgentNode>;
+    /** graph edges (one per non-root node). */
+    nodeEdges: NodeEdge[];
+    /** agent name -> stable display color. */
+    agentColors: Map<string, string>;
+    /** ordered unique agent identities (first-seen order). */
+    agentNames: string[];
+    /** true when the trace has >= 2 agent invocations. */
+    isMultiAgent: boolean;
+}
+
+// The top-level agent always uses the standard agent cyan (matching invoke_agent
+// spans elsewhere in the trace UI). Kept as a theme variable for consistency.
+const ROOT_AGENT_COLOR = "var(--vscode-terminal-ansiCyan)";
+
+// Vivid, high-chroma palette for sub-agent identities. Fixed hues (not theme
+// variables) so colours stay saturated on both light and dark backgrounds, and
+// ordered so consecutive entries are from different hue families. Blue/cyan/teal
+// are excluded (reserved for the root cyan), and pure red is avoided so a colour
+// never reads as an error state — a pinkish rose is used instead.
+const SUB_AGENT_PALETTE = [
+    "#10B981", // emerald
+    "#F59E0B", // amber
+    "#A855F7", // violet
+    "#84CC16", // lime
+    "#EC4899", // pink
+    "#F97316", // orange
+    "#F43F5E", // rose (pinkish red)
+    "#D946EF", // fuchsia
+];
+
+const isInvoke = (span: SpanData): boolean => getSpanTypeBadge(span) === "invoke";
+
+const getAgentName = (span: SpanData): string => {
+    const explicit = getAttributeValue(span.attributes, "gen_ai.agent.name");
+    if (explicit) return explicit;
+    const stripped = stripSpanPrefix(span.name).trim();
+    return stripped || "Agent";
+};
+
+const getToolLabel = (span: SpanData): string => {
+    const toolName = getAttributeValue(span.attributes, "gen_ai.tool.name");
+    return (toolName || stripSpanPrefix(span.name)).trim() || "Delegate";
+};
+
+export function buildAgentFlowModel(trace: TraceData): AgentFlowModel {
+    const spans = trace?.spans ?? [];
+    const spanMap = new Map<string, SpanData>();
+    spans.forEach((s) => spanMap.set(s.spanId, s));
+
+    const isRootId = (id?: string): boolean =>
+        !id || id === ROOT_PARENT || id === "" || !spanMap.has(id);
+
+    // Walk parentSpanId chain, cycle-safe, returning ancestors nearest-first.
+    const ancestorsOf = (span: SpanData): SpanData[] => {
+        const out: SpanData[] = [];
+        const seen = new Set<string>([span.spanId]);
+        let pid = span.parentSpanId;
+        while (!isRootId(pid) && !seen.has(pid)) {
+            const parent = spanMap.get(pid)!;
+            out.push(parent);
+            seen.add(pid);
+            pid = parent.parentSpanId;
+        }
+        return out;
+    };
+
+    const invokeSpans = spans.filter(isInvoke);
+
+    // Unique agent identities in first-seen order. Colours are assigned later,
+    // once run depth (root vs sub-agent) is known.
+    const agentNames: string[] = [];
+    const seenNames = new Set<string>();
+    invokeSpans.forEach((span) => {
+        const name = getAgentName(span);
+        if (!seenNames.has(name)) {
+            seenNames.add(name);
+            agentNames.push(name);
+        }
+    });
+    const agentColors = new Map<string, string>();
+
+    const runsById = new Map<string, AgentRun>();
+
+    invokeSpans.forEach((span) => {
+        const range = getSpanTimeRange(span);
+        const name = getAgentName(span);
+        const inputTokens = parseInt(
+            getAttributeValue(span.attributes, "gen_ai.usage.input_tokens") || "0",
+            10
+        );
+        const outputTokens = parseInt(
+            getAttributeValue(span.attributes, "gen_ai.usage.output_tokens") || "0",
+            10
+        );
+        const hasError = spanHasError(span) || span.status?.code === 2;
+        const status: RunStatus = hasError
+            ? "error"
+            : !span.endTime
+                ? "running"
+                : "success";
+
+        runsById.set(span.spanId, {
+            runId: span.spanId,
+            span,
+            agentName: name,
+            depth: 0,
+            startMs: range?.start ?? null,
+            endMs: range?.end ?? null,
+            durationMs: range ? range.end - range.start : null,
+            inputTokens: Number.isFinite(inputTokens) ? inputTokens : 0,
+            outputTokens: Number.isFinite(outputTokens) ? outputTokens : 0,
+            totalTokens: 0,
+            status,
+            hasError,
+            parentRunId: null,
+            childRunIds: [],
+            internalOps: [],
+            color: ROOT_AGENT_COLOR,
+            seq: null,
+            nodeId: "",
+        });
+    });
+
+    const handoffs: Handoff[] = [];
+
+    // Wire delegation edges from parentSpanId ancestry.
+    invokeSpans.forEach((span) => {
+        const run = runsById.get(span.spanId)!;
+        let parentInvoke: SpanData | null = null;
+        let toolSpan: SpanData | null = null;
+        for (const anc of ancestorsOf(span)) {
+            if (isInvoke(anc)) {
+                parentInvoke = anc;
+                break;
+            }
+            if (!toolSpan && getSpanTypeBadge(anc) === "tool") {
+                toolSpan = anc;
+            }
+        }
+
+        run.parentRunId = parentInvoke ? parentInvoke.spanId : null;
+        if (parentInvoke) {
+            runsById.get(parentInvoke.spanId)!.childRunIds.push(span.spanId);
+        }
+
+        handoffs.push({
+            id: `handoff-${span.spanId}`,
+            fromRunId: run.parentRunId,
+            toRunId: run.runId,
+            toolSpan,
+            targetSpan: span,
+            label: toolSpan ? getToolLabel(toolSpan) : "Delegate",
+        });
+    });
+
+    // Global chronological order of all delegations (non-root runs), so callers
+    // can read the sequence across different subagents. 1-based.
+    Array.from(runsById.values())
+        .filter((r) => r.parentRunId && runsById.has(r.parentRunId))
+        .sort((a, b) => (a.startMs ?? 0) - (b.startMs ?? 0))
+        .forEach((r, i) => {
+            r.seq = i + 1;
+        });
+
+    // Map each handoff tool span -> the delegation it represents, so the caller's
+    // internal op list can mark it as a delegation (not an ordinary tool).
+    const delegationBySpanId = new Map<string, { targetAgentName: string; seq: number | null }>();
+    handoffs.forEach((h) => {
+        if (!h.toolSpan) return;
+        const childRun = runsById.get(h.toRunId);
+        delegationBySpanId.set(h.toolSpan.spanId, {
+            targetAgentName: childRun?.agentName ?? stripSpanPrefix(h.targetSpan.name),
+            seq: childRun?.seq ?? null,
+        });
+    });
+
+    // Assign each non-agent span to its closest ancestor agent run.
+    spans.forEach((span) => {
+        if (isInvoke(span)) return;
+        const owner = ancestorsOf(span).find(isInvoke);
+        if (!owner) return;
+        const range = getSpanTimeRange(span);
+        const deleg = delegationBySpanId.get(span.spanId);
+        runsById.get(owner.spanId)!.internalOps.push({
+            span,
+            kind: getSpanTypeBadge(span),
+            label: stripSpanPrefix(span.name),
+            durationMs: range ? range.end - range.start : null,
+            startMs: range?.start ?? null,
+            hasError: spanHasError(span) || span.status?.code === 2,
+            isAI: isAISpan(span),
+            isDelegation: !!deleg,
+            targetAgentName: deleg?.targetAgentName ?? null,
+            seq: deleg?.seq ?? null,
+        });
+    });
+
+    // Sort internal ops by start time; compute token totals.
+    runsById.forEach((run) => {
+        run.internalOps.sort((a, b) => (a.startMs ?? 0) - (b.startMs ?? 0));
+        run.childRunIds.sort((a, b) => {
+            const ra = runsById.get(a)?.startMs ?? 0;
+            const rb = runsById.get(b)?.startMs ?? 0;
+            return ra - rb;
+        });
+        const invokeTokens = getSpanTokens(run.span);
+        run.totalTokens = invokeTokens > 0
+            ? invokeTokens
+            : run.internalOps.reduce((sum, op) => sum + getSpanTokens(op.span), 0);
+    });
+
+    // Compute delegation depth, cycle-safe.
+    const depthOf = (runId: string, seen: Set<string>): number => {
+        const run = runsById.get(runId);
+        if (!run || !run.parentRunId || seen.has(runId)) return 0;
+        seen.add(runId);
+        return 1 + depthOf(run.parentRunId, seen);
+    };
+    runsById.forEach((run) => {
+        run.depth = depthOf(run.runId, new Set());
+    });
+
+    // Assign colours: any identity that appears as a root run is the top-level
+    // agent (cyan); the rest step through the sub-agent palette in first-seen
+    // order so distinct agents always get visually distinct hues.
+    const rootNames = new Set<string>();
+    runsById.forEach((run) => {
+        if (!run.parentRunId || !runsById.has(run.parentRunId)) rootNames.add(run.agentName);
+    });
+    let subIndex = 0;
+    agentNames.forEach((name) => {
+        if (rootNames.has(name)) {
+            agentColors.set(name, ROOT_AGENT_COLOR);
+        } else {
+            agentColors.set(name, SUB_AGENT_PALETTE[subIndex % SUB_AGENT_PALETTE.length]);
+            subIndex++;
+        }
+    });
+    runsById.forEach((run) => {
+        run.color = agentColors.get(run.agentName) || ROOT_AGENT_COLOR;
+    });
+
+    const runs = Array.from(runsById.values()).sort((a, b) => {
+        if (a.depth !== b.depth) return a.depth - b.depth;
+        return (a.startMs ?? 0) - (b.startMs ?? 0);
+    });
+
+    // Group runs into nodes: (caller node, agent name) => one node. Assign node
+    // ids parents-first so a child's node id can reference its caller's node.
+    const runsByDepth = [...runsById.values()].sort((a, b) => a.depth - b.depth);
+    const parentNodeIdOf = (run: AgentRun): string | null => {
+        if (!run.parentRunId || !runsById.has(run.parentRunId)) return null;
+        return runsById.get(run.parentRunId)!.nodeId;
+    };
+    runsByDepth.forEach((run) => {
+        const parentKey = parentNodeIdOf(run) ?? "ROOT";
+        run.nodeId = `${parentKey}::${run.agentName}`;
+    });
+
+    const nodesById = new Map<string, AgentNode>();
+    runsByDepth.forEach((run) => {
+        let node = nodesById.get(run.nodeId);
+        if (!node) {
+            node = {
+                nodeId: run.nodeId,
+                agentName: run.agentName,
+                color: run.color,
+                depth: run.depth,
+                parentNodeId: parentNodeIdOf(run),
+                childNodeIds: [],
+                runs: [],
+                callCount: 0,
+                totalDurationMs: null,
+                totalTokens: 0,
+                hasError: false,
+                status: "success",
+            };
+            nodesById.set(run.nodeId, node);
+        }
+        node.runs.push(run);
+    });
+
+    nodesById.forEach((node) => {
+        node.runs.sort((a, b) => (a.startMs ?? 0) - (b.startMs ?? 0));
+        node.callCount = node.runs.length;
+        let dur = 0;
+        let durSeen = false;
+        let running = false;
+        node.runs.forEach((r) => {
+            if (r.durationMs != null) {
+                dur += r.durationMs;
+                durSeen = true;
+            }
+            node.totalTokens += r.totalTokens;
+            if (r.hasError) node.hasError = true;
+            if (r.status === "running") running = true;
+        });
+        node.totalDurationMs = durSeen ? dur : null;
+        node.status = node.hasError ? "error" : running ? "running" : "success";
+        if (node.parentNodeId) nodesById.get(node.parentNodeId)?.childNodeIds.push(node.nodeId);
+    });
+
+    // Order children by first invocation time for a stable layout.
+    nodesById.forEach((node) => {
+        node.childNodeIds.sort((a, b) => {
+            const sa = nodesById.get(a)?.runs[0]?.startMs ?? 0;
+            const sb = nodesById.get(b)?.runs[0]?.startMs ?? 0;
+            return sa - sb;
+        });
+    });
+
+    const handoffByRun = new Map<string, Handoff>();
+    handoffs.forEach((h) => handoffByRun.set(h.toRunId, h));
+
+    const nodeEdges: NodeEdge[] = [];
+    nodesById.forEach((node) => {
+        if (!node.parentNodeId) return;
+        const rep = node.runs[0];
+        const repHandoff = handoffByRun.get(rep.runId);
+        nodeEdges.push({
+            id: `edge-${node.nodeId}`,
+            fromNodeId: node.parentNodeId,
+            toNodeId: node.nodeId,
+            toolLabel: repHandoff?.label ?? "Delegate",
+            callCount: node.callCount,
+            seqNumbers: node.runs
+                .map((r) => r.seq)
+                .filter((s): s is number => s != null)
+                .sort((a, b) => a - b),
+            toolSpan: repHandoff?.toolSpan ?? null,
+            targetSpan: rep.span,
+        });
+    });
+
+    const nodes = Array.from(nodesById.values()).sort((a, b) => {
+        if (a.depth !== b.depth) return a.depth - b.depth;
+        return (a.runs[0]?.startMs ?? 0) - (b.runs[0]?.startMs ?? 0);
+    });
+
+    return {
+        runs,
+        runsById,
+        handoffs,
+        nodes,
+        nodesById,
+        nodeEdges,
+        agentColors,
+        agentNames,
+        isMultiAgent: invokeSpans.length >= 2,
+    };
+}
+
+/** Internal ops to display: AI spans only, unless raw internal spans are shown. */
+export const visibleOps = (run: AgentRun, showInternal: boolean): InternalOp[] =>
+    showInternal ? run.internalOps : run.internalOps.filter((op) => op.isAI);
+
+/**
+ * Compact summary of a run's internal work. Delegations (agent-invoking tool
+ * calls) are counted separately from ordinary tools so they aren't conflated.
+ */
+export function summarizeInternal(run: AgentRun): string {
+    let model = 0;
+    let tools = 0;
+    let retrieval = 0;
+    let delegations = 0;
+    for (const op of run.internalOps) {
+        if (op.isDelegation) delegations++;
+        else if (op.kind === "tool") tools++;
+        else if (op.kind === "kb_retrieve" || op.kind === "kb_ingest") retrieval++;
+        else if (op.kind === "chat" || op.kind === "generate_content" || op.kind === "embeddings") model++;
+    }
+    const parts: string[] = [];
+    if (model) parts.push(`${model} model call${model > 1 ? "s" : ""}`);
+    if (delegations) parts.push(`${delegations} agent call${delegations > 1 ? "s" : ""}`);
+    if (tools) parts.push(`${tools} tool${tools > 1 ? "s" : ""}`);
+    if (retrieval) parts.push(`${retrieval} retrieval${retrieval > 1 ? "s" : ""}`);
+    return parts.join(" · ");
+}
+
+/** True when a run, its handoff tool, or an internal op matches the query. */
+export function runMatchesQuery(run: AgentRun, handoff: Handoff | undefined, query: string): boolean {
+    if (!query) return true;
+    const q = query.toLowerCase();
+    if (run.agentName.toLowerCase().includes(q)) return true;
+    if (handoff?.label.toLowerCase().includes(q)) return true;
+    return run.internalOps.some((op) => op.label.toLowerCase().includes(q));
+}
+
+/** True when any of a node's runs (or its incoming edge tool label) match the query. */
+export function nodeMatchesQuery(node: AgentNode, edge: NodeEdge | undefined, query: string): boolean {
+    if (!query) return true;
+    const q = query.toLowerCase();
+    if (node.agentName.toLowerCase().includes(q)) return true;
+    if (edge?.toolLabel.toLowerCase().includes(q)) return true;
+    return node.runs.some((r) => r.internalOps.some((op) => op.label.toLowerCase().includes(q)));
+}


### PR DESCRIPTION
## Summary

Adds an **Agent Flow** view to the Trace Visualizer for traces with two or more `invoke_agent` spans. It complements the existing tree and timeline views with a focused visualization of how agents delegate work.

https://github.com/user-attachments/assets/89b04ada-ac76-48b9-a81c-0dc6b428fc9d

## What this introduces

- A **View Agent Flow** entry point from Trace Details when a trace contains multiple agent invocations.
- A derived, UI-only agent-flow model that builds agent runs and delegation edges from `parentSpanId` ancestry.
- A graph view with agent cards, delegation/tool labels, repeated-call grouping, durations, token totals, errors, expandable operation details, and shared span inspection.
- Search, call-order replay, pan/zoom, fit/reset controls, and the existing trace export actions in the new view.
- Preservation of the existing internal-span policy: normal trace-tree views include raw/internal spans, while Agent Chat continues to respect the user preference.

The existing Tree and Timeline views remain available; Agent Flow is an additional visualization for multi-agent traces.

## Validation

- `node common/scripts/install-run-rush.js build --to @wso2/trace-visualizer`