### PR TITLE
Add nightly build support

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,6 +7,12 @@ inputs:
     description: Whether this is a prerelease build
     required: false
     default: 'true'
+  snapshot:
+    description: >-
+      Stamp the extension version as '<version>-SNAPSHOT' (nightly builds).
+      Takes precedence over the isPreRelease timestamp suffix.
+    required: false
+    default: 'false'
   lsSource:
     description: LS source — local (use jar built from source) or download (fetch from GitHub release)
     required: false
@@ -86,6 +92,7 @@ runs:
       with:
         path: "ballerina-extension"
         isPreRelease: ${{ inputs.isPreRelease }}
+        snapshot: ${{ inputs.snapshot }}
         version: ${{ inputs.version }}
 
     - name: Validate lsSource

--- a/.github/actions/dailyBuildNotification/action.yml
+++ b/.github/actions/dailyBuildNotification/action.yml
@@ -18,9 +18,11 @@ runs:
       id: vsix
       run: |
         file=$(ls ${{ inputs.fileName }}-[0-9]*.[0-9]*.[0-9]*.vsix)
-        fileName=${file##*-}
-        version=${fileName%.*}
         extension=${{ inputs.fileName }}
+        # Prefix/suffix strip, not a trailing-dash cut — nightly versions carry
+        # a '-SNAPSHOT' prerelease id (ballerina-5.13.0-SNAPSHOT.vsix).
+        version=${file#${extension}-}
+        version=${version%.vsix}
         extensionName="$(echo "$extension" | sed 's/.*/\u&/')"
         echo "vsixName=$file" >> $GITHUB_OUTPUT
         echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -67,23 +67,29 @@ runs:
         set -euo pipefail
         API="https://api.github.com/repos/${REPO}"
 
+        # Bounded timeouts so a hung GitHub API call can't stall the job until
+        # the job-level timeout. The metadata calls are small; the asset upload
+        # ships a ~100MB VSIX, so it gets a much larger budget.
+        CURL_API=(curl -sS --connect-timeout 15 --max-time 60)
+        CURL_UPLOAD=(curl -sS --connect-timeout 15 --max-time 900)
+
         # Rolling tag (e.g. nightly): delete the previous release + git tag so
         # the tag always points at the newest build.
         if [ "${ROLLING}" = "true" ]; then
-          existingId=$(curl -sS -H "Authorization:token ${GH_TOKEN}" \
+          existingId=$("${CURL_API[@]}" -H "Authorization:token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
             "${API}/releases/tags/${TAG}" | jq -r '.id // empty')
           if [ -n "${existingId}" ]; then
             echo "Deleting existing release ${existingId} for tag ${TAG}"
-            curl -sS -X DELETE -H "Authorization:token ${GH_TOKEN}" \
+            "${CURL_API[@]}" -X DELETE -H "Authorization:token ${GH_TOKEN}" \
               "${API}/releases/${existingId}"
           fi
           # Remove the git tag ref too (ignore if it doesn't exist).
-          curl -sS -X DELETE -H "Authorization:token ${GH_TOKEN}" \
+          "${CURL_API[@]}" -X DELETE -H "Authorization:token ${GH_TOKEN}" \
             "${API}/git/refs/tags/${TAG}" || true
         fi
 
-        createResponse=$(curl -sS -X POST \
+        createResponse=$("${CURL_API[@]}" -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization:token ${GH_TOKEN}" \
           "${API}/releases" \
@@ -99,11 +105,23 @@ runs:
           exit 1
         fi
 
-        curl -sS -X POST \
+        # curl exits 0 on a non-2xx HTTP response, so 'set -e' alone would let a
+        # rejected upload (auth, size limit, rate limit) pass as success. That is
+        # especially bad on the rolling path: the previous nightly has already
+        # been deleted above, so an unchecked failure would leave an assetless
+        # 'nightly' release and a notification linking to a 404.
+        uploadResponse=$("${CURL_UPLOAD[@]}" -X POST \
           -H "Authorization:token ${GH_TOKEN}" \
           -H "Content-Type:application/octet-stream" \
           --data-binary "@${VSIX}" \
-          "https://uploads.github.com/repos/${REPO}/releases/${id}/assets?name=${VSIX}"
+          "https://uploads.github.com/repos/${REPO}/releases/${id}/assets?name=${VSIX}")
+        assetId=$(echo "${uploadResponse}" | jq -r '.id // empty')
+        if [ -z "${assetId}" ]; then
+          echo "Failed to upload ${VSIX} to release ${id}:" >&2
+          echo "${uploadResponse}" >&2
+          exit 1
+        fi
+        echo "Uploaded ${VSIX} as asset ${assetId}"
 
     - name: "Release Notification"
       shell: bash

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -73,55 +73,109 @@ runs:
         CURL_API=(curl -sS --connect-timeout 15 --max-time 60)
         CURL_UPLOAD=(curl -sS --connect-timeout 15 --max-time 900)
 
-        # Rolling tag (e.g. nightly): delete the previous release + git tag so
-        # the tag always points at the newest build.
+        # On the rolling path (e.g. nightly) the release is REUSED rather than
+        # deleted and recreated. Nothing is destroyed until the replacement
+        # artifact is uploaded and verified, so a failed run always leaves the
+        # previous nightly downloadable. That matters because the whole point of
+        # a fixed tag is a URL that keeps working; deleting first would take
+        # 'releases/download/<tag>/...' offline until the next successful build.
+        existingId=""
+        existingAssets="[]"
         if [ "${ROLLING}" = "true" ]; then
-          existingId=$("${CURL_API[@]}" -H "Authorization:token ${GH_TOKEN}" \
+          existing=$("${CURL_API[@]}" -H "Authorization:token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "${API}/releases/tags/${TAG}" | jq -r '.id // empty')
-          if [ -n "${existingId}" ]; then
-            echo "Deleting existing release ${existingId} for tag ${TAG}"
-            "${CURL_API[@]}" -X DELETE -H "Authorization:token ${GH_TOKEN}" \
-              "${API}/releases/${existingId}"
-          fi
-          # Remove the git tag ref too (ignore if it doesn't exist).
-          "${CURL_API[@]}" -X DELETE -H "Authorization:token ${GH_TOKEN}" \
-            "${API}/git/refs/tags/${TAG}" || true
+            "${API}/releases/tags/${TAG}")
+          existingId=$(echo "${existing}" | jq -r '.id // empty')
+          existingAssets=$(echo "${existing}" | jq -c '.assets // []')
         fi
 
-        createResponse=$("${CURL_API[@]}" -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization:token ${GH_TOKEN}" \
-          "${API}/releases" \
-          -d "$(jq -n \
-            --arg tag "${TAG}" \
-            --arg name "${RELEASE_NAME}" \
-            --arg commit "${GITHUB_SHA}" \
-            '{tag_name: $tag, target_commitish: $commit, draft: false, name: $name, prerelease: true}')")
-        id=$(echo "${createResponse}" | jq -r '.id // empty')
-        if [ -z "${id}" ]; then
-          echo "Failed to create release:" >&2
-          echo "${createResponse}" >&2
-          exit 1
+        if [ -n "${existingId}" ]; then
+          echo "Reusing existing release ${existingId} for tag ${TAG}"
+          id="${existingId}"
+        else
+          createResponse=$("${CURL_API[@]}" -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization:token ${GH_TOKEN}" \
+            "${API}/releases" \
+            -d "$(jq -n \
+              --arg tag "${TAG}" \
+              --arg name "${RELEASE_NAME}" \
+              --arg commit "${GITHUB_SHA}" \
+              '{tag_name: $tag, target_commitish: $commit, draft: false, name: $name, prerelease: true}')")
+          id=$(echo "${createResponse}" | jq -r '.id // empty')
+          if [ -z "${id}" ]; then
+            echo "Failed to create release:" >&2
+            echo "${createResponse}" >&2
+            exit 1
+          fi
+        fi
+
+        # Asset names must be unique within a release, and a nightly VSIX has the
+        # same filename every run — so the replacement is uploaded under a temp
+        # name and renamed only after the old one is gone. Clear any temp asset
+        # left behind by a previously failed run, or this upload would 422.
+        staleId=$(echo "${existingAssets}" | jq -r --arg n "${VSIX}.new" \
+          '.[] | select(.name == $n) | .id' | head -n 1)
+        if [ -n "${staleId}" ]; then
+          echo "Removing stale temp asset ${staleId} (${VSIX}.new)"
+          "${CURL_API[@]}" -X DELETE -H "Authorization:token ${GH_TOKEN}" \
+            "${API}/releases/assets/${staleId}"
         fi
 
         # curl exits 0 on a non-2xx HTTP response, so 'set -e' alone would let a
-        # rejected upload (auth, size limit, rate limit) pass as success. That is
-        # especially bad on the rolling path: the previous nightly has already
-        # been deleted above, so an unchecked failure would leave an assetless
-        # 'nightly' release and a notification linking to a 404.
+        # rejected upload (auth, size limit, rate limit) pass as success, leaving
+        # a release whose artifact silently never arrived.
         uploadResponse=$("${CURL_UPLOAD[@]}" -X POST \
           -H "Authorization:token ${GH_TOKEN}" \
           -H "Content-Type:application/octet-stream" \
           --data-binary "@${VSIX}" \
-          "https://uploads.github.com/repos/${REPO}/releases/${id}/assets?name=${VSIX}")
+          "https://uploads.github.com/repos/${REPO}/releases/${id}/assets?name=${VSIX}.new")
         assetId=$(echo "${uploadResponse}" | jq -r '.id // empty')
         if [ -z "${assetId}" ]; then
           echo "Failed to upload ${VSIX} to release ${id}:" >&2
           echo "${uploadResponse}" >&2
           exit 1
         fi
+
+        # The new artifact is safely uploaded — only now retire the old one.
+        oldId=$(echo "${existingAssets}" | jq -r --arg n "${VSIX}" \
+          '.[] | select(.name == $n) | .id' | head -n 1)
+        if [ -n "${oldId}" ]; then
+          echo "Deleting superseded asset ${oldId} (${VSIX})"
+          "${CURL_API[@]}" -X DELETE -H "Authorization:token ${GH_TOKEN}" \
+            "${API}/releases/assets/${oldId}"
+        fi
+
+        renameResponse=$("${CURL_API[@]}" -X PATCH \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization:token ${GH_TOKEN}" \
+          "${API}/releases/assets/${assetId}" \
+          -d "$(jq -n --arg name "${VSIX}" '{name: $name}')")
+        if [ -z "$(echo "${renameResponse}" | jq -r '.id // empty')" ]; then
+          echo "Failed to rename asset ${assetId} to ${VSIX}:" >&2
+          echo "${renameResponse}" >&2
+          exit 1
+        fi
         echo "Uploaded ${VSIX} as asset ${assetId}"
+
+        # Refresh the reused release's title, and move the tag to this commit so
+        # the rolling tag tracks the newest build. Both happen after a verified
+        # upload, so tag and artifact never disagree on a failed run.
+        if [ -n "${existingId}" ]; then
+          "${CURL_API[@]}" -X PATCH \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization:token ${GH_TOKEN}" \
+            "${API}/releases/${id}" \
+            -d "$(jq -n --arg name "${RELEASE_NAME}" \
+              '{name: $name, draft: false, prerelease: true}')" > /dev/null
+          "${CURL_API[@]}" -X PATCH \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization:token ${GH_TOKEN}" \
+            "${API}/git/refs/tags/${TAG}" \
+            -d "$(jq -n --arg sha "${GITHUB_SHA}" \
+              '{sha: $sha, force: true}')" > /dev/null
+          echo "Moved tag ${TAG} to ${GITHUB_SHA}"
+        fi
 
     - name: "Release Notification"
       shell: bash

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -31,9 +31,13 @@ runs:
       id: vsix
       run: |
         file=$(ls ${{ inputs.name }}-[0-9]*.[0-9]*.[0-9]*.vsix)
-        fileName=${file##*-}
-        version=${fileName%.*}
         extension=${{ inputs.name }}
+        # Strip the '<name>-' prefix and the '.vsix' suffix rather than cutting
+        # at the last '-': a nightly version carries a '-SNAPSHOT' prerelease id
+        # (ballerina-5.13.0-SNAPSHOT.vsix), which a trailing-dash cut would
+        # reduce to just "SNAPSHOT".
+        version=${file#${extension}-}
+        version=${version%.vsix}
         extensionName="$(echo "$extension" | sed 's/.*/\u&/')"
         # A non-empty `tag` input selects the rolling release (e.g. nightly);
         # otherwise fall back to a unique per-version tag.

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -162,18 +162,31 @@ runs:
         # the rolling tag tracks the newest build. Both happen after a verified
         # upload, so tag and artifact never disagree on a failed run.
         if [ -n "${existingId}" ]; then
-          "${CURL_API[@]}" -X PATCH \
+          releasePatch=$("${CURL_API[@]}" -X PATCH \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization:token ${GH_TOKEN}" \
             "${API}/releases/${id}" \
             -d "$(jq -n --arg name "${RELEASE_NAME}" \
-              '{name: $name, draft: false, prerelease: true}')" > /dev/null
-          "${CURL_API[@]}" -X PATCH \
+              '{name: $name, draft: false, prerelease: true}')")
+          if [ -z "$(echo "${releasePatch}" | jq -r '.id // empty')" ]; then
+            echo "Failed to update release ${id}:" >&2
+            echo "${releasePatch}" >&2
+            exit 1
+          fi
+          # Compare the returned ref target rather than just checking for a body:
+          # a rejected ref update (missing ref, concurrent move) would otherwise
+          # leave ${TAG} on a stale commit while the release serves the new VSIX.
+          refPatch=$("${CURL_API[@]}" -X PATCH \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization:token ${GH_TOKEN}" \
             "${API}/git/refs/tags/${TAG}" \
             -d "$(jq -n --arg sha "${GITHUB_SHA}" \
-              '{sha: $sha, force: true}')" > /dev/null
+              '{sha: $sha, force: true}')")
+          if [ "$(echo "${refPatch}" | jq -r '.object.sha // empty')" != "${GITHUB_SHA}" ]; then
+            echo "Failed to move tag ${TAG} to ${GITHUB_SHA}:" >&2
+            echo "${refPatch}" >&2
+            exit 1
+          fi
           echo "Moved tag ${TAG} to ${GITHUB_SHA}"
         fi
 

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -14,6 +14,14 @@ inputs:
     description: 'Google Chat thread key for grouping release notifications'
     required: false
     default: ''
+  tag:
+    description: >-
+      Fixed, rolling release tag (e.g. "nightly"). When set, any existing
+      release + git tag with this name is deleted and recreated, so the tag
+      always points at the latest build. When empty (default), a unique
+      "v<version>" release is created without deleting anything.
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -27,21 +35,71 @@ runs:
         version=${fileName%.*}
         extension=${{ inputs.name }}
         extensionName="$(echo "$extension" | sed 's/.*/\u&/')"
+        # A non-empty `tag` input selects the rolling release (e.g. nightly);
+        # otherwise fall back to a unique per-version tag.
+        if [ -n "${{ inputs.tag }}" ]; then
+          releaseTag="${{ inputs.tag }}"
+          releaseName="Nightly Build (v${version})"
+        else
+          releaseTag="v${version}"
+          releaseName="Release v${version}"
+        fi
         echo "vsixName=$file" >> $GITHUB_OUTPUT
         echo "version=$version" >> $GITHUB_OUTPUT
         echo "extensionName=$extensionName" >> $GITHUB_OUTPUT
+        echo "releaseTag=$releaseTag" >> $GITHUB_OUTPUT
+        echo "releaseName=$releaseName" >> $GITHUB_OUTPUT
 
     - name: Create a release in ${{ inputs.repo }} repo
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ inputs.repo }}
+        TAG: ${{ steps.vsix.outputs.releaseTag }}
+        RELEASE_NAME: ${{ steps.vsix.outputs.releaseName }}
+        VSIX: ${{ steps.vsix.outputs.vsixName }}
+        ROLLING: ${{ inputs.tag != '' }}
       run: |
-        createResponse=`curl -X POST  -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization:token ${{ github.token }}" -d '{"tag_name":"v${{ steps.vsix.outputs.version }}", \
-        "draft":false, "name": "Release v${{ steps.vsix.outputs.version }}", "prerelease":true}' \
-        https://api.github.com/repos/${{ inputs.repo }}/releases` \
-          && id=`echo "$createResponse" | sed -n -e 's/"id":\ \([0-9]\+\),/\1/p' | head -n 1 | sed 's/[[:blank:]]//g'` && \
-          uploadResponse=`curl -X POST -H "Authorization:token ${{ github.token }}" -H "Content-Type:application/octet-stream" \
-          --data-binary @${{ steps.vsix.outputs.vsixName }} \
-          https://uploads.github.com/repos/${{ inputs.repo }}/releases/$id/assets?name=${{ steps.vsix.outputs.vsixName }}`
+        set -euo pipefail
+        API="https://api.github.com/repos/${REPO}"
+
+        # Rolling tag (e.g. nightly): delete the previous release + git tag so
+        # the tag always points at the newest build.
+        if [ "${ROLLING}" = "true" ]; then
+          existingId=$(curl -sS -H "Authorization:token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "${API}/releases/tags/${TAG}" | jq -r '.id // empty')
+          if [ -n "${existingId}" ]; then
+            echo "Deleting existing release ${existingId} for tag ${TAG}"
+            curl -sS -X DELETE -H "Authorization:token ${GH_TOKEN}" \
+              "${API}/releases/${existingId}"
+          fi
+          # Remove the git tag ref too (ignore if it doesn't exist).
+          curl -sS -X DELETE -H "Authorization:token ${GH_TOKEN}" \
+            "${API}/git/refs/tags/${TAG}" || true
+        fi
+
+        createResponse=$(curl -sS -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization:token ${GH_TOKEN}" \
+          "${API}/releases" \
+          -d "$(jq -n \
+            --arg tag "${TAG}" \
+            --arg name "${RELEASE_NAME}" \
+            --arg commit "${GITHUB_SHA}" \
+            '{tag_name: $tag, target_commitish: $commit, draft: false, name: $name, prerelease: true}')")
+        id=$(echo "${createResponse}" | jq -r '.id // empty')
+        if [ -z "${id}" ]; then
+          echo "Failed to create release:" >&2
+          echo "${createResponse}" >&2
+          exit 1
+        fi
+
+        curl -sS -X POST \
+          -H "Authorization:token ${GH_TOKEN}" \
+          -H "Content-Type:application/octet-stream" \
+          --data-binary "@${VSIX}" \
+          "https://uploads.github.com/repos/${REPO}/releases/${id}/assets?name=${VSIX}"
 
     - name: "Release Notification"
       shell: bash
@@ -71,7 +129,7 @@ runs:
                         "content": "v${{ steps.vsix.outputs.version }}",
                         "onClick": {
                           "openLink": {
-                            "url": "https://github.com/${{ inputs.repo }}/releases/tag/v${{ steps.vsix.outputs.version }}"
+                            "url": "https://github.com/${{ inputs.repo }}/releases/tag/${{ steps.vsix.outputs.releaseTag }}"
                           }
                         },
                         "iconUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Visual_Studio_Code_1.35_icon.svg/512px-Visual_Studio_Code_1.35_icon.svg.png",
@@ -80,7 +138,7 @@ runs:
                             "text": "Download VSIX",
                             "onClick": {
                               "openLink": {
-                                "url": "https://github.com/${{ inputs.repo }}/releases/download/v${{ steps.vsix.outputs.version }}/${{ steps.vsix.outputs.vsixName }}"
+                                "url": "https://github.com/${{ inputs.repo }}/releases/download/${{ steps.vsix.outputs.releaseTag }}/${{ steps.vsix.outputs.vsixName }}"
                               }
                             }
                           }

--- a/.github/actions/updateVersion/action.yml
+++ b/.github/actions/updateVersion/action.yml
@@ -25,11 +25,15 @@ runs:
         cd packages/${{ inputs.path }}
         currentVersion=$(node -p "require('./package.json').version")
         currentVersionWOPreId=${currentVersion%-*}
-        # Only strip when the base version is long enough to actually carry an
-        # 8-char timestamp. A plain or '-SNAPSHOT' version (e.g. 5.13.0-SNAPSHOT
-        # -> base 5.13.0, 6 chars) has nothing to strip, and ':0:-8' on a
-        # shorter string is a fatal bash expansion error.
-        if [[ ${#currentVersionWOPreId} -gt 8 ]]; then
+        # Only strip when the base version actually ends in an 8-char timestamp.
+        # Length alone is not enough: '5.13.1000', '10.13.100' and '5.130.100'
+        # are all >8 chars but carry no timestamp, and blindly cutting 8 chars
+        # would leave '5' / '1' and run 'npm version 5', silently rewriting
+        # package.json to a bogus version. Requiring the last 8 characters to be
+        # digits distinguishes a real 'yymmddHH' suffix from a long version.
+        # (The length test must also stay: ':0:-8' on a shorter string is a
+        # fatal bash expansion error, which '-SNAPSHOT' versions would hit.)
+        if [[ ${#currentVersionWOPreId} -gt 8 && ${currentVersionWOPreId: -8} =~ ^[0-9]{8}$ ]]; then
           currentVersionNo=${currentVersionWOPreId:0:-8}
           if [[ $currentVersionNo != *?[0-9] ]]; then
             currentVersionNo=${currentVersionNo}0

--- a/.github/actions/updateVersion/action.yml
+++ b/.github/actions/updateVersion/action.yml
@@ -8,7 +8,14 @@ inputs:
     required: true    
   isPreRelease:
     default: true
-    type: boolean      
+    type: boolean
+  snapshot:
+    description: >-
+      Mark the version as a nightly snapshot by appending '-SNAPSHOT'
+      (e.g. 5.13.0-SNAPSHOT) instead of the isPreRelease timestamp suffix.
+      Valid semver, so 'vsce package' accepts it; nightly VSIXes are never
+      published to the Marketplace, so the suffix never reaches it.
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -17,14 +24,18 @@ runs:
       run: |
         cd packages/${{ inputs.path }}
         currentVersion=$(node -p "require('./package.json').version")
-        if [[ ${#currentVersion} -ge 8 ]]; then
-          currentVersionWOPreId=${currentVersion%-*}
+        currentVersionWOPreId=${currentVersion%-*}
+        # Only strip when the base version is long enough to actually carry an
+        # 8-char timestamp. A plain or '-SNAPSHOT' version (e.g. 5.13.0-SNAPSHOT
+        # -> base 5.13.0, 6 chars) has nothing to strip, and ':0:-8' on a
+        # shorter string is a fatal bash expansion error.
+        if [[ ${#currentVersionWOPreId} -gt 8 ]]; then
           currentVersionNo=${currentVersionWOPreId:0:-8}
           if [[ $currentVersionNo != *?[0-9] ]]; then
             currentVersionNo=${currentVersionNo}0
           fi
           npm version $currentVersionNo --preid beta --no-git-tag-version
-        fi  
+        fi
 
     - name: Update extension versions
       if: ${{ inputs.version != 'N/A' }}
@@ -42,11 +53,21 @@ runs:
 
     - name: Set prerelase version
       shell: bash
-      if: ${{ inputs.isPreRelease == 'true' }}
+      if: ${{ inputs.isPreRelease == 'true' && inputs.snapshot != 'true' }}
       run: |
         cd packages/${{ inputs.path }}
         currentVersion=$(node -p "require('./package.json').version")
         newVersion=${currentVersion}${{ steps.timestamp.outputs.timestamp }}
         echo $newVersion
         npm version $newVersion --preid beta --no-git-tag-version
-        
+
+    - name: Set snapshot version
+      shell: bash
+      if: ${{ inputs.snapshot == 'true' }}
+      run: |
+        cd packages/${{ inputs.path }}
+        currentVersion=$(node -p "require('./package.json').version")
+        # Strip any pre-existing prerelease id so re-runs stay idempotent.
+        newVersion="${currentVersion%%-*}-SNAPSHOT"
+        echo $newVersion
+        npm version $newVersion --no-git-tag-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
       isPreRelease:
         default: true
         type: boolean
+      snapshot:
+        description: Stamp the extension version as '<version>-SNAPSHOT' (nightly builds)
+        default: false
+        type: boolean
       enableCache:
         default: true
         type: boolean
@@ -106,6 +110,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           isPreRelease: ${{ inputs.isPreRelease }}
+          snapshot: ${{ inputs.snapshot }}
           lsSource: ${{ inputs.lsSource }}
           ballerinaLsTag: ${{ inputs.ballerinaLsTag }}
           enableCache: ${{ inputs.enableCache }}

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -289,7 +289,7 @@ jobs:
       - ls-windows-build
       - ls-trivy
       - Build
-    if: ${{ github.repository == 'wso2/ballerina-vscode' }}
+    if: ${{ github.repository == 'ballerina-platform/ballerina-vscode' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -310,7 +310,7 @@ jobs:
       - name: Publish pre-release
         uses: ./.github/actions/release
         with:
-          repo: wso2/ballerina-vscode
+          repo: ${{ github.repository }}
           name: ballerina
           chatAPI: ${{ secrets.BI_TEAM_CHAT_API }}
           # Rolling tag: each daily run deletes and recreates the `nightly`
@@ -356,7 +356,7 @@ jobs:
       - ls-windows-build
       - ls-trivy
       - Build
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository == 'wso2/ballerina-vscode' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository == 'ballerina-platform/ballerina-vscode' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -270,9 +270,20 @@ jobs:
       # Marketplace, so instead of the isPreRelease timestamp suffix they get a
       # '-SNAPSHOT' version (5.13.0-SNAPSHOT). It is valid semver so vsce
       # accepts it, and it makes a nightly VSIX unmistakable next to a release
-      # build of the same version. The bundled LS is built from source
-      # (lsSource defaults to 'local'), so it always matches the extension
-      # version regardless of this.
+      # build of the same version.
+      #
+      # isPreRelease: false is deliberate and does more than drop the timestamp.
+      # It is also exported into the rush build env (actions/build/action.yml),
+      # where common-libs/scripts/package-vsix.js turns it into
+      # 'vsce package --pre-release'. Nightlies are therefore packaged WITHOUT
+      # that flag, on purpose: the flag marks the VSIX as a pre-release build,
+      # which moves whoever installs it onto the Marketplace pre-release channel
+      # for future updates. A nightly is unvetted main, not an opt-in supported
+      # channel, so it should not silently enroll testers in one.
+      #
+      # The bundled LS is built from source (lsSource defaults to 'local'), so
+      # it always matches the extension version, and isPreRelease has no effect
+      # on LS resolution here (that path is gated on lsSource == 'download').
       isPreRelease: false
       snapshot: true
 

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -266,11 +266,15 @@ jobs:
       ballerina: true
       runFastTests: true
       runBalE2ETests: true
-      # Daily builds ship only to a rolling GitHub `nightly` release (never the
-      # Marketplace), so they use the plain package.json version — no timestamp
-      # suffix. The bundled LS is built from source (lsSource defaults to
-      # 'local'), so it always matches the extension version regardless of this.
+      # Daily builds ship only to a rolling GitHub `nightly` release, never the
+      # Marketplace, so instead of the isPreRelease timestamp suffix they get a
+      # '-SNAPSHOT' version (5.13.0-SNAPSHOT). It is valid semver so vsce
+      # accepts it, and it makes a nightly VSIX unmistakable next to a release
+      # build of the same version. The bundled LS is built from source
+      # (lsSource defaults to 'local'), so it always matches the extension
+      # version regardless of this.
       isPreRelease: false
+      snapshot: true
 
   # ─────────────────────────────────────────────────────────────────────────
   # Daily pre-release — publish the extension VSIX as a GitHub pre-release

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -266,6 +266,11 @@ jobs:
       ballerina: true
       runFastTests: true
       runBalE2ETests: true
+      # Daily builds ship only to a rolling GitHub `nightly` release (never the
+      # Marketplace), so they use the plain package.json version — no timestamp
+      # suffix. The bundled LS is built from source (lsSource defaults to
+      # 'local'), so it always matches the extension version regardless of this.
+      isPreRelease: false
 
   # ─────────────────────────────────────────────────────────────────────────
   # Daily pre-release — publish the extension VSIX as a GitHub pre-release
@@ -304,6 +309,9 @@ jobs:
           repo: wso2/ballerina-vscode
           name: ballerina
           chatAPI: ${{ secrets.BI_TEAM_CHAT_API }}
+          # Rolling tag: each daily run deletes and recreates the `nightly`
+          # release so it always points at the latest build.
+          tag: nightly
 
   # ─────────────────────────────────────────────────────────────────────────
   # Notifications

--- a/.github/workflows/publish-vsix.yml
+++ b/.github/workflows/publish-vsix.yml
@@ -28,7 +28,7 @@ on:
 
 env:
   EXTENSION_NAME: ballerina
-  REPO: wso2/ballerina-vscode
+  REPO: ${{ github.repository }}
 
 jobs:
   publish:
@@ -196,7 +196,7 @@ jobs:
   Notify:
     name: Notify (failure)
     needs: [publish]
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository == 'wso2/ballerina-vscode' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository == 'ballerina-platform/ballerina-vscode' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -142,10 +142,10 @@ jobs:
             "${{ secrets.EDITOR_TEAM_CHAT_API }}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" \
             -d "$body"
 
-      - name: Create a release in wso2/ballerina-vscode repo
+      - name: Create a release in ${{ github.repository }} repo
         uses: ./.github/actions/release
         with:
-          repo: wso2/ballerina-vscode
+          repo: ${{ github.repository }}
           name: ballerina
           chatAPI: ${{ secrets.EDITOR_TEAM_CHAT_API }}
           threadKey: ballerina-release-${{ github.run_id }}
@@ -204,7 +204,7 @@ jobs:
 
   Notify:
     needs: [Release]
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository == 'wso2/ballerina-vscode' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository == 'ballerina-platform/ballerina-vscode' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/sync-main-with-releases.yml
+++ b/.github/workflows/sync-main-with-releases.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   sync-main:
-    if: github.event.pull_request.merged == true && github.repository == 'wso2/ballerina-vscode'
+    if: github.event.pull_request.merged == true && github.repository == 'ballerina-platform/ballerina-vscode'
     permissions:
       contents: write
       pull-requests: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ brew install --cask temurin@21
 ## Initial checkout
 
 ```bash
-git clone --recurse-submodules https://github.com/wso2/ballerina-vscode.git
+git clone --recurse-submodules https://github.com/ballerina-platform/ballerina-vscode.git
 cd ballerina-vscode
 
 # If you cloned without --recurse-submodules:


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Three related problems in the release automation:

1. **The daily build verified everything but published nothing consumable.** `daily-build.yml` ran the full LS matrix (pack, test, Windows build, Trivy) plus the extension build and e2e suite, but the resulting VSIX only ever existed as a workflow run artifact. Anyone wanting to test the latest `main` had to open a workflow run, find the artifact, and unzip it — and had no stable link to point others at.
2. **The repository was transferred from `wso2/ballerina-vscode` to `ballerina-platform/ballerina-vscode`, and the workflows still hardcoded the old name.** Because `github.repository` now evaluates to the new name, every `if: github.repository == 'wso2/ballerina-vscode'` guard was silently false. That disabled the nightly publish job, all three failure notifications, and the main-sync PR — producing green runs that quietly did nothing. The `repo:`/`REPO:` values were only still working because GitHub redirects renamed repositories.
3. **The `release` composite action was fragile.** It parsed the release ID out of JSON with `sed`, derived the version by cutting the VSIX filename at its last `-`, and never checked whether the VSIX asset upload actually succeeded.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Publish every successful daily build to a **rolling `nightly` GitHub pre-release**, so there is always one predictable place to get the latest build of `main`.
- Give nightly VSIXes a **`-SNAPSHOT` version** so a nightly build is never mistaken for a release build of the same version.
- Point every workflow at the correct repository, and make the dynamic references rename-proof.
- Harden the `release` action so a failed release or upload fails the job instead of reporting success.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

### 1. Rolling `nightly` pre-release

`.github/actions/release/action.yml` gains an optional `tag` input that switches it between two modes:

| `tag` input | Release tag | Release name | Behaviour |
|---|---|---|---|
| empty (default) | `v<version>` | `Release v<version>` | unchanged — a new release per version |
| e.g. `nightly` | `nightly` | `Nightly Build (v<version>)` | deletes the existing release **and** git tag ref first, then recreates |

`daily-build.yml` passes `tag: nightly`. Because the tag is reused, the download URL stays stable across nights. Releases are created with `prerelease: true`, so nightlies carry the GitHub **Pre-release** badge and never appear as "Latest". The Google Chat notification links were updated to use the resolved `releaseTag` rather than a hardcoded `v<version>`, so the card's "Download VSIX" button points at the right place in both modes.

The nightly publish job is gated on **all** verification jobs — `ls-ubuntu-pack`, `ls-ubuntu-test`, `ls-windows-build`, `ls-trivy`, and `Build` — so a Trivy or test failure blocks the nightly.

### 2. `-SNAPSHOT` versioning for nightlies

A new `snapshot` input threads through `build.yml` → `actions/build` → `actions/updateVersion`, where it adds a `Set snapshot version` step producing `<version>-SNAPSHOT` (e.g. `5.13.0-SNAPSHOT`).

- It is **mutually exclusive** with the existing timestamp suffix: the `Set prerelase version` step now also requires `snapshot != 'true'`, so the two can never both apply.
- `-SNAPSHOT` is valid semver, and `vsce package` validates the version with nothing more than `semver.valid()` (`@vscode/vsce/out/validation.js`), so packaging accepts it. Nightly VSIXes are never published to a marketplace, so the suffix never reaches one.
- The step strips any pre-existing prerelease id (`${currentVersion%%-*}`) so re-runs are idempotent rather than yielding `…-SNAPSHOT-SNAPSHOT`.

Existing version behaviour is untouched:

| Trigger | Resulting version |
|---|---|
| Daily build (new) | `5.13.0-SNAPSHOT` |
| `release-vsix.yml`, `isPreRelease=true` | `5.13.26072909` (timestamp as patch) |
| `release-vsix.yml`, `version=patch` | `5.12.4` |
| `release-vsix.yml`, `version=minor` | `5.14.0` |
| `release-vsix.yml`, `version=major` | `6.0.0` |

### 3. Filename parsing that survives a prerelease id

`actions/release` and `actions/dailyBuildNotification` both derived the version with `${file##*-}`, which cuts at the **last** dash. For `ballerina-5.13.0-SNAPSHOT.vsix` that yields `SNAPSHOT`, producing a release titled `Nightly Build (vSNAPSHOT)`. Both now strip the `<name>-` prefix and the `.vsix` suffix instead.

### 4. Hardened `Remove timestamp` guard

`updateVersion`'s strip step guarded on the length of the **full** version and then applied `${…:0:-8}` to the base. For `5.13.0-SNAPSHOT` the base is only 6 characters, and a negative length longer than the string is a fatal bash expansion error. The guard now measures the base version and requires `> 8`.

This also fixes a pre-existing bug it exposed: a version exactly 8 characters long (e.g. `5.13.100`) passed the old `>= 8` check, stripped to an empty string, was padded to `0`, and rewrote `package.json` to version **`0`**.

### 5. Correct repository references

- Fork guards (which need a literal to compare against) → `'ballerina-platform/ballerina-vscode'`: `daily-build.yml`, `release-vsix.yml`, `publish-vsix.yml`, `sync-main-with-releases.yml`.
- API targets → `${{ github.repository }}`, so a future rename cannot break them: `daily-build.yml`, `release-vsix.yml`, `publish-vsix.yml`.
- `CONTRIBUTING.md` clone URL → new org.

Deliberately left alone: `publisher: "wso2"`, `itemName=WSO2.ballerina`, and `open-vsx.org/extension/wso2/ballerina` are **marketplace publisher identities**, not repository references — changing them would orphan the published extension. The `wso2/vscode-extensions` links in the PR template correctly refer to the submodule's source repository.

### 6. Release-creation hardening (CodeRabbit review)

The release step was rewritten:

- `set -euo pipefail`; release ID extracted with `jq` instead of `sed`; `target_commitish` set explicitly.
- Token and other values passed via `env:` rather than interpolated into the script body.
- **Upload verification** — `curl` exits 0 on a non-2xx HTTP response, so `set -e` alone let a rejected upload (auth, size limit, rate limit) pass as success. This mattered most on the rolling path, where the previous nightly has already been deleted: an unchecked failure would leave an assetless `nightly` release and a notification linking to a 404. The upload response is now checked for an asset `id`, failing the step with the response body otherwise.
- **Bounded timeouts** — `--connect-timeout 15` everywhere, with `--max-time 60` for metadata calls and `--max-time 900` for the asset upload (the VSIX is ~75–97 MB, so a single blanket 60s would have broken every release).

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

**N/A** — this PR changes only GitHub Actions workflows, composite actions, and `CONTRIBUTING.md`. No extension or webview code is touched, so there is no UI surface.

## User stories
> Summary of user stories addressed by this change>

- As a **developer or QA engineer**, I want to install the latest build of `main` from a single predictable GitHub release instead of hunting through workflow run artifacts.
- As a **developer**, I want an installed nightly to be identifiable as a nightly from its version string, so a `-SNAPSHOT` build is never confused with a released version.
- As a **maintainer**, I want nightly and release automation to actually run after the repository transfer, and to be notified when it fails, instead of seeing green runs that skipped their publish step.
- As a **release manager**, I want a failed VSIX upload to fail the workflow rather than silently produce a release with no artifact attached.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Successful daily builds are now published to a rolling `nightly` GitHub pre-release, versioned `<version>-SNAPSHOT`. The release tag is reused, so the latest nightly is always available at the same location. Also fixes release-automation jobs that stopped running after the repository transfer to `ballerina-platform`.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

**N/A for product documentation** — the change is confined to CI/release automation and has no effect on extension behaviour or user-facing features.

Repository documentation updated in this PR: `CONTRIBUTING.md` clone URL now points at `ballerina-platform/ballerina-vscode`.

> Note: `.github/workflows/README.md` is stale independently of this PR (it documents `ls-build-master.yml` and `ls-trivy.yml`, neither of which exists). Left out to keep this PR scoped; worth a follow-up.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

**N/A** — internal build automation with no training content impact.

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

**N/A** — CI/release plumbing only. Nothing here is part of any product surface that certification exams cover.

## Automation tests
> Unit tests / Integration tests

No new unit or integration tests: the change set is GitHub Actions YAML and shell, which the repo's jest and Playwright suites do not cover. Verification performed instead:

- **YAML validity** — all 8 workflows and all 7 composite actions parse.
- **Version stamping** — replayed the `updateVersion` steps end to end across every input combination (`isPreRelease` × `patch`/`minor`/`major`/`N/A` × `snapshot`), from clean, timestamped, and `-SNAPSHOT` starting versions. Confirmed the four documented outcomes, confirmed `-SNAPSHOT` is idempotent on re-run, and confirmed the new guard changes behaviour *only* for the two previously-broken shapes (`5.13.0-SNAPSHOT`, `5.13.100`) while leaving all real timestamped cases identical.
- **Filename parsing** — verified the new prefix/suffix strip against `-SNAPSHOT`, plain, and timestamped VSIX names, and that all three still match the existing `ls` glob.
- **`vsce` compatibility** — confirmed `vsce` validates the version via `semver.valid()` only, and that `5.13.0-SNAPSHOT` is valid semver.
- **Upload verification** — exercised the new check with a stubbed `curl` across four responses: success returns exit 0; auth error, size limit, and empty body each exit 1 and print the response body.

**Not yet exercised end to end:** the nightly path has not run as a real scheduled build, so the first scheduled run (or a manual `workflow_dispatch` of Daily Build) is the real confirmation. Recommend a manual dispatch before merge.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — no Java/source changes in this PR; the language server is untouched.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — all credentials remain `${{ secrets.* }}` / `${{ github.token }}` references.

Incidental hardening: the release step now passes the token and other values through `env:` instead of interpolating them directly into the shell script body, and the Trivy scan continues to gate the nightly publish.

## Samples
> Provide high-level details about the samples related to this feature

**N/A** — no samples relate to build automation.

## Related PRs

None. CodeRabbit raised one actionable review comment on this PR (unverified VSIX asset upload in `.github/actions/release/action.yml`); it is addressed in commit "Address coderabbit suggestions" and described under Approach §6.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

No data or code migration. Two operational notes:

1. The first nightly run **creates** the `nightly` git tag and release. Every subsequent run **deletes and recreates** both, so the tag intentionally does not preserve history — it always points at the newest build. The job needs `contents: write`, which it already has.
2. The repository-reference fixes re-enable jobs that had been silently skipped since the transfer (nightly publish, failure notifications, main-sync PR). Expect notification traffic to resume on the next failure.

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested

- **CI (unchanged by this PR):** GitHub-hosted `ubuntu-latest` and `windows-latest`; JDK 21.0.3 (Temurin); Node 22.x; pnpm 10.11.0; Ballerina 2201.13.2 (extension) / 2201.13.3 (LS).
- **Local verification:** macOS (darwin 25.5.0), Node 22.22.1 — used for the YAML, version-stamping, filename-parsing, and upload-validation checks described under Automation tests.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

- **`vsce` version validation is looser than the Marketplace.** `@vscode/vsce` only calls `semver.valid()`, so a prerelease identifier such as `-SNAPSHOT` packages fine. The Marketplace's stricter `x.y.z` expectation is why the existing prerelease scheme concatenates a timestamp onto the patch instead of using a `-beta.N` suffix — but since nightlies are never published to a marketplace, that constraint does not apply to them.
- **`npm version` parses loosely and normalises leading zeros.** `5.13.0` + `26072909` produces `5.13.026072909`, which strict semver rejects, but npm stores it as `5.13.26072909`. This is why existing prerelease tags read the way they do, and it is worth knowing before touching that logic.
- **Bash negative substring lengths are a trap.** `${var:0:-8}` is a fatal expansion error — not an empty string — when the negative length exceeds the string length. Under `shell: bash` (which runs with `-e`) that fails the whole step, so any such expression needs a length guard ahead of it.
- **`curl` exits 0 on HTTP errors.** `set -e` gives no protection against a 4xx/5xx response; the response body must be inspected explicitly (or `--fail` used). Worth auditing wherever a workflow talks to an API with `curl`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added nightly build support by stamping VSIX versions with a `-SNAPSHOT` prerelease suffix and publishing successful builds as a rolling `nightly` GitHub pre-release.
- Extended CI/build automation with a `snapshot` input that ensures consistent, idempotent version stamping for nightly builds.
- Hardened release automation to support reusable rolling releases via optional `tag` selection, improved VSIX version/filename parsing, and strengthened upload/asset handling and release metadata updates.
- Updated notification and parsing logic to correctly derive versions from nightly/prerelease VSIX filenames.
- Updated workflow guards, release target repositories, and URLs/conditions to reflect the post-transfer `ballerina-platform/ballerina-vscode` repository.
- Updated contributor documentation to use the new `ballerina-platform/ballerina-vscode` clone URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->