### PR TITLE
Add adaptive grouping for AI package components

### DIFF
--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCache.java
@@ -49,7 +49,7 @@ import java.util.logging.Logger;
 class AiComponentDiskCache {
 
     private static final Logger LOGGER = Logger.getLogger(AiComponentDiskCache.class.getName());
-    private static final int SCHEMA_VERSION = 1;
+    private static final int SCHEMA_VERSION = 2;
     private static final String CACHE_DIR_NAME = "ballerina-ls-ai-component-cache";
 
     private final Path cacheDirectory;
@@ -160,7 +160,7 @@ class AiComponentDiskCache {
     }
 
     record CachedComponent(String className, String label, String description,
-                           String category, String symbol) {
+                           String category, String symbol, String icon) {
     }
 
     private record ModuleCache(int schemaVersion, List<CachedComponent> components) {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -793,13 +793,6 @@ public class AiUtils {
                 || org.toLowerCase(Locale.ROOT).contains(lowerQuery);
     }
 
-    private static String getItemLabel(Item item) {
-        if (item instanceof AvailableNode node) {
-            return node.metadata().label();
-        }
-        return ((Category) item).metadata().label();
-    }
-
     private static String getPackageDisplayLabel(String packageName) {
         int lastDot = packageName.lastIndexOf('.');
         String rawPackageName = lastDot >= 0 ? packageName.substring(lastDot + 1) : packageName;

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -38,8 +38,10 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.values.ConstantValue;
 import io.ballerina.flowmodelgenerator.core.model.AvailableNode;
+import io.ballerina.flowmodelgenerator.core.model.Category;
 import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.flowmodelgenerator.core.model.FlowNode;
+import io.ballerina.flowmodelgenerator.core.model.Item;
 import io.ballerina.flowmodelgenerator.core.model.Metadata;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
@@ -704,11 +706,99 @@ public class AiUtils {
      * label (case-insensitive).
      */
     public static boolean matchesQuery(AvailableNode node, String query) {
+        if (query == null || query.isBlank()) {
+            return true;
+        }
         String lowerQuery = query.toLowerCase(Locale.ROOT);
-        String module = node.codedata().module();
+        Codedata codedata = node.codedata();
+        String module = codedata.module();
+        String packageName = codedata.packageName();
+        String org = codedata.org();
+        String object = codedata.object();
         String label = node.metadata() != null ? node.metadata().label() : null;
+        String description = node.metadata() != null ? node.metadata().description() : null;
         return (module != null && module.toLowerCase(Locale.ROOT).contains(lowerQuery))
-                || (label != null && label.toLowerCase(Locale.ROOT).contains(lowerQuery));
+                || (packageName != null && packageName.toLowerCase(Locale.ROOT).contains(lowerQuery))
+                || (org != null && org.toLowerCase(Locale.ROOT).contains(lowerQuery))
+                || (object != null && object.toLowerCase(Locale.ROOT).contains(lowerQuery))
+                || (label != null && label.toLowerCase(Locale.ROOT).contains(lowerQuery))
+                || (description != null && description.toLowerCase(Locale.ROOT).contains(lowerQuery));
+    }
+
+    /**
+     * Builds an AI component category that keeps single-component packages as direct leaves and groups packages
+     * exposing multiple implementations of the requested component type. Grouping happens after component discovery,
+     * so every leaf retains the original codedata needed for template generation.
+     *
+     * @param categoryLabel the label of the outer AI component category
+     * @param components the discovered component implementations
+     * @param query the optional search query
+     * @return the category containing direct leaves and package groups
+     */
+    public static Category buildAdaptiveAiComponentCategory(String categoryLabel, List<AvailableNode> components,
+                                                            String query) {
+        Map<String, List<AvailableNode>> componentsByPackage = components.stream()
+                .collect(Collectors.groupingBy(node -> node.codedata().org() + ":" + node.codedata().packageName()));
+
+        List<Item> items = componentsByPackage.entrySet().stream()
+                .map(entry -> buildAdaptiveAiComponentItem(categoryLabel, entry.getValue(), query))
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(AiUtils::getItemLabel, String.CASE_INSENSITIVE_ORDER))
+                .toList();
+
+        return new Category.Builder(null).metadata().label(categoryLabel).stepOut().items(items).build();
+    }
+
+    private static Item buildAdaptiveAiComponentItem(String categoryLabel, List<AvailableNode> components,
+                                                     String query) {
+        List<AvailableNode> sortedComponents = components.stream()
+                .sorted(Comparator.comparing(node -> node.metadata().label(), String.CASE_INSENSITIVE_ORDER))
+                .toList();
+        AvailableNode firstComponent = sortedComponents.getFirst();
+
+        if (sortedComponents.size() == 1) {
+            return matchesQuery(firstComponent, query) ? firstComponent : null;
+        }
+
+        String packageName = firstComponent.codedata().packageName();
+        String groupLabel = getPackageDisplayLabel(packageName) + " " + categoryLabel;
+        boolean packageMatches = matchesQuery(groupLabel, packageName, firstComponent.codedata().org(), query);
+        List<AvailableNode> matchingComponents = packageMatches ? sortedComponents : sortedComponents.stream()
+                .filter(node -> matchesQuery(node, query))
+                .toList();
+        if (matchingComponents.isEmpty()) {
+            return null;
+        }
+
+        Metadata metadata = new Metadata.Builder<Category.Builder>(null)
+                .label(groupLabel)
+                .description(categoryLabel + " available in " + firstComponent.codedata().org() + "/" + packageName)
+                .icon(firstComponent.metadata().icon())
+                .build();
+        return new Category(metadata, new ArrayList<>(matchingComponents));
+    }
+
+    private static boolean matchesQuery(String groupLabel, String packageName, String org, String query) {
+        if (query == null || query.isBlank()) {
+            return true;
+        }
+        String lowerQuery = query.toLowerCase(Locale.ROOT);
+        return groupLabel.toLowerCase(Locale.ROOT).contains(lowerQuery)
+                || packageName.toLowerCase(Locale.ROOT).contains(lowerQuery)
+                || org.toLowerCase(Locale.ROOT).contains(lowerQuery);
+    }
+
+    private static String getItemLabel(Item item) {
+        if (item instanceof AvailableNode node) {
+            return node.metadata().label();
+        }
+        return ((Category) item).metadata().label();
+    }
+
+    private static String getPackageDisplayLabel(String packageName) {
+        int lastDot = packageName.lastIndexOf('.');
+        String rawPackageName = lastDot >= 0 ? packageName.substring(lastDot + 1) : packageName;
+        return formatProviderName(rawPackageName);
     }
 
     private static List<Module> pinUserDeclaredVersions(Project project, List<Module> modules) {
@@ -1018,16 +1108,24 @@ public class AiUtils {
 
         int lastDot = moduleName.lastIndexOf('.');
         String rawProviderName = lastDot >= 0 ? moduleName.substring(lastDot + 1) : moduleName.replaceAll("^ai", "");
-        String providerName = splitPascalCase(capitalizeFirstChar(rawProviderName));
+        String providerName = formatProviderName(rawProviderName);
         String splitClassName = splitPascalCase(className);
-        String label = (providerName + " " + splitClassName)
+        String label = normalizeProviderCasing(providerName + " " + splitClassName)
+                .trim().replaceAll("\\s+", " ");
+        return label;
+    }
+
+    private static String formatProviderName(String providerName) {
+        return normalizeProviderCasing(splitPascalCase(capitalizeFirstChar(providerName)));
+    }
+
+    private static String normalizeProviderCasing(String providerName) {
+        return providerName
                 .replaceAll("(?i)openai", "OpenAI")
                 .replaceAll("(?i)mssql", "MSSQL")
                 .replaceAll("(?i)\\bai\\b", "AI")
                 .replace("Open AI", "OpenAI")
-                .replace("Openrouter", "OpenRouter")
-                .trim().replaceAll("\\s+", " ");
-        return label;
+                .replace("Openrouter", "OpenRouter");
     }
 
     private static String splitPascalCase(String input) {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -770,10 +770,13 @@ public class AiUtils {
             return null;
         }
 
+        // The group icon is always the package icon, independent of the leaves' class-specific icons.
+        String packageIcon = CommonUtils.generateIcon(firstComponent.codedata().org(), packageName,
+                firstComponent.codedata().version());
         Metadata metadata = new Metadata.Builder<Category.Builder>(null)
                 .label(groupLabel)
                 .description(categoryLabel + " available in " + firstComponent.codedata().org() + "/" + packageName)
-                .icon(firstComponent.metadata().icon())
+                .icon(packageIcon)
                 .build();
         return new Category(metadata, new ArrayList<>(matchingComponents));
     }
@@ -1048,7 +1051,10 @@ public class AiUtils {
                 .flatMap(Documentation::description)
                 .orElse(getDefaultNodeLabel(kind, label.split(" ")[0]));
 
-        String icon = CommonUtils.generateIcon(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version());
+        // Prefer the class-specific icon from the @display annotation; fall back to the package icon.
+        String icon = getDisplayIcon(classSymbol)
+                .orElseGet(() -> CommonUtils.generateIcon(moduleInfo.org(), moduleInfo.packageName(),
+                        moduleInfo.version()));
         Metadata metadata = new Metadata.Builder<>(null).label(label).description(description).icon(icon).build();
         Codedata.Builder<Object> codedataBuilder = new Codedata.Builder<>(null).version(codedataVersion)
                 .packageName(moduleInfo.packageName()).module(moduleInfo.moduleName()).org(moduleInfo.org())
@@ -1064,7 +1070,8 @@ public class AiUtils {
 
     private static AvailableNode reconstructFromCache(AiComponentDiskCache.CachedComponent comp,
                                                       ModuleInfo moduleInfo, String codedataVersion) {
-        String icon = CommonUtils.generateIcon(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version());
+        String icon = (comp.icon() != null && !comp.icon().isEmpty()) ? comp.icon()
+                : CommonUtils.generateIcon(moduleInfo.org(), moduleInfo.packageName(), moduleInfo.version());
         Metadata metadata = new Metadata.Builder<>(null).label(comp.label()).description(comp.description())
                 .icon(icon).build();
         NodeKind kind = NodeKind.valueOf(comp.category());
@@ -1083,19 +1090,27 @@ public class AiUtils {
                                                                           AvailableNode node, NodeKind category) {
         String className = classSymbol.getName().orElse("");
         return new AiComponentDiskCache.CachedComponent(className, node.metadata().label(),
-                node.metadata().description(), category.name(), node.codedata().symbol());
+                node.metadata().description(), category.name(), node.codedata().symbol(), node.metadata().icon());
     }
 
     private static Optional<String> getDisplayLabel(ClassSymbol classSymbol) {
+        return getDisplayField(classSymbol, "label");
+    }
+
+    private static Optional<String> getDisplayIcon(ClassSymbol classSymbol) {
+        return getDisplayField(classSymbol, "iconPath");
+    }
+
+    private static Optional<String> getDisplayField(ClassSymbol classSymbol, String field) {
         return classSymbol.annotAttachments().stream()
                 .filter(a -> a.typeDescriptor().getName().map("display"::equals).orElse(false))
                 .findFirst()
                 .flatMap(AnnotationAttachmentSymbol::attachmentValue)
                 .filter(v -> v.value() instanceof Map)
-                .map(v -> ((Map<?, ?>) v.value()).get("label"))
+                .map(v -> ((Map<?, ?>) v.value()).get(field))
                 .filter(ConstantValue.class::isInstance)
                 .map(v -> ((ConstantValue) v).value().toString())
-                .filter(label -> !label.isEmpty());
+                .filter(value -> !value.isEmpty());
     }
 
     private static String buildLabel(String moduleName, String className) {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AiUtils.java
@@ -75,6 +75,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -738,12 +739,12 @@ public class AiUtils {
     public static Category buildAdaptiveAiComponentCategory(String categoryLabel, List<AvailableNode> components,
                                                             String query) {
         Map<String, List<AvailableNode>> componentsByPackage = components.stream()
-                .collect(Collectors.groupingBy(node -> node.codedata().org() + ":" + node.codedata().packageName()));
+                .collect(Collectors.groupingBy(node -> node.codedata().org() + ":" + node.codedata().packageName(),
+                        LinkedHashMap::new, Collectors.toList()));
 
         List<Item> items = componentsByPackage.entrySet().stream()
                 .map(entry -> buildAdaptiveAiComponentItem(categoryLabel, entry.getValue(), query))
                 .filter(Objects::nonNull)
-                .sorted(Comparator.comparing(AiUtils::getItemLabel, String.CASE_INSENSITIVE_ORDER))
                 .toList();
 
         return new Category.Builder(null).metadata().label(categoryLabel).stepOut().items(items).build();
@@ -751,28 +752,29 @@ public class AiUtils {
 
     private static Item buildAdaptiveAiComponentItem(String categoryLabel, List<AvailableNode> components,
                                                      String query) {
-        List<AvailableNode> sortedComponents = components.stream()
-                .sorted(Comparator.comparing(node -> node.metadata().label(), String.CASE_INSENSITIVE_ORDER))
-                .toList();
-        AvailableNode firstComponent = sortedComponents.getFirst();
+        AvailableNode firstComponent = components.getFirst();
 
-        if (sortedComponents.size() == 1) {
+        if (components.size() == 1) {
             return matchesQuery(firstComponent, query) ? firstComponent : null;
         }
 
         String packageName = firstComponent.codedata().packageName();
         String groupLabel = getPackageDisplayLabel(packageName) + " " + categoryLabel;
         boolean packageMatches = matchesQuery(groupLabel, packageName, firstComponent.codedata().org(), query);
-        List<AvailableNode> matchingComponents = packageMatches ? sortedComponents : sortedComponents.stream()
+        List<AvailableNode> matchingComponents = packageMatches ? components : components.stream()
                 .filter(node -> matchesQuery(node, query))
                 .toList();
         if (matchingComponents.isEmpty()) {
             return null;
         }
 
-        // The group icon is always the package icon, independent of the leaves' class-specific icons.
-        String packageIcon = CommonUtils.generateIcon(firstComponent.codedata().org(), packageName,
-                firstComponent.codedata().version());
+        // The group icon is the package icon when the selected version is available. For latest-version
+        // components, codedata deliberately omits the version, so retain the discovered icon instead of
+        // constructing an invalid "null" package-icon URL.
+        String packageIcon = firstComponent.codedata().version() == null
+                ? firstComponent.metadata().icon()
+                : CommonUtils.generateIcon(firstComponent.codedata().org(), packageName,
+                        firstComponent.codedata().version());
         Metadata metadata = new Metadata.Builder<Category.Builder>(null)
                 .label(groupLabel)
                 .description(categoryLabel + " available in " + firstComponent.codedata().org() + "/" + packageName)

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Category.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Category.java
@@ -77,6 +77,7 @@ public record Category(Metadata metadata, List<Item> items) implements Item {
         VECTOR_STORE("Vector Stores", "Vector stores used in the integration", null),
         DATA_LOADER("Data Loaders", "Data loaders available in the integration", null),
         CHUNKER("Chunkers", "Document chunkers available in the integration", null),
+        SHORT_TERM_MEMORY_STORE("Memory Stores", "Short-term memory stores available in the integration", null),
         AI("AI", "AI components available in the flow", null),
         WORKFLOW("Workflow", "Workflow orchestration components", null),
         BUILTIN_ACTIVITIES("Prebuilt Activities", "Prebuilt activities for common integrations",
@@ -94,6 +95,15 @@ public record Category(Metadata metadata, List<Item> items) implements Item {
             this.name = name;
             this.description = description;
             this.keywords = keywords;
+        }
+
+        /**
+         * Returns the display label for this category.
+         *
+         * @return the category display label
+         */
+        public String label() {
+            return name;
         }
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/ChunkerSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/ChunkerSearchCommand.java
@@ -29,7 +29,6 @@ import io.ballerina.tools.text.LineRange;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Handles the search command for chunkers.
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
  */
 public class ChunkerSearchCommand extends SearchCommand {
 
-    private static final String CHUNKER_LABEL = "Chunkers";
-
     public ChunkerSearchCommand(Project project, LineRange position, Map<String, String> queryMap) {
         super(project, position, queryMap);
     }
@@ -47,21 +44,13 @@ public class ChunkerSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getChunkers(project);
-        Category category = new Category.Builder(null).metadata().label(CHUNKER_LABEL)
-                .stepOut().items(List.copyOf(modelProviders)).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.CHUNKER.label(), modelProviders, null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getChunkers(project);
-        List<Item> matchingProviders = modelProviders.stream()
-                .filter(node -> AiUtils.matchesQuery(node, query))
-                .collect(Collectors.toList());
-
-        Category category = new Category.Builder(null).metadata().label(CHUNKER_LABEL)
-                .stepOut().items(matchingProviders).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.CHUNKER.label(), modelProviders, query));
     }
 
     @Override
@@ -69,4 +58,3 @@ public class ChunkerSearchCommand extends SearchCommand {
         return Collections.emptyMap();
     }
 }
-

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/DataLoaderSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/DataLoaderSearchCommand.java
@@ -29,7 +29,6 @@ import io.ballerina.tools.text.LineRange;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Handles the search command for data loaders.
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
  */
 public class DataLoaderSearchCommand extends SearchCommand {
 
-    private static final String DATA_LOADER_LABEL = "Data Loaders";
-
     public DataLoaderSearchCommand(Project project, LineRange position, Map<String, String> queryMap) {
         super(project, position, queryMap);
     }
@@ -47,21 +44,13 @@ public class DataLoaderSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getDataLoaders(project);
-        Category category = new Category.Builder(null).metadata().label(DATA_LOADER_LABEL)
-                .stepOut().items(List.copyOf(modelProviders)).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.DATA_LOADER.label(), modelProviders, null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getDataLoaders(project);
-        List<Item> matchingProviders = modelProviders.stream()
-                .filter(node -> AiUtils.matchesQuery(node, query))
-                .collect(Collectors.toList());
-
-        Category category = new Category.Builder(null).metadata().label(DATA_LOADER_LABEL)
-                .stepOut().items(matchingProviders).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.DATA_LOADER.label(), modelProviders, query));
     }
 
     @Override
@@ -69,4 +58,3 @@ public class DataLoaderSearchCommand extends SearchCommand {
         return Collections.emptyMap();
     }
 }
-

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/DataLoaderSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/DataLoaderSearchCommand.java
@@ -44,13 +44,15 @@ public class DataLoaderSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getDataLoaders(project);
-        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.DATA_LOADER.label(), modelProviders, null));
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.DATA_LOADER.label(), modelProviders,
+                null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getDataLoaders(project);
-        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.DATA_LOADER.label(), modelProviders, query));
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.DATA_LOADER.label(), modelProviders,
+                query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/EmbeddingProviderSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/EmbeddingProviderSearchCommand.java
@@ -29,7 +29,6 @@ import io.ballerina.tools.text.LineRange;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Handles the search command for embedding providers.
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
  */
 public class EmbeddingProviderSearchCommand extends SearchCommand {
 
-    private static final String EMBEDDING_PROVIDER_LABEL = "Embedding Providers";
-
     public EmbeddingProviderSearchCommand(Project project, LineRange position, Map<String, String> queryMap) {
         super(project, position, queryMap);
     }
@@ -47,21 +44,13 @@ public class EmbeddingProviderSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getEmbeddingProviders(project);
-        Category category = new Category.Builder(null).metadata().label(EMBEDDING_PROVIDER_LABEL)
-                .stepOut().items(List.copyOf(modelProviders)).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.EMBEDDING_PROVIDER.label(), modelProviders, null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getEmbeddingProviders(project);
-        List<Item> matchingProviders = modelProviders.stream()
-                .filter(node -> AiUtils.matchesQuery(node, query))
-                .collect(Collectors.toList());
-
-        Category category = new Category.Builder(null).metadata().label(EMBEDDING_PROVIDER_LABEL)
-                .stepOut().items(matchingProviders).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.EMBEDDING_PROVIDER.label(), modelProviders, query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/EmbeddingProviderSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/EmbeddingProviderSearchCommand.java
@@ -44,13 +44,15 @@ public class EmbeddingProviderSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getEmbeddingProviders(project);
-        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.EMBEDDING_PROVIDER.label(), modelProviders, null));
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.EMBEDDING_PROVIDER.label(),
+                modelProviders, null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getEmbeddingProviders(project);
-        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.EMBEDDING_PROVIDER.label(), modelProviders, query));
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.EMBEDDING_PROVIDER.label(),
+                modelProviders, query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/KnowledgeBaseSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/KnowledgeBaseSearchCommand.java
@@ -29,7 +29,6 @@ import io.ballerina.tools.text.LineRange;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Handles the search command for knowledge bases.
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
  */
 public class KnowledgeBaseSearchCommand extends SearchCommand {
 
-    private static final String KNOWLEDGE_BASE_LABEL = "Knowledge Bases";
-
     public KnowledgeBaseSearchCommand(Project project, LineRange position, Map<String, String> queryMap) {
         super(project, position, queryMap);
     }
@@ -47,21 +44,15 @@ public class KnowledgeBaseSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> knowledgeBases = AiUtils.getKnowledgeBases(project);
-        Category category = new Category.Builder(null).metadata().label(KNOWLEDGE_BASE_LABEL)
-                .stepOut().items(List.copyOf(knowledgeBases)).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.KNOWLEDGE_BASE.label(), knowledgeBases,
+                null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> knowledgeBases = AiUtils.getKnowledgeBases(project);
-        List<Item> matchingBases = knowledgeBases.stream()
-                .filter(node -> AiUtils.matchesQuery(node, query))
-                .collect(Collectors.toList());
-
-        Category category = new Category.Builder(null).metadata().label(KNOWLEDGE_BASE_LABEL)
-                .stepOut().items(matchingBases).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.KNOWLEDGE_BASE.label(), knowledgeBases,
+                query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/ModelProviderSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/ModelProviderSearchCommand.java
@@ -44,13 +44,15 @@ public class ModelProviderSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getModelProviders(project);
-        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.MODEL_PROVIDER.label(), modelProviders, null));
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.MODEL_PROVIDER.label(), modelProviders,
+                null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getModelProviders(project);
-        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.MODEL_PROVIDER.label(), modelProviders, query));
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.MODEL_PROVIDER.label(), modelProviders,
+                query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/ModelProviderSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/ModelProviderSearchCommand.java
@@ -29,7 +29,6 @@ import io.ballerina.tools.text.LineRange;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Handles the search command for model providers.
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
  */
 public class ModelProviderSearchCommand extends SearchCommand {
 
-    private static final String MODEL_PROVIDER_LABEL = "Model Providers";
-
     public ModelProviderSearchCommand(Project project, LineRange position, Map<String, String> queryMap) {
         super(project, position, queryMap);
     }
@@ -47,21 +44,13 @@ public class ModelProviderSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getModelProviders(project);
-        Category category = new Category.Builder(null).metadata().label(MODEL_PROVIDER_LABEL)
-                .stepOut().items(List.copyOf(modelProviders)).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.MODEL_PROVIDER.label(), modelProviders, null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getModelProviders(project);
-        List<Item> matchingProviders = modelProviders.stream()
-                .filter(node -> AiUtils.matchesQuery(node, query))
-                .collect(Collectors.toList());
-
-        Category category = new Category.Builder(null).metadata().label(MODEL_PROVIDER_LABEL)
-                .stepOut().items(matchingProviders).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.MODEL_PROVIDER.label(), modelProviders, query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/ShortTermMemoryStoreSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/ShortTermMemoryStoreSearchCommand.java
@@ -29,7 +29,6 @@ import io.ballerina.tools.text.LineRange;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Handles the search command for short-term memory stores.
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
  */
 public class ShortTermMemoryStoreSearchCommand extends SearchCommand {
 
-    private static final String SHORT_TERM_MEMORY_STORE_LABEL = "Memory Stores";
-
     public ShortTermMemoryStoreSearchCommand(Project project, LineRange position, Map<String, String> queryMap) {
         super(project, position, queryMap);
     }
@@ -47,21 +44,15 @@ public class ShortTermMemoryStoreSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> stores = AiUtils.getShortTermMemoryStores(project);
-        Category category = new Category.Builder(null).metadata().label(SHORT_TERM_MEMORY_STORE_LABEL)
-                .stepOut().items(List.copyOf(stores)).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.SHORT_TERM_MEMORY_STORE.label(), stores,
+                null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> stores = AiUtils.getShortTermMemoryStores(project);
-        List<Item> matchingStores = stores.stream()
-                .filter(node -> AiUtils.matchesQuery(node, query))
-                .collect(Collectors.toList());
-
-        Category category = new Category.Builder(null).metadata().label(SHORT_TERM_MEMORY_STORE_LABEL)
-                .stepOut().items(matchingStores).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.SHORT_TERM_MEMORY_STORE.label(), stores,
+                query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/VectorStoreSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/VectorStoreSearchCommand.java
@@ -29,7 +29,6 @@ import io.ballerina.tools.text.LineRange;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Handles the search command for vector stores.
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
  */
 public class VectorStoreSearchCommand extends SearchCommand {
 
-    private static final String VECTOR_STORE_LABEL = "Vector Stores";
-
     public VectorStoreSearchCommand(Project project, LineRange position, Map<String, String> queryMap) {
         super(project, position, queryMap);
     }
@@ -47,21 +44,13 @@ public class VectorStoreSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getVectorStores(project);
-        Category category = new Category.Builder(null).metadata().label(VECTOR_STORE_LABEL)
-                .stepOut().items(List.copyOf(modelProviders)).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.VECTOR_STORE.label(), modelProviders, null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getVectorStores(project);
-        List<Item> matchingProviders = modelProviders.stream()
-                .filter(node -> AiUtils.matchesQuery(node, query))
-                .collect(Collectors.toList());
-
-        Category category = new Category.Builder(null).metadata().label(VECTOR_STORE_LABEL)
-                .stepOut().items(matchingProviders).build();
-        return List.of(category);
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.VECTOR_STORE.label(), modelProviders, query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/VectorStoreSearchCommand.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/search/VectorStoreSearchCommand.java
@@ -44,13 +44,15 @@ public class VectorStoreSearchCommand extends SearchCommand {
     @Override
     protected List<Item> defaultView() {
         List<AvailableNode> modelProviders = AiUtils.getVectorStores(project);
-        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.VECTOR_STORE.label(), modelProviders, null));
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.VECTOR_STORE.label(), modelProviders,
+                null));
     }
 
     @Override
     protected List<Item> search() {
         List<AvailableNode> modelProviders = AiUtils.getVectorStores(project);
-        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.VECTOR_STORE.label(), modelProviders, query));
+        return List.of(AiUtils.buildAdaptiveAiComponentCategory(Category.Name.VECTOR_STORE.label(), modelProviders,
+                query));
     }
 
     @Override

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCacheTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiComponentDiskCacheTest.java
@@ -56,9 +56,9 @@ public class AiComponentDiskCacheTest {
     public void testRoundtrip() {
         List<CachedComponent> components = List.of(
                 new CachedComponent("OpenAiProvider", "OpenAI", "OpenAI model provider",
-                        NodeKind.MODEL_PROVIDER.name(), "init"),
+                        NodeKind.MODEL_PROVIDER.name(), "init", "https://icons.example/openai.png"),
                 new CachedComponent("PineconeStore", "Pinecone", "Pinecone vector store",
-                        NodeKind.VECTOR_STORE.name(), "init"));
+                        NodeKind.VECTOR_STORE.name(), "init", "https://icons.example/pinecone.png"));
 
         cache.save("ballerinax", "ai.openai", "1.4.0", components);
         Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.openai", "1.4.0");
