### PR TITLE
fix(bi-bridge): gate the websocket handshake

### DIFF
--- a/packages/ballerina-core/src/rpc-types/webview-bridge/index.ts
+++ b/packages/ballerina-core/src/rpc-types/webview-bridge/index.ts
@@ -41,12 +41,11 @@ export const WEBVIEW_WS_EVENTS = {
     CHAT_NOTIFY: "bi.chat.notify",
 } as const;
 
-/** Request envelope the form sends; the bridge unwraps it. The per-session
- *  `token` is required only in websocket (embedded) mode. */
+/** Request envelope the form sends; the bridge unwraps it. Authentication is
+ *  handled once during the websocket handshake, so requests carry no token. */
 export interface WebviewWsRequest {
     action: string;
     params?: unknown;
-    token?: string;
 }
 
 export interface WebviewWsResponseMessage {

--- a/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
+++ b/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
@@ -102,15 +102,7 @@ export class DefaultServer {
                 // cross-site page cannot read the token it also blocks
                 // cross-site websocket hijacking.
                 authToken: this.token,
-                // Retained as defence in depth: the handshake is the real gate,
-                // but this keeps an untokened request from being served if the
-                // transport is ever reached by some other route.
-                handleRequest: (request) => {
-                    if (!request || request.token !== this.token) {
-                        return this.errorResponse(request?.action ?? "unknown", "Unauthorized BI bridge request.");
-                    }
-                    return this.router.handle(request);
-                },
+                handleRequest: (request) => this.router.handle(request),
             });
             this.wsManager = mgr;
             this.wireEvents();

