### PR TITLE
Wire Artifact.icon into the new IconDescriptor model (3/4)

### DIFF
--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/artifactsgenerator/Artifact.java
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/artifactsgenerator/Artifact.java
@@ -24,11 +24,14 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.designmodelgenerator.core.CommonUtils;
+import io.ballerina.modelgenerator.commons.IconDescriptor;
+import io.ballerina.modelgenerator.commons.trigger.utils.TriggerArtifactResolver;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.tools.text.LineRange;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -43,14 +46,14 @@ import java.util.Optional;
  * @param accessor   accessor of the artifact
  * @param scope      lexical scope of the artifact (global/local/object)
  * @param visibility visibility of the artifact (public/module/private)
- * @param icon       icon representing the artifact
+ * @param icon       resolved icon descriptor for the artifact (url/glyph/color/kind/source)
  * @param children   map of child artifacts (id -> child)
  * @param module     module name of the artifact
  * @param metadata   metadata about the artifact
  * @since 1.0.0
  */
 public record Artifact(String id, LineRange location, String type, String name, String accessor,
-                       String scope, String visibility, String icon, String module,
+                       String scope, String visibility, IconDescriptor icon, String module,
                        Map<String, Artifact> children, Map<String, Object> metadata) {
 
     private static final String CATEGORY_ENTRY_POINTS = "Entry Points";
@@ -82,39 +85,6 @@ public record Artifact(String id, LineRange location, String type, String name, 
             Map.entry(Type.VARIABLE.name(), CATEGORY_VARIABLES),
             Map.entry(Type.WORKFLOW.name(), CATEGORY_WORKFLOWS),
             Map.entry(Type.ACTIVITY.name(), CATEGORY_WORKFLOWS));
-
-    private static final Map<String, String> entryPointMap = Map.ofEntries(
-            Map.entry("http", "HTTP Service"),
-            Map.entry("graphql", "GraphQL Service"),
-            Map.entry("tcp", "TCP Service"),
-            Map.entry("file", "Local Files"),
-            Map.entry("ftp", "FTP Integration"),
-            Map.entry("mqtt", "MQTT Event Integration"),
-            Map.entry("asb", "Azure Service Bus Event Integration"),
-            Map.entry("rabbitmq", "RabbitMQ Event Integration"),
-            Map.entry("kafka", "Kafka Event Integration"),
-            Map.entry("salesforce", "Salesforce Event Integration"),
-            Map.entry("github", "GitHub Event Integration"),
-            Map.entry("twilio", "Twilio Event Integration"),
-            Map.entry("ai", "AI Agent Services"),
-            Map.entry("solace", "Solace Event Integration"),
-            Map.entry("mssql", "CDC MSSQL Service"),
-            Map.entry("postgresql", "CDC PostgreSQL Service"),
-            Map.entry("mysql", "CDC MySQL Service"),
-            Map.entry("shopify", "Shopify Event Integration")
-    );
-
-    /**
-     * Mapping of module names to annotation field names for services that derive their name from annotations. Each
-     * module can have multiple field names to try in order of preference.
-     */
-    private static final Map<String, String[]> moduleAnnotationFields = Map.of(
-            "solace", new String[]{"queueName", "topicName"},
-            "mssql", new String[]{"tables"},
-            "postgresql", new String[]{"tables"},
-            "mysql", new String[]{"tables"},
-            "ftp", new String[]{"path"}
-    );
 
     public static String getCategory(String type) {
         return typeCategoryMap.getOrDefault(type, CATEGORY_DEFAULT);
@@ -195,8 +165,9 @@ public record Artifact(String id, LineRange location, String type, String name, 
         private String accessor;
         private Scope scope = Scope.GLOBAL;
         private Visibility visibility = null;
-        private String icon;
+        private IconDescriptor icon;
         private String module;
+        private ModuleID moduleId;
         private final Map<String, Artifact> children = new HashMap<>();
         private Map<String, Object> metadata = null;
 
@@ -248,7 +219,8 @@ public record Artifact(String id, LineRange location, String type, String name, 
                 return this;
             }
             ModuleID moduleId = moduleSymbol.get().id();
-            this.icon = CommonUtils.generateIcon(moduleId);
+            this.moduleId = moduleId;
+            this.icon = TriggerArtifactResolver.resolveIcon(moduleId);
             this.module = moduleId.moduleName();
             return this;
         }
@@ -261,20 +233,16 @@ public record Artifact(String id, LineRange location, String type, String name, 
         }
 
         public Builder serviceNameWithPath(String path) {
-            if (module == null || !entryPointMap.containsKey(module)) {
-                this.name = path;
-            } else {
-                this.name = entryPointMap.get(module) + " - " + path;
-            }
+            Optional<String> displayName = moduleId == null
+                    ? Optional.empty() : TriggerArtifactResolver.resolveDisplayName(moduleId);
+            this.name = displayName.map(dn -> dn + " - " + path).orElse(path);
             return this;
         }
 
         public Builder serviceName(String name) {
-            if (module == null || !entryPointMap.containsKey(module)) {
-                this.name = name;
-            } else {
-                this.name = entryPointMap.get(module);
-            }
+            Optional<String> displayName = moduleId == null
+                    ? Optional.empty() : TriggerArtifactResolver.resolveDisplayName(moduleId);
+            this.name = displayName.orElse(name);
             return this;
         }
 
@@ -298,16 +266,16 @@ public record Artifact(String id, LineRange location, String type, String name, 
          * @return true if name was successfully extracted from annotation, false otherwise
          */
         public boolean trySetNameFromAnnotation(ServiceDeclarationNode serviceNode) {
-            if (module != null && moduleAnnotationFields.containsKey(module)) {
-                String[] fieldNames = moduleAnnotationFields.get(module);
-
-                for (String fieldName : fieldNames) {
-                    Optional<String> extractedValue = CommonUtils.extractServiceAnnotationField(serviceNode, fieldName);
-                    if (extractedValue.isPresent()) {
-                        this.name = Objects.requireNonNullElse(entryPointMap.get(module), "") + " - " +
-                                extractedValue.get();
-                        return true;
-                    }
+            if (moduleId == null) {
+                return false;
+            }
+            List<String> fieldNames = TriggerArtifactResolver.resolveLabelFields(moduleId);
+            for (String fieldName : fieldNames) {
+                Optional<String> extractedValue = CommonUtils.extractServiceAnnotationField(serviceNode, fieldName);
+                if (extractedValue.isPresent()) {
+                    String displayName = TriggerArtifactResolver.resolveDisplayName(moduleId).orElse("");
+                    this.name = displayName + " - " + extractedValue.get();
+                    return true;
                 }
             }
             return false;

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/connection.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/connection.json
@@ -21,7 +21,12 @@
         "name": "graphQlConnection",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_graphql_1.17.0.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_graphql_1.17.0.png",
+          "glyph": "bi-graphql",
+          "kind": "graphql",
+          "source": "central"
+        },
         "module": "graphql",
         "children": {}
       },
@@ -42,7 +47,11 @@
         "name": "httpConnection",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       },
@@ -63,7 +72,10 @@
         "name": "localClient",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/$anon_._0.0.0.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/$anon_._0.0.0.png",
+          "source": "central"
+        },
         "module": ".",
         "children": {}
       },
@@ -84,7 +96,12 @@
         "name": "tcpConnection",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_tcp_1.13.5.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_tcp_1.13.5.png",
+          "glyph": "bi-tcp",
+          "kind": "listener",
+          "source": "central"
+        },
         "module": "tcp",
         "children": {}
       }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/http_service.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/http_service.json