@@ -86,7 +86,7 @@ public class AiComponentDiskCacheTest {
     public void testCorruptJsonReturnsEmpty() throws IOException {
         cache.save("ballerinax", "ai.corrupt", "1.0.0", List.of(
                 new CachedComponent("X", "label", "desc", NodeKind.MODEL_PROVIDER.name(),
-                        "init")));
+                        "init", "icon")));
         Files.writeString(findCacheFile(), "{ not valid json");
 
         Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.corrupt", "1.0.0");
@@ -108,7 +108,7 @@ public class AiComponentDiskCacheTest {
     public void testNullFieldInComponentRejectsFile() {
         List<CachedComponent> bad = List.of(
                 new CachedComponent(null, "label", "desc", NodeKind.MODEL_PROVIDER.name(),
-                        "init"));
+                        "init", "icon"));
         cache.save("ballerinax", "ai.nulls", "1.0.0", bad);
 
         Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.nulls", "1.0.0");
@@ -120,7 +120,7 @@ public class AiComponentDiskCacheTest {
     public void testUnknownCategoryRejectsFile() {
         List<CachedComponent> bad = List.of(
                 new CachedComponent("X", "label", "desc", "NOT_A_REAL_CATEGORY",
-                        "init"));
+                        "init", "icon"));
         cache.save("ballerinax", "ai.bogus", "1.0.0", bad);
 
         Optional<List<CachedComponent>> loaded = cache.load("ballerinax", "ai.bogus", "1.0.0");