--- a/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
+++ b/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
@@ -95,6 +95,7 @@ export class DefaultServer {
         if (!this.wsBootstrap) {
             this.wsBootstrap = this.startWsServer().catch((error: unknown) => {
                 // Let a later call retry instead of caching the failure forever.
+                this.wsManager?.dispose();
                 this.wsBootstrap = undefined;
                 this.wsManager = undefined;
                 throw error;

--- a/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
+++ b/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
@@ -107,12 +107,7 @@ export class DefaultServer {
         const mgr = createExtensionTransportManager<WebviewWsRequest, WebviewWsResponse>({
             initialMode: "websocket",
             wsPort: 0,
-            // Authenticates the websocket handshake: a client that does not
-            // present this token is refused the upgrade, so it can neither send
-            // requests nor observe the events `publishEvent` broadcasts to every
-            // open socket (migration logs, migrated project details, AI chat).
-            // A cross-site page cannot read the token, so gating the upgrade
-            // also rules out cross-site websocket hijacking.
+            // Authenticates the handshake; upgrades without this token are refused.
             authToken: this.token,
             handleRequest: (request) => this.router.handle(request),
         });

--- a/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
+++ b/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
@@ -65,7 +65,9 @@ export class DefaultServer {
     private readonly router = createRequestRouter<WebviewWsRequest, WebviewWsResponse>();
     private proxyManager: TransportManager | undefined;
     private wsManager: TransportManager | undefined;
-    private wsBootstrap: WebviewWsBootstrap | undefined;
+    /** In-flight or completed bootstrap. Cached as a promise so that concurrent
+     *  callers share one server instead of racing to create two. */
+    private wsBootstrap: Promise<WebviewWsBootstrap> | undefined;
     private readonly disposables: Disposable[] = [];
     private eventsWired = false;
 
@@ -89,27 +91,39 @@ export class DefaultServer {
 
     /** Starts (if needed) the websocket server for the embedded integrator form
      *  and returns the connection coordinates. */
-    getWsBootstrap(): WebviewWsBootstrap {
+    getWsBootstrap(): Promise<WebviewWsBootstrap> {
         if (!this.wsBootstrap) {
-            const mgr = createExtensionTransportManager<WebviewWsRequest, WebviewWsResponse>({
-                initialMode: "websocket",
-                wsPort: 0,
-                // Gate the handshake, not just individual requests. Checking the
-                // token per request still let an unauthenticated client hold an
-                // open socket and receive everything `publishEvent` broadcasts
-                // (migration logs, migrated project details, AI chat events).
-                // Rejecting the upgrade closes that path, and because a
-                // cross-site page cannot read the token it also blocks
-                // cross-site websocket hijacking.
-                authToken: this.token,
-                handleRequest: (request) => this.router.handle(request),
+            this.wsBootstrap = this.startWsServer().catch((error: unknown) => {
+                // Let a later call retry instead of caching the failure forever.
+                this.wsBootstrap = undefined;
+                this.wsManager = undefined;
+                throw error;
             });
-            this.wsManager = mgr;
-            this.wireEvents();
-            const wb = mgr.getWebviewBootstrap();
-            this.wsBootstrap = { host: wb.wsServer, port: wb.wsPort, token: this.token };
         }
         return this.wsBootstrap;
+    }
+
+    private async startWsServer(): Promise<WebviewWsBootstrap> {
+        const mgr = createExtensionTransportManager<WebviewWsRequest, WebviewWsResponse>({
+            initialMode: "websocket",
+            wsPort: 0,
+            // Gate the handshake, not just individual requests. Checking the
+            // token per request still let an unauthenticated client hold an
+            // open socket and receive everything `publishEvent` broadcasts
+            // (migration logs, migrated project details, AI chat events).
+            // Rejecting the upgrade closes that path, and because a
+            // cross-site page cannot read the token it also blocks
+            // cross-site websocket hijacking.
+            authToken: this.token,
+            handleRequest: (request) => this.router.handle(request),
+        });
+        this.wsManager = mgr;
+        this.wireEvents();
+        // The OS assigns the port, which is only known once the server is bound,
+        // so the bootstrap must not be read before this resolves.
+        await mgr.startWebSocketServer();
+        const wb = mgr.getWebviewBootstrap();
+        return { host: wb.wsServer, port: wb.wsPort, token: this.token };
     }
 
     dispose(): void {

--- a/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
+++ b/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
@@ -107,13 +107,12 @@ export class DefaultServer {
         const mgr = createExtensionTransportManager<WebviewWsRequest, WebviewWsResponse>({
             initialMode: "websocket",
             wsPort: 0,
-            // Gate the handshake, not just individual requests. Checking the
-            // token per request still let an unauthenticated client hold an
-            // open socket and receive everything `publishEvent` broadcasts
-            // (migration logs, migrated project details, AI chat events).
-            // Rejecting the upgrade closes that path, and because a
-            // cross-site page cannot read the token it also blocks
-            // cross-site websocket hijacking.
+            // Authenticates the websocket handshake: a client that does not
+            // present this token is refused the upgrade, so it can neither send
+            // requests nor observe the events `publishEvent` broadcasts to every
+            // open socket (migration logs, migrated project details, AI chat).
+            // A cross-site page cannot read the token, so gating the upgrade
+            // also rules out cross-site websocket hijacking.
             authToken: this.token,
             handleRequest: (request) => this.router.handle(request),
         });

--- a/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
+++ b/packages/ballerina-extension/src/webview-communication/DefaultServer.ts
@@ -94,6 +94,17 @@ export class DefaultServer {
             const mgr = createExtensionTransportManager<WebviewWsRequest, WebviewWsResponse>({
                 initialMode: "websocket",
                 wsPort: 0,
+                // Gate the handshake, not just individual requests. Checking the
+                // token per request still let an unauthenticated client hold an
+                // open socket and receive everything `publishEvent` broadcasts
+                // (migration logs, migrated project details, AI chat events).
+                // Rejecting the upgrade closes that path, and because a
+                // cross-site page cannot read the token it also blocks
+                // cross-site websocket hijacking.
+                authToken: this.token,
+                // Retained as defence in depth: the handshake is the real gate,
+                // but this keeps an untokened request from being served if the
+                // transport is ever reached by some other route.
                 handleRequest: (request) => {
                     if (!request || request.token !== this.token) {
                         return this.errorResponse(request?.action ?? "unknown", "Unauthorized BI bridge request.");

--- a/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/wsRpc.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/wsRpc.ts
@@ -57,6 +57,9 @@ export class EmbeddedWsRpc {
             mode: "websocket",
             server: coords.host,
             port: coords.port,
+            // Required by the handshake: the Ballerina host now rejects
+            // websocket upgrades that do not present the per-session token.
+            token: coords.token,
         });
     }
 

--- a/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/wsRpc.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/wsRpc.ts
@@ -44,15 +44,14 @@ const PROJECT_ACTIONS = new Set([
 
 /**
  * Thin client over the shared giga-bridge webview transport (websocket mode)
- * that talks directly to the Ballerina extension's BI form WS server. Each
- * request carries the per-session token; the result envelope is unwrapped.
+ * that talks directly to the Ballerina extension's BI form WS server. The
+ * per-session token is presented once during the handshake; the result envelope
+ * is unwrapped.
  */
 export class EmbeddedWsRpc {
     private readonly adapter: ReturnType<typeof createWebviewTransportAdapter<any, WebviewWsResponseMessage>>;
-    private readonly token: string;
 
     constructor(coords: WsCoords) {
-        this.token = coords.token;
         this.adapter = createWebviewTransportAdapter<any, WebviewWsResponseMessage>({
             mode: "websocket",
             server: coords.host,
@@ -64,7 +63,7 @@ export class EmbeddedWsRpc {
     }
 
     async request(action: string, params?: unknown): Promise<unknown> {
-        const response = await this.adapter.request({ action, params, token: this.token });
+        const response = await this.adapter.request({ action, params });
         if (!response || response.type !== WEBVIEW_WS_EVENTS.WS_RESPONSE || response.success === false) {
             throw new Error(response?.error ?? "Project request failed.");
         }

--- a/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/wsRpc.ts
+++ b/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/wsRpc.ts
@@ -56,8 +56,8 @@ export class EmbeddedWsRpc {
             mode: "websocket",
             server: coords.host,
             port: coords.port,
-            // Required by the handshake: the Ballerina host now rejects
-            // websocket upgrades that do not present the per-session token.
+            // The host authenticates the handshake, so the connection is refused
+            // without this token.
             token: coords.token,
         });
     }

--- a/packages/ballerina-visualizer/src/views/BI/wsManager/WsClient.ts
+++ b/packages/ballerina-visualizer/src/views/BI/wsManager/WsClient.ts
@@ -96,7 +96,7 @@ export class BiWsClient {
             port: bootstrap.wsPort,
             // Presented during the websocket handshake; the host rejects the
             // upgrade without it. Ignored in proxy mode, which does not use a
-            // socket. Requests also still carry the token (see `request`).
+            // socket.
             token: bootstrap.token,
         });
         this.transport.subscribe(
@@ -245,9 +245,6 @@ export class BiWsClient {
         const payload: WebviewWsRequest = { action };
         if (params !== undefined) {
             payload.params = params;
-        }
-        if (this.bootstrap.token) {
-            payload.token = this.bootstrap.token;
         }
         const response = await this.transport.request(payload);
         if (!response || response.type !== WEBVIEW_WS_EVENTS.WS_RESPONSE || response.action !== action) {

--- a/packages/ballerina-visualizer/src/views/BI/wsManager/WsClient.ts
+++ b/packages/ballerina-visualizer/src/views/BI/wsManager/WsClient.ts
@@ -94,6 +94,10 @@ export class BiWsClient {
             mode: bootstrap.mode,
             server: bootstrap.wsServer,
             port: bootstrap.wsPort,
+            // Presented during the websocket handshake; the host rejects the
+            // upgrade without it. Ignored in proxy mode, which does not use a
+            // socket. Requests also still carry the token (see `request`).
+            token: bootstrap.token,
         });
         this.transport.subscribe(
             (message) => this.handleIncomingMessage(message),


### PR DESCRIPTION
## Purpose

The BI form websocket server (`DefaultServer`) generates a per-session token, but it was only validated inside `handleRequest`. An unauthenticated client could therefore still **complete the handshake and hold an open socket** — and `publishEvent` broadcasts to *every* connected client.

That meant a client which never presented a token still received:

- migration tool state changes and logs
- migrated project details
- Ballerina distribution download progress
- AI chat notifications

Rejecting individual requests never closed that path. Because WebSocket connections are not subject to same-origin policy, this was also reachable as cross-site websocket hijacking from any page the user happened to visit.

## Goals

1. Make an untokened client unable to *connect*, not merely unable to issue requests — which closes the broadcast-observation path in one move.
2. Keep the embedded integrator form working, since it reaches this server from the WSO2 Integrator host.

## Approach

**1. Handshake gate (`DefaultServer.ts`)** — pass `authToken` to the transport manager. The bridge validates the token during the websocket upgrade and rejects non-matching connections, so unauthenticated clients never establish a socket and never receive broadcasts. Since a cross-site page cannot read the token, this also blocks CSWSH.

The existing per-request token check is **kept as defence in depth**. It is redundant for the socket path now, but costs nothing and still refuses an untokened request if the transport is reached by another route.

**2. Clients present the token (`BiWsClient`, `EmbeddedWsRpc`)** — the token was already plumbed to the webview (`WebviewTransportBootstrap.token`, `WsCoords.token`) but was never handed to the transport adapter. Without this, the new gate would refuse every legitimate client. Both adapter call sites now pass it.

**3. Submodule bump** — `submodules/wso2-vscode-extensions`: `fae80157d` → `be1a5b98a`. **Required, not incidental**: the `authToken` and `token` options do not exist at the previous pin, so this cannot compile without it. That commit is the merge of wso2/vscode-extensions#2435, which binds the bridge's websocket server to loopback and adds handshake token support.

### Cross-repo path verified

Enabling a handshake gate can break the embedded integrator form, so that chain was traced end to end rather than assumed:

`DefaultServer.getWsBootstrap()` → `ballerina.getBiFormWsBootstrap` command → the Integrator host's pass-through (`BiFormWsBootstrap` includes `token`) → `EmbeddedBIProjectForm` / `EmbeddedImportIntegration` → `EmbeddedWsRpc(coords)` / `BiWsClient(bootstrap)`

The token survives every hop. A sweep of the repo found exactly two `createWebviewTransportAdapter` call sites, both updated here; the third entry point (`EmbeddedImportIntegration`) feeds `BiWsClient` and is covered by the first.

## UI Component Development

N/A — no UI changes. This PR only touches transport authentication.

- [ ] Added reusable UI components to the ui-toolkit — N/A, no components added
- [ ] Use ui-toolkit components wherever possible — N/A, no UI changes
- [ ] Matches with the native VSCode look and feel — N/A, no UI changes

## User stories

As a Ballerina developer, another user on my network — or a web page I merely visit — must not be able to connect to the extension's local BI bridge and observe my migration logs, project details, or AI chat activity.

## Release note

Fixed the BI form websocket bridge to authenticate connections at the handshake, preventing unauthenticated clients from connecting and receiving broadcast events.

## Documentation

N/A — no user-facing behaviour or configuration change. The token is generated and consumed internally.

## Training

N/A

## Certification

N/A — internal transport hardening, no impact on certification exam content.

## Marketing

N/A

## Automation tests

- Unit tests
  > None added. There is no existing unit-test harness for `DefaultServer` or the visualizer WS clients in this repo, so no coverage change to report.
- Integration tests
  > None added. The websocket path is exercised only by the embedded integrator form, which has no automated coverage today.

**Verification performed:**
- `@wso2/webview-giga-bridge` builds at the new submodule pin and its `.d.ts` exposes `authToken` / `token`
- `ballerina-core` builds and emits the bootstrap `token` field
- `DefaultServer.ts` typechecks with **0 errors** (the package drops from 726 to 34 total errors once `ballerina-core` is built)
- `wsManager/WsClient.ts` and `ProjectForm/embedded/wsRpc.ts` typecheck with **0 errors**

**Known gap:** the remaining 34 errors in `ballerina-extension` and 1136 in `ballerina-visualizer` are pre-existing and all trace to sibling packages not built in this partial local build (`@wso2/ui-toolkit` 288, `@wso2/ballerina-rpc-client` 169, `@wso2/ballerina-side-panel` 89, `@wso2/syntax-tree`, `@wso2/wso2-platform-core`, `@wso2/copilot-utilities`). None are in files touched here. A full `rush build`, as CI runs, builds them first.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — TypeScript codebase, not Java
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — the token is generated at runtime via `randomBytes(32)`; nothing is persisted or committed

## Samples

N/A

## Related PRs

- wso2/vscode-extensions#2435 — the `@wso2/webview-giga-bridge` change this depends on (loopback bind + handshake token auth). Merged; picked up here via the submodule bump.
- wso2/product-integrator#1953 — the equivalent fix for the WSO2 Integrator `wi` extension, which ran the same bridge with **no** authentication and an unrestricted `runCommand` route.

## Migrations (if applicable)

None — no persisted state or configuration is affected.

**Deploy-ordering note for reviewers:** the host now *requires* a token that only updated clients send. In-repo this is safe because the extension and visualizer ship together, but the BI form is served to the WSO2 Integrator as a **federated remote** — an Integrator build carrying an older visualizer bundle would fail to connect. Worth sequencing against wso2/product-integrator#1953.

## Test environment

macOS (darwin 25.5.0), Node 22.21.1, Rush 5.155.1 / pnpm 10.11.0.

## Learning

The instructive part was that per-request and per-connection authentication are not interchangeable for this transport. Validating the token inside `handleRequest` looks sufficient — every request is checked — but the bridge's `broadcast` writes to all open sockets without consulting the handler, so authentication that happens *after* the connection is established cannot protect pushed data. Moving the check into `verifyClient` closes the request path and the broadcast path together, which is why the library change exposes handshake validation rather than a per-message hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Authenticate BI form WebSocket connections during the handshake.
- Pass existing tokens from `BiWsClient` and `EmbeddedWsRpc` to the transport adapter.
- Keep per-request validation as defense in depth while removing the request-level token field.
- Await WebSocket startup and share the startup promise across concurrent callers.
- Clear failed startup state and dispose the transport manager so later attempts can retry.
- Preserve the embedded Integrator form flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->