@@ -21,7 +21,11 @@
         "name": "httpClient",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       }
@@ -44,7 +48,11 @@
         "name": "refListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       },
@@ -65,7 +73,11 @@
         "name": "securedEP",
         "scope": "Global",
         "visibility": "public",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       }
@@ -88,7 +100,11 @@
         "name": "HTTP Service - /root/path-id",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {
           "post#data": {
@@ -210,7 +226,11 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {
           "init": {
@@ -271,7 +291,11 @@
         "name": "HTTP Service - /api/v1",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {
           "get#path": {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/kafka.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/kafka.json
@@ -42,7 +42,12 @@
         "name": "orderListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_kafka_4.6.5.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerinax_kafka_4.6.5.png",
+          "glyph": "bi-kafka",
+          "kind": "event",
+          "source": "central"
+        },
         "module": "kafka",
         "children": {}
       }
@@ -65,7 +70,12 @@
         "name": "Kafka Event Integration",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_kafka_4.6.5.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerinax_kafka_4.6.5.png",
+          "glyph": "bi-kafka",
+          "kind": "event",
+          "source": "central"
+        },
         "module": "kafka",
         "children": {
           "onConsumerRecord": {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/listener.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/listener.json
@@ -21,7 +21,11 @@
         "name": "httpDefaultListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       },
@@ -61,7 +65,13 @@
         "name": "rabbitmqListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.5.0.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.6.0.png",
+          "glyph": "bi-rabbitmq",
+          "color": "#f60",
+          "kind": "event",
+          "source": "central"
+        },
         "module": "rabbitmq",
         "children": {}
       },
@@ -82,7 +92,11 @@
         "name": "refListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/project.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/project.json
@@ -21,7 +21,11 @@
         "name": "httpClient",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       },
@@ -42,7 +46,11 @@
         "name": "httpClient2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       }
@@ -65,7 +73,11 @@
         "name": "ls",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       },
@@ -86,7 +98,11 @@
         "name": "securedEP",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       },
