### PR TITLE
Bump ballerina/workflow to 0.8.0

### DIFF
--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_activity_and_wait.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_activity_and_wait.json
@@ -97,7 +97,7 @@
         "metadata": {
           "label": "calculateDiscount",
           "description": "Activity function for calculating discount",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.7.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.8.0.png"
         },
         "codedata": {
           "node": "ACTIVITY_CALL",

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_run.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_run.json
@@ -92,7 +92,7 @@
         "metadata": {
           "label": "Run Workflow",
           "description": "Run a workflow instance",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.7.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.8.0.png"
         },
         "codedata": {
           "node": "WORKFLOW_RUN",
@@ -349,7 +349,7 @@
         "metadata": {
           "label": "Send Data",
           "description": "Send data to an existing workflow instance",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.7.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.8.0.png"
         },
         "codedata": {
           "node": "SEND_DATA",
@@ -357,7 +357,7 @@
           "module": "workflow",
           "packageName": "workflow",
           "symbol": "sendData",
-          "version": "0.7.0",
+          "version": "0.8.0",
           "lineRange": {
             "fileName": "workflow_operations.bal",
             "startLine": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_sleep.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_sleep.json
@@ -93,7 +93,7 @@
         "metadata": {
           "label": "Sleep",
           "description": "Pause workflow execution for a specified duration",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.7.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.8.0.png"
         },
         "codedata": {
           "node": "SLEEP",
@@ -102,7 +102,7 @@
           "packageName": "workflow",
           "object": "Context",
           "symbol": "sleep",
-          "version": "0.7.0",
+          "version": "0.8.0",
           "lineRange": {
             "fileName": "workflow_sleep.bal",
             "startLine": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_wait_data_diagnostics.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_wait_data_diagnostics.json
@@ -105,7 +105,7 @@
               "kind": "DEFAULTABLE",
               "originalName": "minCount"
             },
-            "defaultValue": "0"
+            "defaultValue": "<int:Unsigned32>futures.length()"
           },
           "timeout": {
             "metadata": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_wait_data_diagnostics.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_wait_data_diagnostics.json
@@ -53,7 +53,7 @@
         "metadata": {
           "label": "Await Data",
           "description": "Wait for workflow data to be received",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.7.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.8.0.png"
         },
         "codedata": {
           "node": "WAIT_DATA",
@@ -62,7 +62,7 @@
           "packageName": "workflow",
           "object": "Context",
           "symbol": "await",
-          "version": "0.7.0",
+          "version": "0.8.0",
           "lineRange": {
             "fileName": "workflow_wait_data_diagnostics.bal",
             "startLine": {
@@ -105,7 +105,7 @@
               "kind": "DEFAULTABLE",
               "originalName": "minCount"
             },
-            "defaultValue": "<int:Unsigned32>futures.length()"
+            "defaultValue": "0"
           },
           "timeout": {
             "metadata": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_wait_data_optional_tuple.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_wait_data_optional_tuple.json
@@ -105,7 +105,7 @@
               "kind": "DEFAULTABLE",
               "originalName": "minCount"
             },
-            "defaultValue": "0"
+            "defaultValue": "<int:Unsigned32>futures.length()"
           },
           "timeout": {
             "metadata": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_wait_data_optional_tuple.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/workflow_wait_data_optional_tuple.json
@@ -53,7 +53,7 @@
         "metadata": {
           "label": "Await Data",
           "description": "Wait for workflow data to be received",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.7.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.8.0.png"
         },
         "codedata": {
           "node": "WAIT_DATA",
@@ -62,7 +62,7 @@
           "packageName": "workflow",
           "object": "Context",
           "symbol": "await",
-          "version": "0.7.0",
+          "version": "0.8.0",
           "lineRange": {
             "fileName": "workflow_wait_data_optional.bal",
             "startLine": {
@@ -105,7 +105,7 @@
               "kind": "DEFAULTABLE",
               "originalName": "minCount"
             },
-            "defaultValue": "<int:Unsigned32>futures.length()"
+            "defaultValue": "0"
           },
           "timeout": {
             "metadata": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/flow_model_diagnostics/config/wait_data.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/flow_model_diagnostics/config/wait_data.json
@@ -334,7 +334,7 @@
     "metadata": {
       "label": "Await Data",
       "description": "Wait for workflow data to be received",
-      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.7.0.png"
+      "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_workflow_0.8.0.png"
     },
     "codedata": {
       "node": "WAIT_DATA",
@@ -343,7 +343,7 @@
       "packageName": "workflow",
       "object": "Context",
       "symbol": "await",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "lineRange": {
         "fileName": "functions.bal",
         "startLine": {
@@ -386,7 +386,7 @@
           "kind": "DEFAULTABLE",
           "originalName": "minCount"
         },
-        "defaultValue": "<int:Unsigned32>futures.length()"
+        "defaultValue": "0"
       },
       "timeout": {
         "metadata": {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/flow_model_diagnostics/config/wait_data.json
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/flow_model_diagnostics/config/wait_data.json
@@ -386,7 +386,7 @@
           "kind": "DEFAULTABLE",
           "originalName": "minCount"
         },
-        "defaultValue": "0"
+        "defaultValue": "<int:Unsigned32>futures.length()"
       },
       "timeout": {
         "metadata": {

--- a/packages/ballerina-language-server/gradle.properties
+++ b/packages/ballerina-language-server/gradle.properties
@@ -121,4 +121,4 @@ ballerinaxAiMistralVersion = 1.1.2
 migrateTibcoVersion=1.2.13
 migrateMuleVersion=1.2.11
 
-ballerinaWorkflowVersion=0.7.0
+ballerinaWorkflowVersion=0.8.0


### PR DESCRIPTION
## Purpose

`ballerina/workflow` 0.8.0 is released on central. It reworks durable agents into the object model only (`workflow:DurableAgent`), gives agents data-event parity verbs (`sendData`/`getDataResult`/`waitForDataResult`), unifies starting/listing workflows and agents in the management API, and adds compile-time declaration validation.

## Approach
- `ballerinaWorkflowVersion` 0.7.0 → 0.8.0
- Regenerated the six workflow LS test goldens that embed the module version/icon (`workflow_run`, `workflow_sleep`, `workflow_activity_and_wait`, `workflow_wait_data_diagnostics`, `workflow_wait_data_optional_tuple`, `wait_data` diagnostics)

## Verification
Ran the full flow-model LS suite (1897 tests) against 0.8.0 and against a 0.7.0 baseline in the same environment: **the bump introduces zero new failures**, and three previously failing tests (`activity_call`, `config5`, `function_call-user-union2`) now pass. The remaining local failures (currency-converter/new-connection/redis/AI-provider goldens) pre-exist on main independently of the workflow module — matching the currently failing Daily Build — and are deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updated the Ballerina workflow dependency to version 0.8.0 and aligned related workflow icon/package version metadata across workflow language-server test fixtures (updated icon URLs and `codedata.version`/version fields from 0.7.0 to 0.8.0).
- Regenerated six workflow language-server diagram/diagnostics goldens for the new workflow version, including a restore of the `minCount` default expression in the wait-data goldens.
- Validated the update by running the full 1,897-test flow-model language-server suite against 0.8.0; no new failures were introduced, and three previously failing tests now pass while existing unrelated failures remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->