@@ -138,7 +138,7 @@ public class AiComponentDiskCacheTest {
     public void testNullVersionBypassesSave() throws IOException {
         cache.save("ballerinax", "ai.openai", null, List.of(
                 new CachedComponent("X", "l", "d", NodeKind.MODEL_PROVIDER.name(),
-                        "init")));
+                        "init", "icon")));
 
         try (var stream = Files.list(tempDir)) {
             Assert.assertEquals(stream.count(), 0L,
@@ -154,7 +154,7 @@ public class AiComponentDiskCacheTest {
         try {
             List<CachedComponent> components = List.of(
                     new CachedComponent("X", "l", "d", NodeKind.MODEL_PROVIDER.name(),
-                            "init"));
+                            "init", "icon"));
 
             // First save fails because the cache path is a regular file — disables the cache
             blockedCache.save("ballerinax", "ai.blocked", "1.0.0", components);

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiUtilsGroupingTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiUtilsGroupingTest.java
@@ -59,11 +59,11 @@ public class AiUtilsGroupingTest {
                 List.of(openAi, azureOpenAi, azureAnthropic), null);
 
         Assert.assertEquals(category.items().size(), 2);
-        Category azure = (Category) category.items().getFirst();
+        Assert.assertSame(category.items().getFirst(), openAi);
+        Category azure = (Category) category.items().get(1);
         Assert.assertEquals(azure.metadata().label(), "Azure Model Providers");
-        Assert.assertEquals(azure.items(), List.of(azureAnthropic, azureOpenAi));
-        Assert.assertSame(((AvailableNode) azure.items().get(1)).codedata(), azureOpenAi.codedata());
-        Assert.assertSame(category.items().get(1), openAi);
+        Assert.assertEquals(azure.items(), List.of(azureOpenAi, azureAnthropic));
+        Assert.assertSame(((AvailableNode) azure.items().getFirst()).codedata(), azureOpenAi.codedata());
     }
 
     @Test(description = "Filters grouped packages by subtype and retains all children when the package matches.")
@@ -80,7 +80,17 @@ public class AiUtilsGroupingTest {
         Category packageSearch = AiUtils.buildAdaptiveAiComponentCategory("Model Providers",
                 List.of(azureOpenAi, azureAnthropic), "Azure");
         Category azureFromPackageSearch = (Category) packageSearch.items().getFirst();
-        Assert.assertEquals(azureFromPackageSearch.items(), List.of(azureAnthropic, azureOpenAi));
+        Assert.assertEquals(azureFromPackageSearch.items(), List.of(azureOpenAi, azureAnthropic));
+    }
+
+    @Test(description = "Uses a discovered icon when latest-version components omit codedata version.")
+    public void testGroupedLatestVersionComponentsKeepAValidIcon() {
+        AvailableNode first = component("First Chunker", "ai", "FirstChunker", null);
+        AvailableNode second = component("Second Chunker", "ai", "SecondChunker", null);
+
+        Category category = AiUtils.buildAdaptiveAiComponentCategory("Chunkers", List.of(first, second), null);
+
+        Assert.assertEquals(((Category) category.items().getFirst()).metadata().icon(), first.metadata().icon());
     }
 
     @Test(description = "Builds categories for every supported AI component type using the shared grouping helper.")
@@ -97,10 +107,14 @@ public class AiUtilsGroupingTest {
     }
 
     private static AvailableNode component(String label, String packageName, String object) {
+        return component(label, packageName, object, "1.0.0");
+    }
+
+    private static AvailableNode component(String label, String packageName, String object, String version) {
         return new AvailableNode(
                 new Metadata(label, label + " description", null, "icon-" + packageName, null, null, null),
                 new Codedata(NodeKind.MODEL_PROVIDER, "ballerinax", packageName, packageName, object, "init",
-                        "1.0.0", null, null, null, null, null, false, false, null, null),
+                        version, null, null, null, null, null, false, false, null, null),
                 true);
     }
 }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiUtilsGroupingTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/AiUtilsGroupingTest.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import io.ballerina.flowmodelgenerator.core.model.AvailableNode;