@@ -107,7 +123,11 @@
         "name": "securedEP2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {}
       }
@@ -170,7 +190,11 @@
         "name": "HTTP Service - /api2",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {
           "get#path": {
@@ -212,7 +236,11 @@
         "name": "HTTP Service - /api1",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {
           "get#path": {
@@ -273,7 +301,11 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {
           "init": {
@@ -334,7 +366,11 @@
         "name": "HTTP Service - /",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.4.png",
+          "kind": "http",
+          "source": "central"
+        },
         "module": "http",
         "children": {
           "init": {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/rabbitmq.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/rabbitmq.json
@@ -21,7 +21,13 @@
         "name": "rabbitmqListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.5.0.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.6.0.png",
+          "glyph": "bi-rabbitmq",
+          "color": "#f60",
+          "kind": "event",
+          "source": "central"
+        },
         "module": "rabbitmq",
         "children": {}
       }
@@ -44,7 +50,13 @@
         "name": "RabbitMQ Event Integration - \"queueName\"",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.5.0.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerinax_rabbitmq_3.6.0.png",
+          "glyph": "bi-rabbitmq",
+          "color": "#f60",
+          "kind": "event",
+          "source": "central"
+        },
         "module": "rabbitmq",
         "children": {
           "onMessage": {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/tcp.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/artifacts/config/tcp.json
@@ -100,7 +100,12 @@
         "name": "tcpListener",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_tcp_1.13.5.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_tcp_1.13.5.png",
+          "glyph": "bi-tcp",
+          "kind": "listener",
+          "source": "central"
+        },
         "module": "tcp",
         "children": {}
       }
@@ -123,7 +128,12 @@
         "name": "TCP Service",
         "scope": "Global",
         "visibility": "module",
-        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_tcp_1.13.5.png",
+        "icon": {
+          "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_tcp_1.13.5.png",
+          "glyph": "bi-tcp",
+          "kind": "listener",
+          "source": "central"
+        },
         "module": "tcp",
         "children": {
           "onConnect": {

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/connections.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/connections.json
@@ -22,7 +22,11 @@
           "name": "httpEp",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+          "icon": {
+            "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.6.png",
+            "kind": "http",
+            "source": "central"
+          },
           "module": "http",
           "children": {}
         }

--- a/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/main.json
+++ b/packages/ballerina-language-server/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/publish_artifacts/config/main.json
@@ -89,7 +89,11 @@
           "name": "httpListener",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+          "icon": {
+            "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.6.png",
+            "kind": "http",
+            "source": "central"
+          },
           "module": "http",
           "children": {}
         }
@@ -114,7 +118,11 @@
           "name": "HTTP Service - /restaurant",
           "scope": "Global",
           "visibility": "module",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.3.png",
+          "icon": {
+            "url": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.16.6.png",
+            "kind": "http",
+            "source": "central"
+          },
           "module": "http",
           "children": {
             "post#orders": {


### PR DESCRIPTION
## Summary

**PR 3 of 4** (see #731 for the full split and overall architecture). This PR is stacked on
`phase2/connector-onboarding` and is a small, self-contained tie-in: it wires
`architecture-model-generator`'s `Artifact` model into the `IconDescriptor` type that PR 1 introduced,
so architecture/project-tree nodes (connections, listeners, entry points, etc. in the project explorer
and component diagram) get the same rich icon resolution triggers already get, instead of a bare
image-URL string.

## Scope

```mermaid
classDiagram
    class Artifact {
        +String id
        +String name
        ~~icon: String~~
        +icon: IconDescriptor
    }
    class IconDescriptor {
        +String url
        +String glyph
        +String color
        +String kind
        +String source
        +String light
        +String dark
    }
    Artifact --> IconDescriptor : icon (was plain String)
```

- `Artifact.icon` changes from a plain `String` (just a central-derived PNG URL) to the structured
  `IconDescriptor` record from PR 1 — `url` for a directly renderable image, plus optional
  `glyph`/`color` (IDE brand icon + tint) and `light`/`dark` theme-paired variants, matching how
  trigger icons already resolve.
- Regenerated two `publish_artifacts` test goldens (`connections.json`, `main.json`) whose `icon`
  fixtures predated this type change and still had plain strings — Gson threw a hard
  `JsonSyntaxException` trying to deserialize a string where an object was now expected. No production
  code deserializes an `Artifact` from JSON (it's serialize-only), so this was purely a stale-fixture
  fix, not a new compatibility shim.

## Known follow-ups (not part of this PR)

- `existing_project.json` / `testReloadProjectWithPreExistingArtifacts` is left red on top of the same
  stale-icon issue: its golden also bakes in an unrelated, pre-existing reclassification (telegram-agent
  connections mis-typed as `VARIABLE` instead of `CONNECTION`) that needs its own investigation before
  regenerating — deliberately not touched here to avoid silently absorbing an unrelated bug into this
  golden.
- `ArtifactsTest` shows 4 pre-existing failures (`connection`/`http_service`/`listener`/`project.json`)
  from the same `http` 2.16.5-vs-2.16.6 golden drift called out in PR 1/2 — unrelated to this change.
- This checkout deliberately **excludes** `DesignModelGenerator.java` and 3 `get_design_model` fixtures:
  this feature branch never actually touched that file (identical to its own base commit), but `main`
  gained an unrelated workflow-deletion-range fix to it after the branch diverged. A naive
  whole-directory port would have silently reverted that fix — this PR's diff intentionally leaves it
  alone.

## Testing

- `./gradlew :architecture-model-generator:architecture-model-generator-core:test :architecture-model-generator:architecture-model-generator-ls-extension:test`
  — 51/56 pass; the 5 failures are the two pre-existing issues above, not regressions from this change.
- Checkstyle clean.

## Merge order

Stacked on PR 2 (connector-onboarding) — independent of PR 4 (frontend).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced `Artifact.icon` string values with structured `IconDescriptor` models.
- Refactored artifact naming and category resolution to use module metadata and `TriggerArtifactResolver`.
- Updated architecture-model and publish-artifacts test fixtures to reflect structured icon metadata and refreshed icon URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->