### PR TITLE
Add a quota request flow to the usage-limit banner

### DIFF
--- a/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -43,6 +43,8 @@ import {
     CheckpointInfo,
     AbortAIGenerationRequest,
     UsageResponse,
+    QuotaRequestParams,
+    QuotaRequestResult,
     OpenFileDiffRequest,
     WebToolApprovalRequest,
     CompactConversationRequest,
@@ -142,6 +144,7 @@ export interface AIPanelAPI {
     getActiveTempDir: () => Promise<string>;
     hasPendingReview: () => Promise<boolean>;
     getUsage: () => Promise<UsageResponse | undefined>;
+    requestQuota: (params: QuotaRequestParams) => Promise<QuotaRequestResult>;
     openFileDiff: (params: OpenFileDiffRequest) => void;
     approveWebTool: (params: WebToolApprovalRequest) => Promise<void>;
     declineWebTool: (params: WebToolApprovalRequest) => Promise<void>;

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -552,6 +552,15 @@ export interface UsageResponse {
     remainingUsagePercentage: number;
     resetsIn: number; // in seconds
     orgId?: string;  // org UUID for the quota request portal link
+    alreadyRequested?: boolean;  // an open quota top-up request already exists for this cap-hit
+}
+
+export interface QuotaRequestParams {
+    note?: string;  // optional message from the user to the reviewer
+}
+
+export interface QuotaRequestResult {
+    status: "submitted" | "already_requested" | "failed";
 }
 
 export interface OpenFileDiffRequest {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -45,6 +45,8 @@ import {
     CheckpointInfo,
     AbortAIGenerationRequest,
     UsageResponse,
+    QuotaRequestParams,
+    QuotaRequestResult,
     OpenFileDiffRequest,
     WebToolApprovalRequest,
     CompactConversationRequest,
@@ -130,6 +132,7 @@ export const updateChatMessage: RequestType<UpdateChatMessageRequest, void> = { 
 export const getActiveTempDir: RequestType<void, string> = { method: `${_preFix}/getActiveTempDir` };
 export const hasPendingReview: RequestType<void, boolean> = { method: `${_preFix}/hasPendingReview` };
 export const getUsage: RequestType<void, UsageResponse | undefined> = { method: `${_preFix}/getUsage` };
+export const requestQuota: RequestType<QuotaRequestParams, QuotaRequestResult> = { method: `${_preFix}/requestQuota` };
 export const openFileDiff: NotificationType<OpenFileDiffRequest> = { method: `${_preFix}/openFileDiff` };
 export const approveWebTool: RequestType<WebToolApprovalRequest, void> = { method: `${_preFix}/approveWebTool` };
 export const declineWebTool: RequestType<WebToolApprovalRequest, void> = { method: `${_preFix}/declineWebTool` };

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -90,7 +90,9 @@ import {
     approveWebTool,
     declineWebTool,
     WebToolApprovalRequest,
+    QuotaRequestParams,
     getUsage,
+    requestQuota,
     compactConversation,
     CompactConversationRequest,
     getShowContextUsage,
@@ -200,6 +202,7 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(getActiveTempDir, () => rpcManger.getActiveTempDir());
     messenger.onRequest(hasPendingReview, () => rpcManger.hasPendingReview());
     messenger.onRequest(getUsage, () => rpcManger.getUsage());
+    messenger.onRequest(requestQuota, (args: QuotaRequestParams) => rpcManger.requestQuota(args));
     messenger.onNotification(openFileDiff, (args: OpenFileDiffRequest) => rpcManger.openFileDiff(args));
     messenger.onRequest(approveWebTool, (args: WebToolApprovalRequest) => rpcManger.approveWebTool(args));
     messenger.onRequest(declineWebTool, (args: WebToolApprovalRequest) => rpcManger.declineWebTool(args));

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -45,6 +45,8 @@ import {
     UIChatMessage,
     UpdateChatMessageRequest,
     UsageResponse,
+    QuotaRequestParams,
+    QuotaRequestResult,
     WebToolApprovalRequest,
     CompactConversationRequest,
     CompactConversationResponse,
@@ -822,6 +824,32 @@ User reverted the last made changes. The files have been restored to the state b
         } catch (error) {
             console.error("Failed to fetch usage:", error);
             return undefined;
+        }
+    }
+
+    async requestQuota(params: QuotaRequestParams): Promise<QuotaRequestResult> {
+        const loginMethod = await getLoginMethod();
+        if (loginMethod !== LoginMethod.BI_INTEL) {
+            return { status: "failed" };
+        }
+        try {
+            const email = platformExtStore.getState().state?.userInfo?.userEmail;
+            const url = BACKEND_URL + LLM_API_BASE_PATH + "/quota-requests";
+            const response = await fetchWithAuth(url, {
+                method: "POST",
+                body: JSON.stringify({ note: params.note, email }),
+            });
+            if (response?.status === 201) {
+                return { status: "submitted" };
+            }
+            if (response?.status === 409) {
+                return { status: "already_requested" };
+            }
+            console.error("Failed to submit quota request: ", response?.status, response?.statusText);
+            return { status: "failed" };
+        } catch (error) {
+            console.error("Failed to submit quota request:", error);
+            return { status: "failed" };
         }
     }
 

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -832,12 +832,19 @@ User reverted the last made changes. The files have been restored to the state b
         if (loginMethod !== LoginMethod.BI_INTEL) {
             return { status: "failed" };
         }
+        const email = platformExtStore.getState().state?.userInfo?.userEmail;
+        if (!email) {
+            console.error("Failed to submit quota request: no account email available");
+            return { status: "failed" };
+        }
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 20000);
         try {
-            const email = platformExtStore.getState().state?.userInfo?.userEmail;
             const url = BACKEND_URL + LLM_API_BASE_PATH + "/quota-requests";
             const response = await fetchWithAuth(url, {
                 method: "POST",
                 body: JSON.stringify({ note: params.note, email }),
+                signal: controller.signal,
             });
             if (response?.status === 201) {
                 return { status: "submitted" };
@@ -850,6 +857,8 @@ User reverted the last made changes. The files have been restored to the state b
         } catch (error) {
             console.error("Failed to submit quota request:", error);
             return { status: "failed" };
+        } finally {
+            clearTimeout(timeout);
         }
     }
 

--- a/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -49,6 +49,8 @@ import {
     UIChatMessage,
     UpdateChatMessageRequest,
     UsageResponse,
+    QuotaRequestParams,
+    QuotaRequestResult,
     WebToolApprovalRequest,
     ClarifyAnswerRequest,
     ClarifyCancelRequest,
@@ -104,6 +106,7 @@ import {
     updateChatMessage,
     updateRequirementSpecification,
     getUsage,
+    requestQuota,
     compactConversation,
     CompactConversationRequest,
     CompactConversationResponse,
@@ -354,6 +357,10 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     getUsage(): Promise<UsageResponse | undefined> {
         return this._messenger.sendRequest(getUsage, HOST_EXTENSION);
+    }
+
+    requestQuota(params: QuotaRequestParams): Promise<QuotaRequestResult> {
+        return this._messenger.sendRequest(requestQuota, HOST_EXTENSION, params);
     }
 
     openFileDiff(params: OpenFileDiffRequest): void {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2321,7 +2321,7 @@ const AIChat: React.FC = () => {
                                 You've reached your Integrator Copilot usage limit
                                 {usage && usage.resetsIn !== -1 ? `, which resets in ${formatResetsIn(usage.resetsIn)}` : ""}.
                                 {usage?.alreadyRequested
-                                    ? <>{" "}Your request for additional quota has been submitted. Prefer email? Reach us at <a href={`mailto:${QUOTA_CONTACT_EMAIL}`}>{QUOTA_CONTACT_EMAIL}</a>.</>
+                                    ? <>{" "}Your request for additional quota has been submitted. Reach us at <a href={`mailto:${QUOTA_CONTACT_EMAIL}`}>{QUOTA_CONTACT_EMAIL}</a>.</>
                                     : <>{" "}<a href="#" onClick={(e) => { e.preventDefault(); setShowQuotaDialog(true); }}>Request additional quota</a>.</>
                                 }
                             </span>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -88,6 +88,7 @@ import WelcomeMessage from "./Welcome";
 import { getOnboardingOpens, incrementOnboardingOpens, convertToUIMessages, isContainsSyntaxError } from "./utils/utils";
 
 import FeedbackBar from "./../FeedbackBar";
+import QuotaRequestDialog from "./../QuotaRequestDialog";
 import { useFeedback } from "./utils/useFeedback";
 import { SegmentType, splitContent } from "./segment";
 import { MigrationContextCard } from "../MigrationContextCard";
@@ -101,7 +102,6 @@ const DRIFT_CHECK_ERROR = "Failed to check drift between the code and the docume
 
 const USAGE_EXCEEDED_THRESHOLD_PERCENT = 3;
 const QUOTA_CONTACT_EMAIL = "support@wso2.com";
-const QUOTA_PORTAL_BASE_URL = "https://subscriptions.wso2.com/cloud/devant/subscriptions";
 
 //TODO: Add better error handling from backend. stream error type and non 200 status codes
 
@@ -292,8 +292,11 @@ const AIChat: React.FC = () => {
 
     const [migrationSession, setMigrationSession] = useState<ActiveMigrationSession | null>(null);
     const [isMigrationEnhancementRunning, setIsMigrationEnhancementRunning] = useState(false);
-    const [usage, setUsage] = useState<{ remainingUsagePercentage: number; resetsIn: number; orgId?: string } | null>(null);
+    const [usage, setUsage] = useState<{ remainingUsagePercentage: number; resetsIn: number; orgId?: string; alreadyRequested?: boolean } | null>(null);
     const [isUsageExceeded, setIsUsageExceeded] = useState(false);
+    const [showQuotaDialog, setShowQuotaDialog] = useState(false);
+    const [quotaRequestSubmitting, setQuotaRequestSubmitting] = useState(false);
+    const [quotaRequestError, setQuotaRequestError] = useState<string | undefined>(undefined);
     const [loginMethod, setLoginMethod] = useState<LoginMethod | null>(null);
 
     const [contextUsage, setContextUsage] = useState<{
@@ -450,6 +453,25 @@ const AIChat: React.FC = () => {
             // Reset on error to avoid permanently blocking the user on transient failures
             setUsage(null);
             setIsUsageExceeded(false);
+        }
+    };
+
+    const handleQuotaRequestSubmit = async (note: string) => {
+        setQuotaRequestSubmitting(true);
+        setQuotaRequestError(undefined);
+        try {
+            const result = await rpcClient.getAiPanelRpcClient().requestQuota({ note });
+            if (result.status === "submitted" || result.status === "already_requested") {
+                setShowQuotaDialog(false);
+                await fetchUsage();
+            } else {
+                setQuotaRequestError(`Something went wrong. Please try again or email ${QUOTA_CONTACT_EMAIL}.`);
+            }
+        } catch (e) {
+            console.error("Failed to submit quota request:", e);
+            setQuotaRequestError(`Something went wrong. Please try again or email ${QUOTA_CONTACT_EMAIL}.`);
+        } finally {
+            setQuotaRequestSubmitting(false);
         }
     };
 
@@ -2298,12 +2320,20 @@ const AIChat: React.FC = () => {
                             <span>
                                 You've reached your Integrator Copilot usage limit
                                 {usage && usage.resetsIn !== -1 ? `, which resets in ${formatResetsIn(usage.resetsIn)}` : ""}.
-                                {usage?.orgId
-                                    ? <>{" "}<a href={`${QUOTA_PORTAL_BASE_URL}?orgId=${usage.orgId}`}>Request additional quota</a>.</>
-                                    : <>{" "}Email <a href={`mailto:${QUOTA_CONTACT_EMAIL}`}>{QUOTA_CONTACT_EMAIL}</a> to request additional quota.</>
+                                {usage?.alreadyRequested
+                                    ? <>{" "}Your request for additional quota has been submitted. Prefer email? Reach us at <a href={`mailto:${QUOTA_CONTACT_EMAIL}`}>{QUOTA_CONTACT_EMAIL}</a>.</>
+                                    : <>{" "}<a href="#" onClick={(e) => { e.preventDefault(); setShowQuotaDialog(true); }}>Request additional quota</a>.</>
                                 }
                             </span>
                         </UsageLimitNoticeContainer>
+                    )}
+                    {showQuotaDialog && (
+                        <QuotaRequestDialog
+                            submitting={quotaRequestSubmitting}
+                            error={quotaRequestError}
+                            onCancel={() => { setShowQuotaDialog(false); setQuotaRequestError(undefined); }}
+                            onSubmit={handleQuotaRequestSubmit}
+                        />
                     )}
                     {(() => {
                         const lastAssistantMsg = [...otherMessages].reverse().find(m => m.role === "Copilot");

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
@@ -135,13 +135,19 @@ const QuotaRequestDialog: React.FC<QuotaRequestDialogProps> = ({ submitting, err
 
     return (
         <Overlay>
-            <DialogContainer>
-                <Title>Request additional quota</Title>
-                <Text>Let the team know you'd like more Integrator Copilot quota this week.</Text>
+            <DialogContainer
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="quota-request-title"
+                aria-describedby="quota-request-desc"
+            >
+                <Title id="quota-request-title">Request additional quota</Title>
+                <Text id="quota-request-desc">Let the team know you'd like more Integrator Copilot quota this week.</Text>
                 <TextArea
                     value={note}
                     onChange={(e) => setNote(e.target.value)}
                     placeholder="Add a message (optional)"
+                    aria-label="Message (optional)"
                     maxLength={NOTE_MAX_LENGTH}
                     autoFocus
                 />
@@ -151,7 +157,7 @@ const QuotaRequestDialog: React.FC<QuotaRequestDialogProps> = ({ submitting, err
                 <Notice>
                     Reach us at {QUOTA_CONTACT_EMAIL}.
                 </Notice>
-                {error && <ErrorText>{error}</ErrorText>}
+                {error && <ErrorText role="alert">{error}</ErrorText>}
                 <ButtonContainer>
                     <Button appearance="secondary" onClick={onCancel} disabled={submitting}>
                         Cancel

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
@@ -149,7 +149,7 @@ const QuotaRequestDialog: React.FC<QuotaRequestDialogProps> = ({ submitting, err
                     Your WSO2 account email will be included with this request so the team can follow up.
                 </Notice>
                 <Notice>
-                    Prefer email? Reach us at {QUOTA_CONTACT_EMAIL}.
+                    Reach us at {QUOTA_CONTACT_EMAIL}.
                 </Notice>
                 {error && <ErrorText>{error}</ErrorText>}
                 <ButtonContainer>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/QuotaRequestDialog/index.tsx
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import { Button } from "@wso2/ui-toolkit";
+
+const QUOTA_CONTACT_EMAIL = "support@wso2.com";
+const NOTE_MAX_LENGTH = 2000;
+
+const Overlay = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    transition: all 0.2s ease;
+`;
+
+const DialogContainer = styled.div`
+    background-color: var(--vscode-editor-background);
+    border-radius: 8px;
+    padding: 24px;
+    width: 420px;
+    max-width: 90%;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.1));
+    transition: transform 0.2s ease, opacity 0.2s ease;
+    animation: dialogFadeIn 0.2s ease;
+
+    @keyframes dialogFadeIn {
+        from {
+            opacity: 0;
+            transform: translateY(-8px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+`;
+
+const Title = styled.h3`
+    margin-top: 0;
+    margin-bottom: 16px;
+    color: var(--vscode-foreground);
+    font-weight: 500;
+    font-size: 16px;
+    letter-spacing: 0.01em;
+`;
+
+const Text = styled.p`
+    margin-bottom: 12px;
+    font-size: 14px;
+    color: var(--vscode-foreground);
+    opacity: 0.9;
+`;
+
+const TextArea = styled.textarea`
+    width: 100%;
+    height: 60px;
+    padding: 8px 10px;
+    margin-top: 10px;
+    background-color: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-focusBorder);
+    border-radius: 4px;
+    resize: vertical;
+    font-family: inherit;
+    font-size: 14px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    box-sizing: border-box;
+    box-shadow: 0 0 0 1px var(--vscode-focusBorder, transparent);
+    &:focus {
+        outline: none;
+    }
+    &::placeholder {
+        color: var(--vscode-input-placeholderForeground, rgba(255, 255, 255, 0.4));
+    }
+`;
+
+const Notice = styled.p`
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    margin-bottom: 0px;
+    margin-top: 8px;
+    opacity: 0.8;
+    line-height: 1.4;
+`;
+
+const ErrorText = styled.p`
+    font-size: 12px;
+    color: var(--vscode-errorForeground);
+    margin-top: 8px;
+    margin-bottom: 0px;
+    line-height: 1.4;
+`;
+
+const ButtonContainer = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 12px;
+`;
+
+interface QuotaRequestDialogProps {
+    submitting?: boolean;
+    error?: string;
+    onCancel: () => void;
+    onSubmit: (note: string) => void;
+}
+
+const QuotaRequestDialog: React.FC<QuotaRequestDialogProps> = ({ submitting, error, onCancel, onSubmit }) => {
+    const [note, setNote] = useState("");
+
+    return (
+        <Overlay>
+            <DialogContainer>
+                <Title>Request additional quota</Title>
+                <Text>Let the team know you'd like more Integrator Copilot quota this week.</Text>
+                <TextArea
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    placeholder="Add a message (optional)"
+                    maxLength={NOTE_MAX_LENGTH}
+                    autoFocus
+                />
+                <Notice>
+                    Your WSO2 account email will be included with this request so the team can follow up.
+                </Notice>
+                <Notice>
+                    Prefer email? Reach us at {QUOTA_CONTACT_EMAIL}.
+                </Notice>
+                {error && <ErrorText>{error}</ErrorText>}
+                <ButtonContainer>
+                    <Button appearance="secondary" onClick={onCancel} disabled={submitting}>
+                        Cancel
+                    </Button>
+                    <Button appearance="primary" onClick={() => onSubmit(note)} disabled={submitting}>
+                        {submitting ? "Submitting..." : "Submit"}
+                    </Button>
+                </ButtonContainer>
+            </DialogContainer>
+        </Overlay>
+    );
+};
+
+export default QuotaRequestDialog;


### PR DESCRIPTION
Adds an in-product way for users who hit their weekly Integrator Copilot usage limit to request additional quota, straight from the usage-limit banner — without leaving the IDE.

- Add a `requestQuota` RPC (core types + client + ai-panel manager) that POSTs the user's note and account email to the backend `/quota-requests` endpoint, and maps the response to `submitted` (201) / `already_requested` (409) / `failed`.
- Add an `alreadyRequested` field to the usage state so the banner reflects whether a request was already sent this cycle.
- Add a "Request additional quota" dialog (optional message, account-email notice, support contact) opened from the banner.
- Wire the banner to show a "Request additional quota" link before requesting, and a submitted-confirmation with support contact afterwards.

### Screenshots

**Request form + banner call-to-action**
<img width="726" height="988" alt="quota-request-form" src="https://github.com/user-attachments/assets/8a8f4f66-8c48-42c5-8260-27985b441224" />


**Banner after submitting**
<img width="714" height="206" alt="quota-request-submitted" src="https://github.com/user-attachments/assets/f48daf42-c384-4780-836b-0b7a4335060e" />