+import io.ballerina.flowmodelgenerator.core.model.Category;
+import io.ballerina.flowmodelgenerator.core.model.Codedata;
+import io.ballerina.flowmodelgenerator.core.model.Metadata;
+import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Tests adaptive package grouping for AI component search results.
+ *
+ * @since 1.8.0
+ */
+public class AiUtilsGroupingTest {
+
+    private static final List<String> AI_COMPONENT_CATEGORY_LABELS = List.of(
+            "Model Providers", "Embedding Providers", "Vector Stores", "Chunkers", "Data Loaders",
+            "Memory Stores", "Knowledge Bases");
+
+    @Test(description = "Keeps packages with a single component as direct selectable leaves.")
+    public void testSingleComponentPackageRemainsFlat() {
+        AvailableNode openAi = component("OpenAI Model Provider", "ai.openai", "OpenAiModelProvider");
+
+        Category category = AiUtils.buildAdaptiveAiComponentCategory("Model Providers", List.of(openAi), null);
+
+        Assert.assertEquals(category.items(), List.of(openAi));
+    }
+
+    @Test(description = "Groups multiple implementations from one package while preserving leaf codedata.")
+    public void testMultiComponentPackageIsGrouped() {
+        AvailableNode openAi = component("OpenAI Model Provider", "ai.openai", "OpenAiModelProvider");
+        AvailableNode azureOpenAi = component("Azure OpenAI Model Provider", "ai.azure", "AzureOpenAiModelProvider");
+        AvailableNode azureAnthropic = component("Azure Anthropic Model Provider", "ai.azure",
+                "AzureAnthropicModelProvider");
+
+        Category category = AiUtils.buildAdaptiveAiComponentCategory("Model Providers",
+                List.of(openAi, azureOpenAi, azureAnthropic), null);
+
+        Assert.assertEquals(category.items().size(), 2);
+        Category azure = (Category) category.items().getFirst();
+        Assert.assertEquals(azure.metadata().label(), "Azure Model Providers");
+        Assert.assertEquals(azure.items(), List.of(azureAnthropic, azureOpenAi));
+        Assert.assertSame(((AvailableNode) azure.items().get(1)).codedata(), azureOpenAi.codedata());
+        Assert.assertSame(category.items().get(1), openAi);
+    }
+
+    @Test(description = "Filters grouped packages by subtype and retains all children when the package matches.")
+    public void testGroupedPackageSearch() {
+        AvailableNode azureOpenAi = component("Azure OpenAI Model Provider", "ai.azure", "AzureOpenAiModelProvider");
+        AvailableNode azureAnthropic = component("Azure Anthropic Model Provider", "ai.azure",
+                "AzureAnthropicModelProvider");
+
+        Category subtypeSearch = AiUtils.buildAdaptiveAiComponentCategory("Model Providers",
+                List.of(azureOpenAi, azureAnthropic), "Anthropic");
+        Category azureFromSubtypeSearch = (Category) subtypeSearch.items().getFirst();
+        Assert.assertEquals(azureFromSubtypeSearch.items(), List.of(azureAnthropic));
+
+        Category packageSearch = AiUtils.buildAdaptiveAiComponentCategory("Model Providers",
+                List.of(azureOpenAi, azureAnthropic), "Azure");
+        Category azureFromPackageSearch = (Category) packageSearch.items().getFirst();
+        Assert.assertEquals(azureFromPackageSearch.items(), List.of(azureAnthropic, azureOpenAi));
+    }
+
+    @Test(description = "Builds categories for every supported AI component type using the shared grouping helper.")
+    public void testAllAiComponentCategoriesUseSharedGrouping() {
+        List<AvailableNode> components = List.of(
+                component("Azure First", "ai.azure", "AzureFirst"),
+                component("Azure Second", "ai.azure", "AzureSecond"));
+
+        for (String categoryLabel : AI_COMPONENT_CATEGORY_LABELS) {
+            Category category = AiUtils.buildAdaptiveAiComponentCategory(categoryLabel, components, null);
+            Assert.assertEquals(category.metadata().label(), categoryLabel);
+            Assert.assertTrue(category.items().getFirst() instanceof Category);
+        }
+    }
+
+    private static AvailableNode component(String label, String packageName, String object) {
+        return new AvailableNode(
+                new Metadata(label, label + " description", null, "icon-" + packageName, null, null, null),
+                new Codedata(NodeKind.MODEL_PROVIDER, "ballerinax", packageName, packageName, object, "init",
+                        "1.0.0", null, null, null, null, null, false, false, null, null),
+                true);
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
@@ -4,6 +4,7 @@
     <test name="flow-model-generator-core-tests">
         <classes>
             <class name="io.ballerina.flowmodelgenerator.core.AiComponentDiskCacheTest"/>
+            <class name="io.ballerina.flowmodelgenerator.core.AiUtilsGroupingTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.ConnectionActionProviderTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.DiagnosticHandlerTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.service.ServiceIndexLoaderTest"/>

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/chunker_manager/config/chunkers.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/chunker_manager/config/chunkers.json
@@ -9,6 +9,13 @@
         "items": [
           {
             "metadata": {
+              "label": "AI Chunkers",
+              "description": "Chunkers available in ballerina/ai",
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.12.0.png"
+            },
+            "items": [
+          {
+            "metadata": {
               "label": "Generic Recursive Chunker",
               "description": "Represents a Genereric document chunker.\nProvides functionality to recursively chunk a text document using a configurable strategy.\n\nThe chunking process begins with the specified strategy and recursively falls back to\nfiner-grained strategies if the content exceeds the configured `maxChunkSize`. Overlapping content\nbetween chunks can be controlled using `maxOverlapSize`.",
               "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.12.0.png"
@@ -54,6 +61,8 @@
               "symbol": "init"
             },
             "enabled": true
+          }
+            ]
           }
         ]
       }

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/chunker_manager/config/chunkers_with_existing_ai.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/chunker_manager/config/chunkers_with_existing_ai.json
@@ -9,6 +9,13 @@
         "items": [
           {
             "metadata": {
+              "label": "AI Chunkers",
+              "description": "Chunkers available in ballerina/ai",
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.3.0.png"
+            },
+            "items": [
+          {
+            "metadata": {
               "label": "Generic Recursive Chunker",
               "description": "Represents a Genereric document chunker.\nProvides functionality to recursively chunk a text document using a configurable strategy.\n\nThe chunking process begins with the specified strategy and recursively falls back to\nfiner-grained strategies if the content exceeds the configured `maxChunkSize`. Overlapping content\nbetween chunks can be controlled using `maxOverlapSize`.",
               "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_ai_1.3.0.png"
@@ -40,6 +47,8 @@
               "version": "1.3.0"
             },
             "enabled": true
+          }
+            ]
           },
           {
             "metadata": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/embedding_providers_search_openai.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/embedding_provider_manager/config/embedding_providers_search_openai.json
@@ -10,6 +10,22 @@
         "items": [
           {
             "metadata": {
+              "label": "Azure Embedding Provider",
+              "description": "EmbeddingProvider provides an interface for interacting with Azure OpenAI Embedding Models.",
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.azure_1.4.4.png"
+            },
+            "codedata": {
+              "node": "EMBEDDING_PROVIDER",
+              "org": "ballerinax",
+              "module": "ai.azure",
+              "packageName": "ai.azure",
+              "object": "EmbeddingProvider",
+              "symbol": "init"
+            },
+            "enabled": true
+          },
+          {
+            "metadata": {
               "label": "OpenAI Embedding Provider",
               "description": "EmbeddingProvider provides an interface for interacting with OpenAI Embedding Models.",
               "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.openai_1.3.5.png"
@@ -19,6 +35,22 @@
               "org": "ballerinax",
               "module": "ai.openai",
               "packageName": "ai.openai",
+              "object": "EmbeddingProvider",
+              "symbol": "init"
+            },
+            "enabled": true
+          },
+          {
+            "metadata": {
+              "label": "OpenRouter Embedding Provider",
+              "description": "EmbeddingProvider is a client class that provides an interface for generating\nvector embeddings via the OpenRouter unified API, which supports embedding models\nfrom OpenAI, Google, Mistral, and other providers.",
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.openrouter_1.0.2.png"
+            },
+            "codedata": {
+              "node": "EMBEDDING_PROVIDER",
+              "org": "ballerinax",
+              "module": "ai.openrouter",
+              "packageName": "ai.openrouter",
               "object": "EmbeddingProvider",
               "symbol": "init"
             },

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/model_provider_manager/config/model_providers_search_deepseek.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/model_provider_manager/config/model_providers_search_deepseek.json
@@ -23,6 +23,22 @@
               "symbol": "init"
             },
             "enabled": true
+          },
+          {
+            "metadata": {
+              "label": "Google Vertex Model Provider",
+              "description": "ModelProvider is a client class that provides an interface for interacting with\nmodels hosted on Google Vertex AI, including Google Gemini models and partner\nmodels (Anthropic Claude, Mistral) available through Vertex AI Model Garden.\n\nThe `model` parameter uses `\"publisher/model-name\"` format, which determines both\nthe endpoint path and the wire format used for requests:\n- `\"google/gemini-2.0-flash\"` — Vertex AI `generateContent` API\n- `\"anthropic/claude-sonnet-4-6\"` — Anthropic Messages API via `rawPredict`\n- `\"mistralai/mistral-medium-3\"` — OpenAI-compatible format via `rawPredict`\n- `\"meta/llama-4-maverick-17b-128e-instruct-maas\"` — OpenAI-compatible open-models endpoint\n- `\"deepseek-ai/deepseek-v3-0324\"` — OpenAI-compatible open-models endpoint\n- `\"qwen/qwen3-235b-a22b\"` — OpenAI-compatible open-models endpoint\n- `\"kimi/kimi-k2\"` — OpenAI-compatible open-models endpoint\n- `\"minimax/minimax-m2\"` — OpenAI-compatible open-models endpoint",
+              "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_ai.googleapis.vertex_1.0.2.png"
+            },
+            "codedata": {
+              "node": "MODEL_PROVIDER",
+              "org": "ballerinax",
+              "module": "ai.googleapis.vertex",
+              "packageName": "ai.googleapis.vertex",
+              "object": "ModelProvider",
+              "symbol": "init"
+            },
+            "enabled": true
           }
         ]
       }

--- a/packages/ballerina-side-panel/src/components/CardList/index.tsx
+++ b/packages/ballerina-side-panel/src/components/CardList/index.tsx
@@ -506,6 +506,14 @@ function CardList(props: CardListProps) {
                         key={node.id + index}
                         enabled={node.enabled}
                         onClick={() => node.enabled !== false && handleCardClick(node)}
+                        onKeyDown={(event) => {
+                            if (node.enabled !== false && (event.key === "Enter" || event.key === " ")) {
+                                event.preventDefault();
+                                handleCardClick(node);
+                            }
+                        }}
+                        role="button"
+                        tabIndex={node.enabled !== false ? 0 : -1}
                         title={node.description}
                     >
                         <S.ChildIcon>

--- a/packages/ballerina-side-panel/src/components/CardList/index.tsx
+++ b/packages/ballerina-side-panel/src/components/CardList/index.tsx
@@ -393,14 +393,22 @@ export interface CardListProps {
     onSearch?: (text: string) => void;
     onBack?: () => void;
     onClose?: () => void;
+    // Supply both to keep a group expanded across view switches (e.g. returning from a form).
+    expandedGroupId?: string | null;
+    onExpandedGroupChange?: (groupId: string | null) => void;
 }
 
 function CardList(props: CardListProps) {
-    const { categories, title, searchPlaceholder, onSelect, onSearch, onBack, onClose } = props;
+    const { categories, title, searchPlaceholder, onSelect, onSearch, onBack, onClose,
+        expandedGroupId: controlledExpandedGroupId, onExpandedGroupChange } = props;
 
     const [searchText, setSearchText] = useState<string>("");
     const [isSearching, setIsSearching] = useState(false);
-    const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
+    const [localExpandedGroupId, setLocalExpandedGroupId] = useState<string | null>(null);
+
+    const isControlled = onExpandedGroupChange !== undefined;
+    const expandedGroupId = isControlled ? controlledExpandedGroupId ?? null : localExpandedGroupId;
+    const setExpandedGroupId = isControlled ? onExpandedGroupChange : setLocalExpandedGroupId;
 
     useEffect(() => {
         if (onSearch) {
@@ -427,7 +435,9 @@ function CardList(props: CardListProps) {
     }, [categories]);
 
     useEffect(() => {
-        setExpandedGroupId(null);
+        if (!isControlled) {
+            setLocalExpandedGroupId(null);
+        }
     }, [categories]);
 
     const handleCardClick = (node: Node) => {
@@ -438,7 +448,7 @@ function CardList(props: CardListProps) {
 
     const handleGroupClick = (category: Category) => {
         const groupId = getGroupId(category);
-        setExpandedGroupId((expandedId) => (expandedId === groupId ? null : groupId));
+        setExpandedGroupId(expandedGroupId === groupId ? null : groupId);
     };
 
     // Filter items based on search text (only if no onSearch prop - local filtering)

--- a/packages/ballerina-side-panel/src/components/CardList/index.tsx
+++ b/packages/ballerina-side-panel/src/components/CardList/index.tsx
@@ -87,6 +87,8 @@ namespace S {
         transition: all 0.2s ease;
         background-color: ${ThemeColors.SURFACE};
         min-height: 60px;
+        user-select: none;
+        -webkit-user-select: none;
 
         ${({ enabled }) => !enabled && "opacity: 0.5;"}
 
@@ -159,6 +161,8 @@ namespace S {
         border-radius: 8px;
         background-color: ${ThemeColors.SURFACE};
         overflow: hidden;
+        user-select: none;
+        -webkit-user-select: none;
         transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 
         ${({ expanded }) => expanded && `box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);`}
@@ -184,6 +188,15 @@ namespace S {
         min-height: 60px;
         cursor: pointer;
         background-color: transparent;
+
+        &:focus {
+            outline: none;
+        }
+
+        &:focus-visible {
+            outline: 1px solid var(--vscode-focusBorder, ${ThemeColors.PRIMARY});
+            outline-offset: -2px;
+        }
     `;
 
     export const CountPill = styled.span`
@@ -232,8 +245,8 @@ namespace S {
         display: flex;
         flex-direction: row;
         align-items: center;
-        gap: 10px;
-        padding: 12px 20px;
+        gap: 15px;
+        padding: 12px 16px;
         cursor: ${({ enabled }) => (enabled ? "pointer" : "not-allowed")};
         transition: background-color 0.15s ease;
 
@@ -247,6 +260,51 @@ namespace S {
             ${({ enabled }) =>
             enabled !== false &&
             `background-color: var(--vscode-list-hoverBackground, ${ThemeColors.SURFACE_CONTAINER});`}
+        }
+    `;
+
+    export const ChildIcon = styled.div`
+        position: relative;
+        display: flex;
+        align-items: flex-start;
+        justify-content: flex-start;
+        width: 28px;
+        height: 28px;
+        flex-shrink: 0;
+    `;
+
+    export const ChildIconMain = styled.div`
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        & svg,
+        & img {
+            width: 18px !important;
+            height: 18px !important;
+            border-radius: 3px;
+        }
+    `;
+
+    export const ChildIconBadge = styled.div`
+        position: absolute;
+        right: -3px;
+        bottom: -3px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        border-radius: 4px;
+        overflow: hidden;
+        background-color: ${ThemeColors.SURFACE};
+        box-shadow: 0 0 0 1px ${ThemeColors.OUTLINE_VARIANT};
+
+        & svg,
+        & img {
+            width: 12px !important;
+            height: 12px !important;
+            border-radius: 2px;
         }
     `;
 
@@ -423,11 +481,11 @@ function CardList(props: CardListProps) {
             .filter(Boolean) as Item[];
     };
 
-    const renderGroupChildren = (items: Item[]) => {
+    const renderGroupChildren = (items: Item[], groupIcon?: JSX.Element) => {
         return items
             .filter((item): item is Node | Category => item != null)
             .map((item, index) => {
-                // Nested categories are not expected inside a group, but fall back gracefully.
+                // Not expected inside a group, but fall back gracefully.
                 if ("items" in item && "title" in item) {
                     return <React.Fragment key={item.title + index}>{renderCards([item])}</React.Fragment>;
                 }
@@ -440,6 +498,10 @@ function CardList(props: CardListProps) {
                         onClick={() => node.enabled !== false && handleCardClick(node)}
                         title={node.description}
                     >
+                        <S.ChildIcon>
+                            <S.ChildIconMain>{groupIcon ? groupIcon : node.icon ? node.icon : <LogIcon />}</S.ChildIconMain>
+                            {groupIcon && node.icon && <S.ChildIconBadge>{node.icon}</S.ChildIconBadge>}
+                        </S.ChildIcon>
                         <S.ChildContent>
                             <S.ChildTitle>{node.label}</S.ChildTitle>
                             {node.description && <S.ChildDescription>{node.description}</S.ChildDescription>}
@@ -515,7 +577,7 @@ function CardList(props: CardListProps) {
                             </S.GroupHeader>
                             {isExpanded && (
                                 <S.GroupBody id={groupChildrenId}>
-                                    {renderGroupChildren(category.items)}
+                                    {renderGroupChildren(category.items, category.icon)}
                                 </S.GroupBody>
                             )}
                         </S.GroupContainer>

--- a/packages/ballerina-side-panel/src/components/CardList/index.tsx
+++ b/packages/ballerina-side-panel/src/components/CardList/index.tsx
@@ -152,6 +152,13 @@ namespace S {
         overflow: hidden;
     `;
 
+    export const GroupIndicator = styled.div`
+        color: ${ThemeColors.ON_SURFACE_VARIANT};
+        font-size: 24px;
+        line-height: 1;
+        flex-shrink: 0;
+    `;
+
     export const Row = styled.div<{}>`
         display: flex;
         flex-direction: row;
@@ -218,6 +225,7 @@ function CardList(props: CardListProps) {
 
     const [searchText, setSearchText] = useState<string>("");
     const [isSearching, setIsSearching] = useState(false);
+    const [categoryPath, setCategoryPath] = useState<Category[]>([]);
 
     useEffect(() => {
         if (onSearch) {
@@ -237,14 +245,31 @@ function CardList(props: CardListProps) {
 
     const handleOnSearch = (text: string) => {
         setSearchText(text);
+        setCategoryPath([]);
     };
 
     useEffect(() => {
         setIsSearching(false);
     }, [categories]);
 
+    useEffect(() => {
+        setCategoryPath([]);
+    }, [categories]);
+
     const handleCardClick = (node: Node) => {
         onSelect(node.id, { node: node.metadata });
+    };
+
+    const handleGroupClick = (category: Category) => {
+        setCategoryPath((path) => [...path, category]);
+    };
+
+    const handleBack = () => {
+        if (categoryPath.length > 0) {
+            setCategoryPath((path) => path.slice(0, -1));
+            return;
+        }
+        onBack?.();
     };
 
     // Filter items based on search text (only if no onSearch prop - local filtering)
@@ -264,7 +289,7 @@ function CardList(props: CardListProps) {
                     if (categoryMatches || filteredItems.length > 0) {
                         return {
                             ...item,
-                            items: filteredItems,
+                            items: categoryMatches ? item.items : filteredItems,
                         };
                     }
                     return null;
@@ -288,9 +313,11 @@ function CardList(props: CardListProps) {
     };
 
     const renderCards = (items: Item[]) => {
-        const nodes = items.filter((item): item is Node => item != null && "id" in item && "label" in item);
+        const cards = items.filter((item): item is Node | Category => item != null && (
+            ("id" in item && "label" in item) || ("items" in item && "title" in item)
+        ));
 
-        if (nodes.length === 0) {
+        if (cards.length === 0) {
             return (
                 <S.EmptyState>
                     <S.EmptyStateText>No items found</S.EmptyStateText>
@@ -301,15 +328,37 @@ function CardList(props: CardListProps) {
 
         return (
             <S.CardsContainer>
-                {nodes.map((node, index) => (
-                    <S.Card key={node.id + index} enabled={node.enabled} onClick={() => handleCardClick(node)} title={node.description}>
-                        <S.CardIcon>{node.icon ? node.icon : <LogIcon />}</S.CardIcon>
-                        <S.CardContent>
-                            <S.CardTitle>{node.label}</S.CardTitle>
-                            {node.description && <S.CardDescription>{node.description}</S.CardDescription>}
-                        </S.CardContent>
-                    </S.Card>
-                ))}
+                {cards.map((item, index) => {
+                    if ("id" in item && "label" in item) {
+                        const node = item as Node;
+                        return (
+                            <S.Card key={node.id + index} enabled={node.enabled} onClick={() => handleCardClick(node)} title={node.description}>
+                                <S.CardIcon>{node.icon ? node.icon : <LogIcon />}</S.CardIcon>
+                                <S.CardContent>
+                                    <S.CardTitle>{node.label}</S.CardTitle>
+                                    {node.description && <S.CardDescription>{node.description}</S.CardDescription>}
+                                </S.CardContent>
+                            </S.Card>
+                        );
+                    }
+
+                    const category = item as Category;
+                    const itemCount = category.items.length;
+                    const countLabel = `${itemCount} ${itemCount === 1 ? "option" : "options"}`;
+                    const description = category.description
+                        ? `${countLabel} · ${category.description}`
+                        : countLabel;
+                    return (
+                        <S.Card key={category.title + index} enabled={true} onClick={() => handleGroupClick(category)} title={category.description}>
+                            <S.CardIcon>{category.icon ? category.icon : <LogIcon />}</S.CardIcon>
+                            <S.CardContent>
+                                <S.CardTitle>{category.title}</S.CardTitle>
+                                <S.CardDescription>{description}</S.CardDescription>
+                            </S.CardContent>
+                            <S.GroupIndicator aria-hidden="true">›</S.GroupIndicator>
+                        </S.Card>
+                    );
+                })}
             </S.CardsContainer>
         );
     };
@@ -324,19 +373,23 @@ function CardList(props: CardListProps) {
               return category;
           });
 
-    const hasContent = filteredCategories.some((category) => category?.items && category.items.length > 0);
-    const shouldShowHeaderActions = (onBack && title) || onClose;
+    const activeCategory = categoryPath.at(-1);
+    const visibleCategories = activeCategory ? [activeCategory] : filteredCategories;
+    const hasContent = visibleCategories.some((category) => category?.items && category.items.length > 0);
+    const headerTitle = activeCategory?.title || title;
+    const canGoBack = categoryPath.length > 0 || Boolean(onBack);
+    const shouldShowHeaderActions = (canGoBack && headerTitle) || onClose;
     return (
         <S.Container>
             <S.HeaderContainer>
                 {shouldShowHeaderActions && (
                     <S.Row>
-                        {onBack && title && (
+                        {canGoBack && headerTitle && (
                             <S.LeftAlignRow>
-                                <S.BackButton appearance="icon" onClick={onBack}>
+                                <S.BackButton appearance="icon" onClick={handleBack}>
                                     <BackIcon />
                                 </S.BackButton>
-                                {title}
+                                {headerTitle}
                             </S.LeftAlignRow>
                         )}
                         {onClose && (
@@ -373,7 +426,7 @@ function CardList(props: CardListProps) {
                             <S.EmptyStateSubText>Try adjusting your search terms</S.EmptyStateSubText>
                         </S.EmptyState>
                     ) : (
-                        filteredCategories.map((category, index) => {
+                        visibleCategories.map((category, index) => {
                             if (!category?.items || category.items.length === 0) {
                                 return null;
                             }

--- a/packages/ballerina-side-panel/src/components/CardList/index.tsx
+++ b/packages/ballerina-side-panel/src/components/CardList/index.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { Button, ProgressRing, SearchBox, SidePanelBody, ThemeColors } from "@wso2/ui-toolkit";
+import { Button, Codicon, ProgressRing, SearchBox, SidePanelBody, ThemeColors } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
 import { BackIcon, CloseIcon, LogIcon } from "../../resources";
 import { Category, Item, Node } from "../NodeList/types";
@@ -92,8 +92,8 @@ namespace S {
 
         &:hover {
             ${({ enabled }) =>
-                enabled &&
-                `
+            enabled &&
+            `
                 background-color: ${ThemeColors.PRIMARY_CONTAINER};
                 border: 1px solid ${ThemeColors.PRIMARY};
                 transform: translateY(-1px);
@@ -152,11 +152,128 @@ namespace S {
         overflow: hidden;
     `;
 
-    export const GroupIndicator = styled.div`
-        color: ${ThemeColors.ON_SURFACE_VARIANT};
-        font-size: 24px;
-        line-height: 1;
+    export const GroupContainer = styled.div<{ expanded?: boolean }>`
+        display: flex;
+        flex-direction: column;
+        border: 1px solid ${({ expanded }) => (expanded ? ThemeColors.PRIMARY : ThemeColors.OUTLINE_VARIANT)};
+        border-radius: 8px;
+        background-color: ${ThemeColors.SURFACE};
+        overflow: hidden;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+
+        ${({ expanded }) => expanded && `box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);`}
+
+        ${({ expanded }) =>
+            !expanded &&
+            `
+            &:hover {
+                background-color: ${ThemeColors.PRIMARY_CONTAINER};
+                border-color: ${ThemeColors.PRIMARY};
+                transform: translateY(-1px);
+                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+            }
+        `}
+    `;
+
+    export const GroupHeader = styled.div`
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 12px;
+        padding: 12px;
+        min-height: 60px;
+        cursor: pointer;
+        background-color: transparent;
+    `;
+
+    export const CountPill = styled.span`
         flex-shrink: 0;
+        font-size: 11px;
+        font-weight: 500;
+        line-height: 1;
+        padding: 3px 8px;
+        border-radius: 999px;
+        color: ${ThemeColors.ON_SURFACE_VARIANT};
+        background-color: ${ThemeColors.SURFACE_CONTAINER};
+        border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+        white-space: nowrap;
+    `;
+
+    export const ChevronWrapper = styled.div<{ expanded?: boolean }>`
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        color: ${ThemeColors.ON_SURFACE_VARIANT};
+        transition: transform 0.2s ease;
+        transform: rotate(${({ expanded }) => (expanded ? "180deg" : "0deg")});
+    `;
+
+    export const GroupBody = styled.div`
+        display: flex;
+        flex-direction: column;
+        border-top: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+        background-color: ${ThemeColors.SURFACE_DIM};
+        animation: groupBodyIn 0.18s ease;
+
+        @keyframes groupBodyIn {
+            from {
+                opacity: 0;
+                transform: translateY(-4px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+    `;
+
+    export const ChildCard = styled.div<{ enabled?: boolean }>`
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 10px;
+        padding: 12px 20px;
+        cursor: ${({ enabled }) => (enabled ? "pointer" : "not-allowed")};
+        transition: background-color 0.15s ease;
+
+        &:not(:last-child) {
+            border-bottom: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+        }
+
+        ${({ enabled }) => enabled === false && "opacity: 0.5;"}
+
+        &:hover {
+            ${({ enabled }) =>
+            enabled !== false &&
+            `background-color: var(--vscode-list-hoverBackground, ${ThemeColors.SURFACE_CONTAINER});`}
+        }
+    `;
+
+    export const ChildContent = styled.div`
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        min-width: 0;
+    `;
+
+    export const ChildTitle = styled.div`
+        font-size: 13px;
+        font-weight: 600;
+        color: ${ThemeColors.ON_SURFACE};
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    `;
+
+    export const ChildDescription = styled.div`
+        font-size: 12px;
+        color: ${ThemeColors.ON_SURFACE_VARIANT};
+        opacity: 0.8;
+        margin-top: 2px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     `;
 
     export const Row = styled.div<{}>`
@@ -225,7 +342,7 @@ function CardList(props: CardListProps) {
 
     const [searchText, setSearchText] = useState<string>("");
     const [isSearching, setIsSearching] = useState(false);
-    const [categoryPath, setCategoryPath] = useState<Category[]>([]);
+    const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
 
     useEffect(() => {
         if (onSearch) {
@@ -245,7 +362,6 @@ function CardList(props: CardListProps) {
 
     const handleOnSearch = (text: string) => {
         setSearchText(text);
-        setCategoryPath([]);
     };
 
     useEffect(() => {
@@ -253,23 +369,18 @@ function CardList(props: CardListProps) {
     }, [categories]);
 
     useEffect(() => {
-        setCategoryPath([]);
+        setExpandedGroupId(null);
     }, [categories]);
 
     const handleCardClick = (node: Node) => {
         onSelect(node.id, { node: node.metadata });
     };
 
-    const handleGroupClick = (category: Category) => {
-        setCategoryPath((path) => [...path, category]);
-    };
+    const getGroupId = (category: Category) => `${category.title}:${category.description}`;
 
-    const handleBack = () => {
-        if (categoryPath.length > 0) {
-            setCategoryPath((path) => path.slice(0, -1));
-            return;
-        }
-        onBack?.();
+    const handleGroupClick = (category: Category) => {
+        const groupId = getGroupId(category);
+        setExpandedGroupId((expandedId) => (expandedId === groupId ? null : groupId));
     };
 
     // Filter items based on search text (only if no onSearch prop - local filtering)
@@ -312,6 +423,32 @@ function CardList(props: CardListProps) {
             .filter(Boolean) as Item[];
     };
 
+    const renderGroupChildren = (items: Item[]) => {
+        return items
+            .filter((item): item is Node | Category => item != null)
+            .map((item, index) => {
+                // Nested categories are not expected inside a group, but fall back gracefully.
+                if ("items" in item && "title" in item) {
+                    return <React.Fragment key={item.title + index}>{renderCards([item])}</React.Fragment>;
+                }
+
+                const node = item as Node;
+                return (
+                    <S.ChildCard
+                        key={node.id + index}
+                        enabled={node.enabled}
+                        onClick={() => node.enabled !== false && handleCardClick(node)}
+                        title={node.description}
+                    >
+                        <S.ChildContent>
+                            <S.ChildTitle>{node.label}</S.ChildTitle>
+                            {node.description && <S.ChildDescription>{node.description}</S.ChildDescription>}
+                        </S.ChildContent>
+                    </S.ChildCard>
+                );
+            });
+    };
+
     const renderCards = (items: Item[]) => {
         const cards = items.filter((item): item is Node | Category => item != null && (
             ("id" in item && "label" in item) || ("items" in item && "title" in item)
@@ -345,18 +482,43 @@ function CardList(props: CardListProps) {
                     const category = item as Category;
                     const itemCount = category.items.length;
                     const countLabel = `${itemCount} ${itemCount === 1 ? "option" : "options"}`;
-                    const description = category.description
-                        ? `${countLabel} · ${category.description}`
-                        : countLabel;
+                    const groupId = getGroupId(category);
+                    const isExpanded = Boolean(searchText) || expandedGroupId === groupId;
+                    const groupChildrenId = `group-${category.title.replace(/[^a-zA-Z0-9]+/g, "-").toLowerCase()}-${index}`;
                     return (
-                        <S.Card key={category.title + index} enabled={true} onClick={() => handleGroupClick(category)} title={category.description}>
-                            <S.CardIcon>{category.icon ? category.icon : <LogIcon />}</S.CardIcon>
-                            <S.CardContent>
-                                <S.CardTitle>{category.title}</S.CardTitle>
-                                <S.CardDescription>{description}</S.CardDescription>
-                            </S.CardContent>
-                            <S.GroupIndicator aria-hidden="true">›</S.GroupIndicator>
-                        </S.Card>
+                        <S.GroupContainer key={category.title + index} expanded={isExpanded}>
+                            <S.GroupHeader
+                                onClick={() => handleGroupClick(category)}
+                                onKeyDown={(event) => {
+                                    if (event.key === "Enter" || event.key === " ") {
+                                        event.preventDefault();
+                                        handleGroupClick(category);
+                                    }
+                                }}
+                                role="button"
+                                tabIndex={0}
+                                aria-expanded={isExpanded}
+                                aria-controls={groupChildrenId}
+                                title={category.description}
+                            >
+                                <S.CardIcon>{category.icon ? category.icon : <LogIcon />}</S.CardIcon>
+                                <S.CardContent>
+                                    <S.CardTitle>{category.title}</S.CardTitle>
+                                    {category.description && (
+                                        <S.CardDescription>{category.description}</S.CardDescription>
+                                    )}
+                                </S.CardContent>
+                                <S.CountPill>{countLabel}</S.CountPill>
+                                <S.ChevronWrapper expanded={isExpanded} aria-hidden="true">
+                                    <Codicon name="chevron-down" sx={{ fontSize: 16 }} />
+                                </S.ChevronWrapper>
+                            </S.GroupHeader>
+                            {isExpanded && (
+                                <S.GroupBody id={groupChildrenId}>
+                                    {renderGroupChildren(category.items)}
+                                </S.GroupBody>
+                            )}
+                        </S.GroupContainer>
                     );
                 })}
             </S.CardsContainer>
@@ -366,18 +528,16 @@ function CardList(props: CardListProps) {
     const filteredCategories = onSearch
         ? categories
         : cloneDeep(categories).map((category) => {
-              if (!category || !category.items) {
-                  return category;
-              }
-              category.items = filterItems(category.items) || [];
-              return category;
-          });
+            if (!category || !category.items) {
+                return category;
+            }
+            category.items = filterItems(category.items) || [];
+            return category;
+        });
 
-    const activeCategory = categoryPath.at(-1);
-    const visibleCategories = activeCategory ? [activeCategory] : filteredCategories;
-    const hasContent = visibleCategories.some((category) => category?.items && category.items.length > 0);
-    const headerTitle = activeCategory?.title || title;
-    const canGoBack = categoryPath.length > 0 || Boolean(onBack);
+    const hasContent = filteredCategories.some((category) => category?.items && category.items.length > 0);
+    const headerTitle = title;
+    const canGoBack = Boolean(onBack);
     const shouldShowHeaderActions = (canGoBack && headerTitle) || onClose;
     return (
         <S.Container>
@@ -386,7 +546,7 @@ function CardList(props: CardListProps) {
                     <S.Row>
                         {canGoBack && headerTitle && (
                             <S.LeftAlignRow>
-                                <S.BackButton appearance="icon" onClick={handleBack}>
+                                <S.BackButton appearance="icon" onClick={() => onBack?.()}>
                                     <BackIcon />
                                 </S.BackButton>
                                 {headerTitle}
@@ -426,7 +586,7 @@ function CardList(props: CardListProps) {
                             <S.EmptyStateSubText>Try adjusting your search terms</S.EmptyStateSubText>
                         </S.EmptyState>
                     ) : (
-                        visibleCategories.map((category, index) => {
+                        filteredCategories.map((category, index) => {
                             if (!category?.items || category.items.length === 0) {
                                 return null;
                             }

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/ConnectionSelectionList.tsx
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/ConnectionSelectionList.tsx
@@ -27,7 +27,7 @@ import { AI_COMPONENT_PROGRESS_MESSAGE, AI_COMPONENT_PROGRESS_MESSAGE_TIMEOUT, L
 import { LoaderContainer } from "../RelativeLoader/styles";
 
 export function ConnectionSelectionList(props: ConnectionSelectionListProps): JSX.Element {
-    const { connectionKind, selectedNode, onSelect } = props;
+    const { connectionKind, selectedNode, onSelect, expandedGroupId, onExpandedGroupChange } = props;
 
     const { rpcClient } = useRpcContext();
     const [connectionCategories, setConnectionCategories] = useState<Category[]>([]);
@@ -85,6 +85,8 @@ export function ConnectionSelectionList(props: ConnectionSelectionListProps): JS
                 <CardList
                     categories={connectionCategories}
                     onSelect={onSelect}
+                    expandedGroupId={expandedGroupId}
+                    onExpandedGroupChange={onExpandedGroupChange}
                 />
             )}
         </>

--- a/packages/ballerina-visualizer/src/components/ConnectionSelector/types.ts
+++ b/packages/ballerina-visualizer/src/components/ConnectionSelector/types.ts
@@ -56,6 +56,8 @@ export interface ConnectionSelectionListProps {
     connectionKind: ConnectionKind;
     selectedNode?: FlowNode;
     onSelect?: (id: string, metadata?: any) => void;
+    expandedGroupId?: string | null;
+    onExpandedGroupChange?: (groupId: string | null) => void;
 }
 
 export interface ConnectionCreatorProps {

--- a/packages/ballerina-visualizer/src/constants.ts
+++ b/packages/ballerina-visualizer/src/constants.ts
@@ -55,6 +55,7 @@ export const FUNCTION_CALL = "FUNCTION_CALL";
 export const METHOD_CALL = "METHOD_CALL";
 
 export const LOADING_MESSAGE = "Loading...";
+export const FORM_LOADING_MESSAGE = "Loading form...";
 export const AI_COMPONENT_PROGRESS_MESSAGE_TIMEOUT = 3000; // Timeout (ms) before showing the 'fetching from Central' progress message
 export const AI_COMPONENT_PROGRESS_MESSAGE = "Fetching resources from Ballerina Central. This may take a few moments...";
 

--- a/packages/ballerina-visualizer/src/utils/bi.tsx
+++ b/packages/ballerina-visualizer/src/utils/bi.tsx
@@ -73,7 +73,7 @@ import { cloneDeep } from "lodash";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import hljs from "highlight.js";
-import { COMPLETION_ITEM_KIND, CompletionItem, CompletionItemKind, convertCompletionItemKind, FnSignatureDocumentation } from "@wso2/ui-toolkit";
+import { COMPLETION_ITEM_KIND, CompletionItem, CompletionItemKind, convertCompletionItemKind, FnSignatureDocumentation, getAIModuleIcon } from "@wso2/ui-toolkit";
 import { FunctionDefinition, STNode } from "@wso2/syntax-tree";
 import { DocSection } from "../components/ExpressionEditor";
 
@@ -131,6 +131,49 @@ function convertAvailableNodeToPanelNode(
     };
 }
 
+
+// Central icon URLs are `…/{org}_{package}_{version}.png`; the middle segment is the package key.
+function getPackageKeyFromIconUrl(iconUrl?: string): string | undefined {
+    const fileName = iconUrl?.split("/").pop();
+    const parts = fileName?.split("_");
+    return parts && parts.length >= 3 ? parts[1] : undefined;
+}
+
+// Prefer the embedded provider SVG so monochrome logos stay visible in dark mode.
+function resolveChildBadgeIcon(codedata: any, iconUrl?: string): React.ReactElement {
+    const embedded =
+        getAIModuleIcon(getPackageKeyFromIconUrl(iconUrl), 14) ?? getAIModuleIcon(codedata?.object, 14);
+    if (embedded) {
+        return embedded;
+    }
+    return <img src={iconUrl} style={{ width: 14, height: 14 }} />;
+}
+
+// Keeps the package icon on the group header and gives each child its own @display icon.
+function applyGroupedChildIcons(group: PanelCategory, rawItems: any[]): void {
+    const rawGroup = rawItems?.find(
+        (r) => r && !("codedata" in r) && r.metadata?.label === group.title
+    );
+    const packageIconUrl: string | undefined = rawGroup?.metadata?.icon;
+
+    if (packageIconUrl) {
+        group.icon = (
+            <ConnectorIcon url={packageIconUrl} style={{ width: "20px", height: "20px", fontSize: "20px" }} />
+        );
+    }
+
+    group.items?.forEach((child) => {
+        const childNode = child as PanelNode;
+        const codedata = childNode.metadata?.codedata;
+        const childIconUrl: string | undefined = childNode.metadata?.metadata?.icon;
+        const hasClassIcon = Boolean(childIconUrl) && childIconUrl !== packageIconUrl;
+        child.icon = hasClassIcon ? (
+            resolveChildBadgeIcon(codedata, childIconUrl)
+        ) : (
+            <NodeIcon type={codedata?.node} size={14} />
+        );
+    });
+}
 
 function convertDiagramCategoryToSidePanelCategory(category: Category, functionType?: FUNCTION_TYPE): PanelCategory {
     const connectorType = (category?.metadata?.data as NodeMetadata)?.connectorType;
@@ -233,18 +276,15 @@ export function convertFunctionCategoriesToSidePanelCategories(
 
 export function convertModelProviderCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
     const panelCategories = categories.map((category) => convertDiagramCategoryToSidePanelCategory(category));
-    panelCategories.forEach((category) => {
+    panelCategories.forEach((category, index) => {
         category.items?.forEach((item) => {
             if ((item as PanelNode).metadata?.codedata) {
                 const codedata = (item as PanelNode).metadata.codedata;
                 const iconUrl = (item as PanelNode)?.metadata?.metadata?.icon;
                 const iconType = codedata?.module == "ai" ? codedata.object : codedata?.module;
                 item.icon = <AIModelIcon type={iconType} codedata={codedata} iconUrl={iconUrl} />;
-            } else if (((item as PanelCategory).items.at(0) as PanelNode)?.metadata?.codedata) {
-                const codedata = ((item as PanelCategory).items.at(0) as PanelNode)?.metadata.codedata;
-                const iconUrl = ((item as PanelCategory).items.at(0) as PanelNode)?.metadata?.metadata?.icon;
-                const iconType = codedata?.module == "ai" ? codedata.object : codedata?.module;
-                item.icon = <AIModelIcon type={iconType} codedata={codedata} iconUrl={iconUrl} />;
+            } else if ((item as PanelCategory).items) {
+                applyGroupedChildIcons(item as PanelCategory, categories[index]?.items as any[]);
             }
         });
     });
@@ -278,16 +318,14 @@ export function convertCategoriesToSidePanelCategoriesWithIcon(
     iconFactory: (codedata: any, iconUrl?: string) => React.ReactElement
 ): PanelCategory[] {
     const panelCategories = categories.map((category) => convertDiagramCategoryToSidePanelCategory(category));
-    panelCategories.forEach((category) => {
+    panelCategories.forEach((category, index) => {
         category.items?.forEach((item) => {
             if ((item as PanelNode).metadata?.codedata) {
                 const codedata = (item as PanelNode).metadata.codedata;
                 const iconUrl = (item as PanelNode)?.metadata?.metadata?.icon;
                 item.icon = iconFactory(codedata, iconUrl);
-            } else if (((item as PanelCategory).items.at(0) as PanelNode)?.metadata?.codedata) {
-                const codedata = ((item as PanelCategory).items.at(0) as PanelNode)?.metadata.codedata;
-                const iconUrl = ((item as PanelCategory).items.at(0) as PanelNode)?.metadata?.metadata?.icon;
-                item.icon = iconFactory(codedata, iconUrl);
+            } else if ((item as PanelCategory).items) {
+                applyGroupedChildIcons(item as PanelCategory, categories[index]?.items as any[]);
             }
         });
     });

--- a/packages/ballerina-visualizer/src/views/BI/Connection/EditConnectionPopup/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/EditConnectionPopup/index.tsx
@@ -123,6 +123,7 @@ export function EditConnectionPopup(props: EditConnectionPopupProps) {
 
     // Navigation state
     const [currentView, setCurrentView] = useState<PopupView>(PopupView.CONNECTION_CONFIG);
+    const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
     const [selectedConnectionKind, setSelectedConnectionKind] = useState<ConnectionKind>();
     const [nodeFormTemplate, setNodeFormTemplate] = useState<FlowNode>();
 
@@ -181,7 +182,7 @@ export function EditConnectionPopup(props: EditConnectionPopupProps) {
                             connection: connectionName,
                             projectPath: visualizerLocation.projectPath
                         });
-                    
+
                         if (response?.data) {
                             setConnectorCredentials(response.data);
                         }
@@ -313,10 +314,10 @@ export function EditConnectionPopup(props: EditConnectionPopupProps) {
     };
 
     const handleOpenERDiagram = async () => {
-        if(!connectorCredentials?.modelFilePath) {
+        if (!connectorCredentials?.modelFilePath) {
             return;
         }
-        
+
         const visualizerLocation = await rpcClient.getVisualizerLocation();
         const modelDocumentUri = (await rpcClient.getVisualizerRpcClient().joinProjectPath({
             segments: [connectorCredentials.modelFilePath]
@@ -366,6 +367,8 @@ export function EditConnectionPopup(props: EditConnectionPopupProps) {
                         connectionKind={selectedConnectionKind}
                         selectedNode={connection}
                         onSelect={handleSelectNewConnection}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={setExpandedGroupId}
                     />
                 );
             case PopupView.CONNECTION_CREATE:

--- a/packages/ballerina-visualizer/src/views/BI/Connection/EditConnectionWizard/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Connection/EditConnectionWizard/index.tsx
@@ -65,6 +65,7 @@ export function EditConnectionWizard(props: EditConnectionWizardProps) {
 
     // Navigation state
     const [currentView, setCurrentView] = useState<WizardView>(WizardView.CONNECTION_CONFIG);
+    const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
     const [selectedConnectionKind, setSelectedConnectionKind] = useState<ConnectionKind>();
     const [nodeFormTemplate, setNodeFormTemplate] = useState<FlowNode>();
 
@@ -246,6 +247,8 @@ export function EditConnectionWizard(props: EditConnectionWizardProps) {
                         connectionKind={selectedConnectionKind}
                         selectedNode={connection}
                         onSelect={handleSelectNewConnection}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={setExpandedGroupId}
                     />
                 );
 

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
@@ -156,6 +156,8 @@ interface PanelManagerProps {
     onSearchChunker?: (searchText: string, functionType: FUNCTION_TYPE) => void;
     onSearchTextChange?: (searchText: string) => void;
     searchText?: string;
+    expandedGroupId?: string | null;
+    onExpandedGroupChange?: (groupId: string | null) => void;
     onAddAgent?: () => void;
     onEditAgent?: () => void;
     onNavigateToPanel?: (targetPanel: SidePanelView, connectionKind?: ConnectionKind) => void;
@@ -234,6 +236,8 @@ export function PanelManager(props: PanelManagerProps) {
         onSearchNpFunction,
         onSearchTextChange,
         searchText,
+        expandedGroupId,
+        onExpandedGroupChange,
         onSearchAll,
         onSearchVectorStore,
         onSearchEmbeddingProvider,
@@ -524,6 +528,8 @@ export function PanelManager(props: PanelManagerProps) {
                         title={"Model Providers"}
                         searchPlaceholder={"Search model providers"}
                         onBack={canGoBack ? onBack : undefined}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={onExpandedGroupChange}
                     />
                 );
 
@@ -552,6 +558,8 @@ export function PanelManager(props: PanelManagerProps) {
                         title={"Vector Stores"}
                         searchPlaceholder={"Search vector stores"}
                         onBack={canGoBack ? onBack : undefined}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={onExpandedGroupChange}
                     />
                 );
 
@@ -582,6 +590,8 @@ export function PanelManager(props: PanelManagerProps) {
                         title={"Embedding Providers"}
                         searchPlaceholder={"Search embedding providers"}
                         onBack={canGoBack ? onBack : undefined}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={onExpandedGroupChange}
                     />
                 );
 
@@ -612,6 +622,8 @@ export function PanelManager(props: PanelManagerProps) {
                         title={"Knowledge Bases"}
                         searchPlaceholder={"Search knowledge bases"}
                         onBack={canGoBack ? onBack : undefined}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={onExpandedGroupChange}
                     />
                 );
 
@@ -642,6 +654,8 @@ export function PanelManager(props: PanelManagerProps) {
                         title={"Data Loaders"}
                         searchPlaceholder={"Search data loaders"}
                         onBack={canGoBack ? onBack : undefined}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={onExpandedGroupChange}
                     />
                 );
 
@@ -672,6 +686,8 @@ export function PanelManager(props: PanelManagerProps) {
                         title={"Chunkers"}
                         searchPlaceholder={"Search chunkers"}
                         onBack={canGoBack ? onBack : undefined}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={onExpandedGroupChange}
                     />
                 );
 

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
@@ -703,7 +703,14 @@ export function PanelManager(props: PanelManagerProps) {
                 );
 
             case SidePanelView.CONNECTION_SELECT:
-                return <ConnectionSelectionList connectionKind={selectedConnectionKind} onSelect={onSelectNewConnection} />;
+                return (
+                    <ConnectionSelectionList
+                        connectionKind={selectedConnectionKind}
+                        onSelect={onSelectNewConnection}
+                        expandedGroupId={expandedGroupId}
+                        onExpandedGroupChange={onExpandedGroupChange}
+                    />
+                );
 
             case SidePanelView.CONNECTION_CREATE:
                 return (

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -133,6 +133,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     const [sidePanelView, setSidePanelView] = useState<SidePanelView>(SidePanelView.NODE_LIST);
     const [categories, setCategories] = useState<PanelCategory[]>([]); //
     const [searchText, setSearchText] = useState<string>("");
+    // Kept here so an expanded AI package group survives switching to a form and back.
+    const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
     const [fetchingAiSuggestions, setFetchingAiSuggestions] = useState(false);
     const [showProgressIndicator, setShowProgressIndicator] = useState(false);
     const [showProgressSpinner, setShowProgressSpinner] = useState<boolean>(false);
@@ -901,6 +903,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     const resetNodeSelectionStates = () => {
         setShowSidePanel(false);
         setSidePanelView(SidePanelView.NODE_LIST);
+        setExpandedGroupId(null);
         setSubPanel({ view: SubPanelView.UNDEFINED });
         setSelectedNodeId(undefined);
         selectedNodeRef.current = undefined;
@@ -3406,6 +3409,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 onSearchNpFunction={handleSearchNpFunction}
                 onSearchTextChange={handleSearchTextChange}
                 searchText={searchText}
+                expandedGroupId={expandedGroupId}
+                onExpandedGroupChange={setExpandedGroupId}
                 // isSearching={isSearching}
                 onSearchModelProvider={handleSearchModelProvider}
                 onSearchVectorStore={handleSearchVectorStore}

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -83,7 +83,7 @@ import {
     removeToolFromAgentNode,
 } from "../AIChatAgent/utils";
 import { DiagramSkeleton } from "../../../components/Skeletons";
-import { AI_COMPONENT_PROGRESS_MESSAGE, AI_COMPONENT_PROGRESS_MESSAGE_TIMEOUT, GET_DEFAULT_EMBEDDING_PROVIDER, GET_DEFAULT_MODEL_PROVIDER, LOADING_MESSAGE } from "../../../constants";
+import { AI_COMPONENT_PROGRESS_MESSAGE, AI_COMPONENT_PROGRESS_MESSAGE_TIMEOUT, FORM_LOADING_MESSAGE, GET_DEFAULT_EMBEDDING_PROVIDER, GET_DEFAULT_MODEL_PROVIDER, LOADING_MESSAGE } from "../../../constants";
 import { ConnectionListItem } from "@wso2/wso2-platform-core";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
 
@@ -121,6 +121,16 @@ type NodePromptLaunchOptions = {
 };
 
 const SIDE_PANEL_DEFAULT_ERROR_MESSAGE = "Error while performing the action.";
+
+// AI component pickers resolve templates from Central, so selecting one shows a full-panel loader.
+const AI_COMPONENT_PICKER_VIEWS: SidePanelView[] = [
+    SidePanelView.MODEL_PROVIDERS,
+    SidePanelView.VECTOR_STORES,
+    SidePanelView.EMBEDDING_PROVIDERS,
+    SidePanelView.KNOWLEDGE_BASES,
+    SidePanelView.DATA_LOADERS,
+    SidePanelView.CHUNKERS,
+];
 
 export function BIFlowDiagram(props: BIFlowDiagramProps) {
     const { projectPath, breakpointState, syntaxTree, onUpdate, onReady, onSave } = props;
@@ -1404,6 +1414,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         // Push current state to navigation stack before navigating
         pushToNavigationStack(sidePanelView, categories, selectedNodeRef.current, selectedClientName.current);
 
+        const showFormLoader = AI_COMPONENT_PICKER_VIEWS.includes(sidePanelView);
+
         switch (node.codedata.node) {
             case "FUNCTION":
                 setShowProgressIndicator(true);
@@ -1738,6 +1750,11 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 // default node
                 selectedClientName.current = category;
                 setShowProgressIndicator(true);
+                if (showFormLoader) {
+                    setShowProgressSpinner(true);
+                    setProgressTitle(node.metadata?.label || LOADING_MESSAGE);
+                    setProgressMessage(FORM_LOADING_MESSAGE);
+                }
                 rpcClient.getBIDiagramRpcClient().getNodeTemplate({
                     position: targetRef.current.startLine,
                     filePath: model?.fileName || fileName,
@@ -1759,6 +1776,10 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     })
                     .finally(() => {
                         setShowProgressIndicator(false);
+                        if (showFormLoader) {
+                            setShowProgressSpinner(false);
+                            setProgressMessage(LOADING_MESSAGE);
+                        }
                     });
                 break;
         }

--- a/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1243,7 +1243,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         await handleSearch(searchText, functionType, "FUNCTION");
     };
 
-     const handleSearchWorkflow = async (searchText: string, functionType: FUNCTION_TYPE) => {
+    const handleSearchWorkflow = async (searchText: string, functionType: FUNCTION_TYPE) => {
         // NOTE: Backend payloads may still contain legacy "WORKFLOW_START" in some environments.
         // FE is intentionally standardized on "WORKFLOW_RUN"; align API/LS payloads to avoid mismatches.
         await handleSearch(searchText, functionType, "WORKFLOW_RUN");
@@ -1789,6 +1789,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         // Push current state to navigation stack before navigating
         pushToNavigationStack(sidePanelView, categories, selectedNodeRef.current, selectedClientName.current);
         setShowProgressIndicator(true);
+        setShowProgressSpinner(true);
+        setProgressTitle("");
+        setProgressMessage(FORM_LOADING_MESSAGE);
 
         try {
             const { flowNode, connectionKind } = await getNodeTemplateForConnection(
@@ -1805,6 +1808,8 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             setShowSidePanel(true);
         } finally {
             setShowProgressIndicator(false);
+            setShowProgressSpinner(false);
+            setProgressMessage(LOADING_MESSAGE);
         }
     };
 
@@ -2490,7 +2495,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             });
     };
 
-   
+
 
     const handleOnAddNPFunction = () => {
         rpcClient.getVisualizerRpcClient().openView({

--- a/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/FocusFlowDiagram/index.tsx
@@ -92,6 +92,7 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
     const [showConnectionPanel, setShowConnectionPanel] = useState(false);
     const [selectedConnectionKind, setSelectedConnectionKind] = useState<ConnectionKind>();
     const [connectionView, setConnectionView] = useState<SidePanelView.CONNECTION_CONFIG | SidePanelView.CONNECTION_SELECT | SidePanelView.CONNECTION_CREATE>();
+    const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
 
     const selectedNodeRef = useRef<FlowNode>();
     const nodeTemplateRef = useRef<FlowNode>();
@@ -364,18 +365,18 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
             filePath: model.fileName,
             id: node.codedata,
         }).then((response) => {
-                const nodesWithCustomForms = ["IF", "FORK"];
-                // if node doesn't have properties. don't show edit form
-                if (!response.flowNode.properties && !nodesWithCustomForms.includes(response.flowNode.codedata.node)) {
-                    console.log(">>> Node doesn't have properties. Don't show edit form", response.flowNode);
-                    setShowProgressIndicator(false);
-                    showEditForm.current = false;
-                    return;
-                }
+            const nodesWithCustomForms = ["IF", "FORK"];
+            // if node doesn't have properties. don't show edit form
+            if (!response.flowNode.properties && !nodesWithCustomForms.includes(response.flowNode.codedata.node)) {
+                console.log(">>> Node doesn't have properties. Don't show edit form", response.flowNode);
+                setShowProgressIndicator(false);
+                showEditForm.current = false;
+                return;
+            }
 
-                nodeTemplateRef.current = response.flowNode;
-                showEditForm.current = true;
-            })
+            nodeTemplateRef.current = response.flowNode;
+            showEditForm.current = true;
+        })
             .finally(() => {
                 setShowProgressIndicator(false);
             });
@@ -719,6 +720,8 @@ export function BIFocusFlowDiagram(props: BIFocusFlowDiagramProps) {
                             connectionKind={selectedConnectionKind}
                             selectedNode={selectedNodeRef.current}
                             onSelect={handleSelectConnection}
+                            expandedGroupId={expandedGroupId}
+                            onExpandedGroupChange={setExpandedGroupId}
                         />
                     )}
                     {connectionView === SidePanelView.CONNECTION_CREATE && (


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/product-integrator/issues/1885

The AI component picker previously assumed a Ballerina package exposes at most one implementation of a given AI component interface. A single hosting package can now expose several compatible providers (e.g. `ballerinax/ai.azure` exposes Azure-hosted OpenAI, Anthropic, Mistral, and DeepSeek model providers).

This adds **adaptive package grouping** across all seven AI component types (model providers, embedding providers, vector stores, data loaders, chunkers, short-term memory stores, knowledge bases):

- A package with one compatible implementation stays a direct, selectable card (unchanged).
- A package with two or more becomes an inline **accordion** group whose children are the selectable implementations.

https://github.com/user-attachments/assets/8b4764e4-ff78-42fa-9e67-71598eddf143

## Language server

- Grouping happens after discovery via a shared helper (`AiUtils.buildAdaptiveAiComponentCategory`); discovery stays class-level and `AvailableNode` `codedata` is unchanged.
- Category labels consolidated into `Category.Name` so group labels/descriptions can't drift from the picker headings.
- Each AI component's icon is now taken from its class `@display` `iconPath` (falling back to the package icon); the group keeps the package icon. Icons are persisted through the disk cache (schema bumped to v2).

## Webview

- `CardList` renders a package group as an inline accordion: distinct header/body surfaces, row dividers, a rotating chevron, `focus-visible` ring, one-open-at-a-time, keyboard support, and non-selectable card text.
- Grouped children show a composite icon — the package icon as the main icon with the provider's icon as a bottom-right badge — preferring the embedded, theme-aware provider SVGs (via `getAIModuleIcon`, resolved from the `@display` `iconPath` package key) so monochrome logos like Anthropic don't clash in dark mode.
- No new RPC method or serialized leaf schema.

## Tests

- `AiUtilsGroupingTest`: singleton stays a leaf, multiple leaves become a group, leaf `codedata` identity retained, query behavior, all seven category labels.
- `AiComponentDiskCacheTest`: updated for the persisted icon field and round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added adaptive grouping for AI components: single-provider packages remain selectable cards, while multi-provider packages appear as expandable groups.
- Centralized grouping, category labeling, query matching, provider-name formatting, and icon resolution in the language server.
- Added per-component icon support with package-icon fallbacks and upgraded the AI component disk-cache schema.
- Updated the webview with accordion controls, keyboard/focus styling, composite icons, persistent expansion state, and loading indicators for AI forms.
- Added coverage for grouping, filtering, category handling, codedata preservation, and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->