### PR TITLE
Add Claude Sonnet 5 support

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -100,6 +100,14 @@
       "brace-expansion@>=1 <2": "1.1.16",
       "brace-expansion@>=2 <3": "2.1.2",
       "brace-expansion@>=5.0.0 <6": "5.0.8",
+      // Claude Sonnet 5 must be sent `thinking: {"type": "disabled"}` explicitly,
+      // because an absent `thinking` field means adaptive reasoning is ON. Only
+      // @ai-sdk/anthropic >= 3.0.104 serializes that value — earlier 3.x releases
+      // accept it and then silently drop it from the request body. google-vertex
+      // pins 3.0.63 and anthropic-aws pins 3.0.81, so both need forcing. The
+      // selector stays inside 3.x: the 4.x line implements the v4 model spec,
+      // which the pinned ai@6 core cannot consume.
+      "@ai-sdk/anthropic@>=3 <4": "3.0.104",
       // Security overrides — keep in sync with trivy findings. Bump to the
       // first fix version listed for each CVE. If a bump breaks workspace
       // consumers, narrow the selector (e.g. "pkg@<x.y.z": "x.y.z").

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   brace-expansion@>=1 <2: 1.1.16
   brace-expansion@>=2 <3: 2.1.2
   brace-expansion@>=5.0.0 <6: 5.0.8
+  '@ai-sdk/anthropic@>=3 <4': 3.0.104
   '@babel/core@>=7 <8': 7.29.6
   '@hono/node-server': 2.0.10
   '@tootallnate/once': 3.0.1
@@ -139,8 +140,8 @@ importers:
         specifier: 4.0.83
         version: 4.0.83(zod@4.1.8)
       '@ai-sdk/anthropic':
-        specifier: 3.0.64
-        version: 3.0.64(zod@4.1.8)
+        specifier: 3.0.104
+        version: 3.0.104(zod@4.1.8)
       '@ai-sdk/anthropic-aws':
         specifier: 1.0.3
         version: 1.0.3(zod@4.1.8)
@@ -2848,20 +2849,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/anthropic@3.0.63':
-    resolution: {integrity: sha512-SiLosFr0FfKfrNpAAj8mD/i3S5YBB/z5orb1DH3pN1yATuBNjjPMLnRE4P3Dn7Y5cQsro0uzw5g5117hkShWoQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/anthropic@3.0.64':
-    resolution: {integrity: sha512-rwLi/Rsuj2pYniQXIrvClHvXDzgM4UQHHnvHTWEF14efnlKclG/1ghpNC+adsRujAbCTr6gRsSbDE2vEqriV7g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/anthropic@3.0.81':
-    resolution: {integrity: sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==}
+  '@ai-sdk/anthropic@3.0.104':
+    resolution: {integrity: sha512-D1d/whdUWF8KrXr9TzK6/S1wD9WmmxJ5DRWgGJX6Ip8iZW0up/yRtWuZwTkuX86bOPQTd2c370lIVteEBUGxPg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2902,8 +2891,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.41':
+    resolution: {integrity: sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
@@ -4407,6 +4406,10 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -16228,6 +16231,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -17212,7 +17219,7 @@ snapshots:
 
   '@ai-sdk/amazon-bedrock@4.0.83(zod@4.1.8)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.64(zod@4.1.8)
+      '@ai-sdk/anthropic': 3.0.104(zod@4.1.8)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.1.8)
       '@smithy/eventstream-codec': 4.4.2
@@ -17222,28 +17229,16 @@ snapshots:
 
   '@ai-sdk/anthropic-aws@1.0.3(zod@4.1.8)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.81(zod@4.1.8)
+      '@ai-sdk/anthropic': 3.0.104(zod@4.1.8)
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@4.1.8)
       aws4fetch: 1.0.20
       zod: 4.1.8
 
-  '@ai-sdk/anthropic@3.0.63(zod@4.1.8)':
+  '@ai-sdk/anthropic@3.0.104(zod@4.1.8)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.21(zod@4.1.8)
-      zod: 4.1.8
-
-  '@ai-sdk/anthropic@3.0.64(zod@4.1.8)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.21(zod@4.1.8)
-      zod: 4.1.8
-
-  '@ai-sdk/anthropic@3.0.81(zod@4.1.8)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.1.8)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.1.8)
       zod: 4.1.8
 
   '@ai-sdk/gateway@3.0.57(zod@4.1.8)':
@@ -17255,7 +17250,7 @@ snapshots:
 
   '@ai-sdk/google-vertex@4.0.94(zod@4.1.8)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.63(zod@4.1.8)
+      '@ai-sdk/anthropic': 3.0.104(zod@4.1.8)
       '@ai-sdk/google': 3.0.53(zod@4.1.8)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.1.8)
@@ -17291,7 +17286,19 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.1.8
 
+  '@ai-sdk/provider-utils@4.0.41(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      undici: 5.29.0
+      zod: 4.1.8
+
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 
@@ -19159,6 +19166,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
+
+  '@fastify/busboy@2.1.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -38331,6 +38340,10 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@7.28.0: {}
 

--- a/packages/ballerina-extension/package.json
+++ b/packages/ballerina-extension/package.json
@@ -1498,7 +1498,7 @@
     "dependencies": {
         "@ai-sdk/amazon-bedrock": "4.0.83",
         "@ai-sdk/anthropic-aws": "1.0.3",
-        "@ai-sdk/anthropic": "3.0.64",
+        "@ai-sdk/anthropic": "3.0.104",
         "@ai-sdk/google-vertex": "4.0.94",
         "@iarna/toml": "2.2.5",
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -20,7 +20,7 @@ import { AICommandExecutor, AICommandConfig, AIExecutionResult } from '../execut
 import { Command, GenerateAgentCodeRequest, ProjectSource, ExecutionContext, SemanticDiff, ReviewModeData, PROJECT_KIND, LoginMethod } from '@wso2/ballerina-core';
 import { StateMachine } from '../../../stateMachine';
 import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
-import { getAnthropicClient, getProviderCacheControl, addCacheControlToMessages, ANTHROPIC_SONNET_4 } from '../utils/ai-client';
+import { getAnthropicClient, getProviderCacheControl, getProviderModelOptions, addCacheControlToMessages, ANTHROPIC_SONNET } from '../utils/ai-client';
 import { populateHistoryForAgent, getErrorMessage, getErrorCode, buildChatError } from '../utils/ai-utils';
 import { sendAgentDidOpenForFreshProjects } from '../utils/project/ls-schema-notifications';
 import { getSystemPrompt, getUserPrompt } from './prompts';
@@ -290,7 +290,7 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
 
             // Resolve model and login method
             const loginMethod = await getLoginMethod();
-            const model = await getAnthropicClient(ANTHROPIC_SONNET_4);
+            const model = await getAnthropicClient(ANTHROPIC_SONNET);
 
             const projectRootPath = this.config.executionContext.workspacePath || this.config.executionContext.projectPath || '';
             const agentsMd = await prepareAgentsMdForTurn(workspaceId || '', threadId);
@@ -317,10 +317,14 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
             const floorTokens = estimateFloorTokens(systemPromptText, JSON.stringify(userMessageContent));
 
 
-            const providerOptions = buildCompactionProviderOptions(loginMethod, floorTokens);
-            if (supportsCompaction(loginMethod) && providerOptions === undefined) {
+            const compactionOptions = buildCompactionProviderOptions(loginMethod, floorTokens);
+            if (supportsCompaction(loginMethod) && compactionOptions === undefined) {
                 warnCompactionDisabledOnce(projectRootPath, this.config.eventHandler);
             }
+            const modelOptions = await getProviderModelOptions('xhigh');
+            const providerOptions = compactionOptions
+                ? { anthropic: { ...(modelOptions as { anthropic?: object }).anthropic, ...compactionOptions.anthropic } }
+                : modelOptions;
 
             // Ensure the pre-edit snapshot exists before any tool can run.
             await chatStateStorage.waitForCheckpointCapture(this.config.generationId);
@@ -390,7 +394,6 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
             const { fullStream, response, usage, totalUsage } = streamText({
                 model,
                 maxOutputTokens: 8192,
-                temperature: 0,
                 messages: allMessages,
                 tools,
                 abortSignal: this.config.abortController.signal,
@@ -452,7 +455,7 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                         );
                         this.config.eventHandler({
                             type: "usage_metrics",
-                            model: ANTHROPIC_SONNET_4,
+                            model: ANTHROPIC_SONNET,
                             usage: {
                                 inputTokens,
                                 cacheCreationInputTokens: cacheWriteTokens,
@@ -868,7 +871,7 @@ Generation stopped by user. The last in-progress task was not saved. Any complet
         );
 
         const totalCost = calculateTotalCost(
-            ANTHROPIC_SONNET_4,
+            ANTHROPIC_SONNET,
             { inputTokens, outputTokens, cacheReadTokens: totalCacheRead, cacheWriteTokens: totalCacheWrite },
             context.toolModelUsage
         );

--- a/packages/ballerina-extension/src/features/ai/agent/tools/healthcare-library.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/healthcare-library.ts
@@ -21,7 +21,7 @@ import { jsonSchema } from "ai";
 import { Library } from "../../utils/libs/library-types";
 import { selectRequiredFunctions, ModelUsage, mergeUsage } from "../../utils/libs/function-registry";
 import { MinifiedLibrary } from "@wso2/ballerina-core";
-import { ANTHROPIC_SONNET_4, getAnthropicClient, getProviderCacheControl } from "../../utils/ai-client";
+import { ANTHROPIC_SONNET, getAnthropicClient, getProviderCacheControl, getProviderModelOptions } from "../../utils/ai-client";
 import { z } from "zod";
 import { CopilotEventHandler, emitModelUsage, ToolModelUsage } from "../../utils/events";
 
@@ -170,7 +170,7 @@ export async function getRelevantLibrariesAndFunctions(
 export async function getSelectedLibraries(prompt: string, libraryType: GenerationType): Promise<{ libraries: string[], usage: ModelUsage }> {
     const allLibraries = await getAllLibraries(libraryType);
     if (allLibraries.length === 0) {
-        return { libraries: [], usage: { model: ANTHROPIC_SONNET_4, inputTokens: 0, outputTokens: 0 } };
+        return { libraries: [], usage: { model: ANTHROPIC_SONNET, inputTokens: 0, outputTokens: 0 } };
     }
     const cacheOptions = await getProviderCacheControl();
     const messages: ModelMessage[] = [
@@ -188,15 +188,15 @@ export async function getSelectedLibraries(prompt: string, libraryType: Generati
     //TODO: Add thinking and test with claude haiku
     const startTime = Date.now();
     const { object, usage } = await generateObject({
-        model: await getAnthropicClient(ANTHROPIC_SONNET_4),
+        model: await getAnthropicClient(ANTHROPIC_SONNET),
         maxOutputTokens: 4096,
-        temperature: 0,
+        providerOptions: await getProviderModelOptions(),
         messages: messages,
         schema: LibraryListSchema,
         abortSignal: new AbortController().signal,
     });
     const endTime = Date.now();
-    const callUsage: ModelUsage = { model: ANTHROPIC_SONNET_4, inputTokens: usage.inputTokens || 0, outputTokens: usage.outputTokens || 0 };
+    const callUsage: ModelUsage = { model: ANTHROPIC_SONNET, inputTokens: usage.inputTokens || 0, outputTokens: usage.outputTokens || 0 };
     console.log(`Library selection took ${endTime - startTime}ms, Usage:`, callUsage);
 
     console.log("Selected libraries:", object.libraries);

--- a/packages/ballerina-extension/src/features/ai/agent/tools/web-tools.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/web-tools.ts
@@ -20,7 +20,7 @@ import { anthropic } from '@ai-sdk/anthropic';
 import { v4 as uuidv4 } from 'uuid';
 import { CopilotEventHandler } from '../../utils/events';
 import { approvalManager } from '../../state/ApprovalManager';
-import { getAnthropicClient, ANTHROPIC_SONNET_4 } from '../../utils/ai-client';
+import { getAnthropicClient, getProviderModelOptions, ANTHROPIC_SONNET } from '../../utils/ai-client';
 import { sendWebToolToggleNotification } from '../../utils/ai-utils';
 
 const WEB_TOOL_NOTIFICATION_TYPE = "webtool";
@@ -139,7 +139,8 @@ async function executeWebSearch(
 
         console.log(`[WebTools] search | query: ${input.query} | context: ${input.context}`);
         const result = await generateText({
-            model: await getAnthropicClient(ANTHROPIC_SONNET_4),
+            model: await getAnthropicClient(ANTHROPIC_SONNET),
+            providerOptions: await getProviderModelOptions(),
             system: WEB_SEARCH_SYSTEM_PROMPT,
             prompt: `Context: ${input.context}\n\nSearch query: ${input.query}\n\nSearch the web and provide a detailed, accurate answer based on the results.`,
             tools: {
@@ -221,7 +222,8 @@ async function executeWebFetch(
 
         console.log(`[WebTools] fetch | url: ${input.url}`);
         const result = await generateText({
-            model: await getAnthropicClient(ANTHROPIC_SONNET_4),
+            model: await getAnthropicClient(ANTHROPIC_SONNET),
+            providerOptions: await getProviderModelOptions(),
             system: 'You are a web fetcher. Your only job is to invoke the web_fetch tool with the given URL. STRICT RULES: (1) Do NOT write any text before the tool call. (2) Do NOT write any text after the tool call. (3) Do NOT summarize, describe, or explain the result. The tool result is consumed programmatically — any text you emit is ignored and wastes tokens.',
             prompt: `URL: ${input.url}`,
             tools: {

--- a/packages/ballerina-extension/src/features/ai/data-mapper/context-api.ts
+++ b/packages/ballerina-extension/src/features/ai/data-mapper/context-api.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { generateText, ModelMessage } from "ai";
-import { getAnthropicClient, ANTHROPIC_SONNET_4 } from "../utils/ai-client";
+import { getAnthropicClient, getProviderModelOptions, ANTHROPIC_SONNET } from "../utils/ai-client";
 import { AttachmentProcessRequest, AttachmentProcessResponse, ContentPart, FileData, FileTypeHandler, ProcessType } from "./types";
 import { getRecordsPrompt, getRequirementsPrompt } from "./prompts/attachment-prompts";
 
@@ -165,9 +165,9 @@ async function processFilesWithClaude(files: FileData[], promptText: string): Pr
     const messages = buildClaudeMessages(files, promptText);
 
     const { text } = await generateText({
-        model: await getAnthropicClient(ANTHROPIC_SONNET_4),
+        model: await getAnthropicClient(ANTHROPIC_SONNET),
         maxOutputTokens: 8192,
-        temperature: 0,
+        providerOptions: await getProviderModelOptions(),
         messages,
         abortSignal: new AbortController().signal
     });

--- a/packages/ballerina-extension/src/features/ai/documentation/index.ts
+++ b/packages/ballerina-extension/src/features/ai/documentation/index.ts
@@ -16,7 +16,7 @@
 
 import { Command, ProjectSource } from "@wso2/ballerina-core";
 import { streamText, ModelMessage } from "ai";
-import { getAnthropicClient, ANTHROPIC_SONNET_4 } from "../utils/ai-client";
+import { getAnthropicClient, getProviderModelOptions, ANTHROPIC_SONNET } from "../utils/ai-client";
 import {
     getDocumentationGenerationSystemPrompt,
     createDocumentationGenMessages
@@ -50,9 +50,9 @@ export async function generateDocumentationCore(
     ];
 
     const { fullStream } = streamText({
-        model: await getAnthropicClient(ANTHROPIC_SONNET_4),
+        model: await getAnthropicClient(ANTHROPIC_SONNET),
         maxOutputTokens: 16384,
-        temperature: 0,
+        providerOptions: await getProviderModelOptions(),
         messages: allMessages,
         abortSignal: abortController.signal,
     });

--- a/packages/ballerina-extension/src/features/ai/payload-generator/payload_json.ts
+++ b/packages/ballerina-extension/src/features/ai/payload-generator/payload_json.ts
@@ -16,7 +16,7 @@
 
 import { generateText } from "ai";
 import { PayloadContext } from "@wso2/ballerina-core";
-import { getAnthropicClient, ANTHROPIC_SONNET_4 } from "../utils/ai-client";
+import { getAnthropicClient, getProviderModelOptions, ANTHROPIC_SONNET } from "../utils/ai-client";
 import { getPayloadGenerationSystemPrompt, getPayloadGenerationUserPrompt } from "./prompts";
 
 /**
@@ -32,9 +32,9 @@ export async function generateExamplePayload(context: PayloadContext): Promise<o
 
     try {
         const { text } = await generateText({
-            model: await getAnthropicClient(ANTHROPIC_SONNET_4),
+            model: await getAnthropicClient(ANTHROPIC_SONNET),
             maxOutputTokens: 4096 * 2,
-            temperature: 0,
+            providerOptions: await getProviderModelOptions(),
             system: systemPrompt,
             prompt: userPrompt,
             abortSignal: new AbortController().signal,

--- a/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -26,7 +26,7 @@ import { LLM_API_BASE_PATH } from "../constants";
 import { AIMachineEventType, AnthropicKeySecrets, AnthropicAwsSecrets, LoginMethod, BIIntelSecrets } from "@wso2/ballerina-core";
 
 export const ANTHROPIC_HAIKU = "claude-haiku-4-5-20251001";
-export const ANTHROPIC_SONNET_4 = "claude-sonnet-4-6";
+export const ANTHROPIC_SONNET = "claude-sonnet-5";
 
 // Contact for requesting more Copilot quota once the usage limit is reached.
 export const QUOTA_REQUEST_CONTACT_EMAIL = "support@wso2.com";
@@ -35,7 +35,7 @@ export const USAGE_LIMIT_EXCEEDED_MESSAGE =
 
 type AnthropicModel =
     | typeof ANTHROPIC_HAIKU
-    | typeof ANTHROPIC_SONNET_4;
+    | typeof ANTHROPIC_SONNET;
 
 /**
  * Maps AWS regions to their corresponding Bedrock inference profile prefixes
@@ -196,7 +196,7 @@ export const getAnthropicClient = async (model: AnthropicModel): Promise<any> =>
             // Map Anthropic model names to AWS Bedrock model IDs (base models without region prefix)
             const baseModelMap: Record<AnthropicModel, string> = {
                 [ANTHROPIC_HAIKU]: "anthropic.claude-haiku-4-5-20251001-v1:0",
-                [ANTHROPIC_SONNET_4]: "anthropic.claude-sonnet-4-6",
+                [ANTHROPIC_SONNET]: "anthropic.claude-sonnet-5",
             };
             
             const baseModelId = baseModelMap[model];
@@ -225,7 +225,7 @@ export const getAnthropicClient = async (model: AnthropicModel): Promise<any> =>
 
             const vertexModelMap: Record<AnthropicModel, string> = {
                 [ANTHROPIC_HAIKU]: "claude-haiku-4-5@20251001",
-                [ANTHROPIC_SONNET_4]: "claude-sonnet-4-6",
+                [ANTHROPIC_SONNET]: "claude-sonnet-5",
             };
 
             const vertexModelId = vertexModelMap[model];
@@ -282,6 +282,26 @@ export const getProviderCacheControl = async (): Promise<ProviderCacheOptions> =
         default:
             return { anthropic: { cacheControl: { type: "ephemeral" } } };
     }
+};
+
+export type AnthropicEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export type ProviderModelOptions =
+    | { anthropic: { thinking: { type: 'disabled' }; effort?: AnthropicEffort } }
+    | { bedrock: { reasoningConfig: { type: 'disabled' } } };
+
+/**
+ * Sonnet 5 enables adaptive thinking when `thinking` is omitted, and reasoning shares
+ * `maxOutputTokens` with the response — omitting it truncates answers. Bedrock ignores the
+ * `anthropic` namespace and reads `providerOptions.bedrock`.
+ */
+export const getProviderModelOptions = async (effort?: AnthropicEffort): Promise<ProviderModelOptions> => {
+    const loginMethod = await getLoginMethod();
+
+    if (loginMethod === LoginMethod.AWS_BEDROCK) {
+        return { bedrock: { reasoningConfig: { type: 'disabled' } } };
+    }
+    return { anthropic: { thinking: { type: 'disabled' }, ...(effort ? { effort } : {}) } };
 };
 
 function isAnthropicModel(model: LanguageModel): boolean {

--- a/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -288,18 +288,23 @@ export type AnthropicEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export type ProviderModelOptions =
     | { anthropic: { thinking: { type: 'disabled' }; effort?: AnthropicEffort } }
-    | { bedrock: { reasoningConfig: { type: 'disabled' } } };
+    | { bedrock: { additionalModelRequestFields: { thinking: { type: 'disabled' } } } };
 
 /**
  * Sonnet 5 enables adaptive thinking when `thinking` is omitted, and reasoning shares
  * `maxOutputTokens` with the response — omitting it truncates answers. Bedrock ignores the
  * `anthropic` namespace and reads `providerOptions.bedrock`.
+ *
+ * On Bedrock the field goes through `additionalModelRequestFields`, not `reasoningConfig`:
+ * the provider only serializes `reasoningConfig` when reasoning is enabled or adaptive, so a
+ * `disabled` value there is silently dropped. Bedrock also requires reasoning to be off
+ * alongside a forced `tool_choice`, which web-tools uses.
  */
 export const getProviderModelOptions = async (effort?: AnthropicEffort): Promise<ProviderModelOptions> => {
     const loginMethod = await getLoginMethod();
 
     if (loginMethod === LoginMethod.AWS_BEDROCK) {
-        return { bedrock: { reasoningConfig: { type: 'disabled' } } };
+        return { bedrock: { additionalModelRequestFields: { thinking: { type: 'disabled' } } } };
     }
     return { anthropic: { thinking: { type: 'disabled' }, ...(effort ? { effort } : {}) } };
 };

--- a/packages/ballerina-extension/src/features/ai/utils/events.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/events.ts
@@ -27,36 +27,9 @@ export type CopilotEventHandler = (event: ChatNotify) => void;
 
 export type ToolModelUsage = Record<string, { inputTokens: number; outputTokens: number }>;
 
-// Per-million-token pricing by model
-const MODEL_PRICING: Record<string, { input: number; cacheWrite: number; cacheRead: number; output: number }> = {
-    'claude-sonnet-5':              { input: 3,  cacheWrite: 3.75, cacheRead: 0.30, output: 15 },
-    'claude-sonnet-4-6':            { input: 3,  cacheWrite: 3.75, cacheRead: 0.30, output: 15 },
-    'claude-haiku-4-5-20251001':    { input: 1,  cacheWrite: 1.25, cacheRead: 0.10, output: 5  },
-};
+import { calculateCost } from "./model-pricing";
 
-interface CostInput {
-    model: string;
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens?: number;
-    cacheWriteTokens?: number;
-}
-
-export function calculateCost(usage: CostInput): number {
-    const pricing = MODEL_PRICING[usage.model];
-    if (!pricing) { return 0; }
-
-    const cacheRead = usage.cacheReadTokens || 0;
-    const cacheWrite = usage.cacheWriteTokens || 0;
-    const baseInput = usage.inputTokens - cacheRead - cacheWrite;
-
-    return (
-        baseInput   * pricing.input      +
-        cacheWrite  * pricing.cacheWrite  +
-        cacheRead   * pricing.cacheRead   +
-        usage.outputTokens * pricing.output
-    ) / 1_000_000;
-}
+export { calculateCost };
 
 export function calculateTotalCost(
     mainModel: string,

--- a/packages/ballerina-extension/src/features/ai/utils/events.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/events.ts
@@ -29,6 +29,7 @@ export type ToolModelUsage = Record<string, { inputTokens: number; outputTokens:
 
 // Per-million-token pricing by model
 const MODEL_PRICING: Record<string, { input: number; cacheWrite: number; cacheRead: number; output: number }> = {
+    'claude-sonnet-5':              { input: 3,  cacheWrite: 3.75, cacheRead: 0.30, output: 15 },
     'claude-sonnet-4-6':            { input: 3,  cacheWrite: 3.75, cacheRead: 0.30, output: 15 },
     'claude-haiku-4-5-20251001':    { input: 1,  cacheWrite: 1.25, cacheRead: 0.10, output: 5  },
 };

--- a/packages/ballerina-extension/src/features/ai/utils/model-pricing.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/model-pricing.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface ModelPricing {
+    input: number;
+    cacheWrite: number;
+    cacheRead: number;
+    output: number;
+}
+
+// Cache-write rates are the 5-minute-TTL tier, matching getProviderCacheControl().
+// Per-million-token pricing by model
+const MODEL_PRICING: Record<string, ModelPricing> = {
+    'claude-sonnet-4-6':            { input: 3,  cacheWrite: 3.75, cacheRead: 0.30, output: 15 },
+    'claude-haiku-4-5-20251001':    { input: 1,  cacheWrite: 1.25, cacheRead: 0.10, output: 5  },
+};
+
+// Sonnet 5 is published as two price rows: launch rates until this instant, standard after.
+const SONNET_5_STANDARD_FROM = Date.parse('2026-09-01T00:00:00Z');
+const SONNET_5_LAUNCH_PRICING: ModelPricing = { input: 2, cacheWrite: 2.50, cacheRead: 0.20, output: 10 };
+const SONNET_5_STANDARD_PRICING: ModelPricing = { input: 3, cacheWrite: 3.75, cacheRead: 0.30, output: 15 };
+
+// Resolved per call, not at module load, so a long-lived host crosses the cutover correctly.
+function getModelPricing(model: string): ModelPricing | undefined {
+    if (model === 'claude-sonnet-5') {
+        return Date.now() < SONNET_5_STANDARD_FROM ? SONNET_5_LAUNCH_PRICING : SONNET_5_STANDARD_PRICING;
+    }
+    return MODEL_PRICING[model];
+}
+
+export interface CostInput {
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+}
+
+export function calculateCost(usage: CostInput): number {
+    const pricing = getModelPricing(usage.model);
+    if (!pricing) { return 0; }
+
+    const cacheRead = usage.cacheReadTokens || 0;
+    const cacheWrite = usage.cacheWriteTokens || 0;
+    const baseInput = usage.inputTokens - cacheRead - cacheWrite;
+
+    return (
+        baseInput   * pricing.input      +
+        cacheWrite  * pricing.cacheWrite  +
+        cacheRead   * pricing.cacheRead   +
+        usage.outputTokens * pricing.output
+    ) / 1_000_000;
+}

--- a/packages/ballerina-extension/src/features/natural-programming/drift-check/index.ts
+++ b/packages/ballerina-extension/src/features/natural-programming/drift-check/index.ts
@@ -17,7 +17,7 @@
  */
 
 import { generateObject } from "ai";
-import { getAnthropicClient, ANTHROPIC_SONNET_4 } from "../../ai/utils/ai-client";
+import { getAnthropicClient, getProviderModelOptions, ANTHROPIC_SONNET } from "../../ai/utils/ai-client";
 import { getCodeAndApiDocsSyncPrompt, getCodeAndDocumentationSyncPrompt } from "./prompts";
 import {
     ApiDocsDriftResponseSchema,
@@ -47,9 +47,9 @@ export async function validateDriftWithApiDocs(ballerinaSources: string): Promis
     const prompt = getCodeAndApiDocsSyncPrompt(ballerinaSources);
 
     const { object } = await generateObject({
-        model: await getAnthropicClient(ANTHROPIC_SONNET_4),
+        model: await getAnthropicClient(ANTHROPIC_SONNET),
         maxOutputTokens: 8192,
-        temperature: 0,
+        providerOptions: await getProviderModelOptions(),
         schema: ApiDocsDriftResponseSchema,
         messages: [
             {
@@ -76,9 +76,9 @@ export async function validateDriftWithDocumentation(params: DocumentationDriftC
     );
 
     const { object } = await generateObject({
-        model: await getAnthropicClient(ANTHROPIC_SONNET_4),
+        model: await getAnthropicClient(ANTHROPIC_SONNET),
         maxOutputTokens: 8192,
-        temperature: 0,
+        providerOptions: await getProviderModelOptions(),
         schema: DocumentationDriftResponseSchema,
         messages: [
             {

--- a/packages/ballerina-extension/src/test-support/modelPricing.test.ts
+++ b/packages/ballerina-extension/src/test-support/modelPricing.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * calculateCost returns 0 for any model missing from the pricing table, so a wrong or
+ * absent key reports every turn as free rather than failing. Sonnet 5 compounds that:
+ * it is published as two price rows with a dated cutover, so the same key needs
+ * different rates either side of 2026-09-01.
+ */
+
+import { calculateCost } from '../features/ai/utils/model-pricing';
+
+const MTOK = 1_000_000;
+const DURING_LAUNCH = Date.parse('2026-08-15T00:00:00Z');
+const AFTER_CUTOVER = Date.parse('2026-09-01T00:00:00Z');
+
+function at<T>(instant: number, fn: () => T): T {
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(instant);
+    try { return fn(); } finally { spy.mockRestore(); }
+}
+
+const rates = (model: string) => ({
+    input: calculateCost({ model, inputTokens: MTOK, outputTokens: 0 }),
+    output: calculateCost({ model, inputTokens: 0, outputTokens: MTOK }),
+    cacheWrite: calculateCost({ model, inputTokens: MTOK, outputTokens: 0, cacheWriteTokens: MTOK }),
+    cacheRead: calculateCost({ model, inputTokens: MTOK, outputTokens: 0, cacheReadTokens: MTOK }),
+});
+
+describe('claude-sonnet-5 pricing', () => {
+    it('uses launch rates before the cutover', () => {
+        expect(at(DURING_LAUNCH, () => rates('claude-sonnet-5')))
+            .toEqual({ input: 2, output: 10, cacheWrite: 2.5, cacheRead: 0.2 });
+    });
+
+    it('uses standard rates from the cutover onward', () => {
+        expect(at(AFTER_CUTOVER, () => rates('claude-sonnet-5')))
+            .toEqual({ input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 });
+    });
+
+    it('switches exactly at the boundary, not a day early or late', () => {
+        expect(at(AFTER_CUTOVER - 1, () => rates('claude-sonnet-5')).input).toBe(2);
+        expect(at(AFTER_CUTOVER, () => rates('claude-sonnet-5')).input).toBe(3);
+    });
+
+    it('is never priced at zero, in either window', () => {
+        for (const instant of [DURING_LAUNCH, AFTER_CUTOVER]) {
+            expect(at(instant, () => rates('claude-sonnet-5')).input).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe('other models in the pricing table', () => {
+    it('prices claude-sonnet-4-6 at its published rates', () => {
+        expect(rates('claude-sonnet-4-6')).toEqual({ input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 });
+    });
+
+    it('prices claude-haiku-4-5-20251001 at its published rates', () => {
+        expect(rates('claude-haiku-4-5-20251001')).toEqual({ input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.1 });
+    });
+
+    it('reports an unknown model as zero, which is why the key has to be right', () => {
+        expect(calculateCost({ model: 'claude-sonnet-4-5', inputTokens: MTOK, outputTokens: MTOK })).toBe(0);
+    });
+});


### PR DESCRIPTION

Moves the Copilot base model from Claude Sonnet 4.6 to Claude Sonnet 5. Sonnet 5 rejects
non-default sampling parameters, and omitting `thinking` enables adaptive reasoning that
shares `maxOutputTokens` with the response — so reasoning is now disabled explicitly at
every Sonnet call site.

- Point the Sonnet constant, Bedrock map and Vertex map at `claude-sonnet-5`; rename
  `ANTHROPIC_SONNET_4` to `ANTHROPIC_SONNET`, matching `ANTHROPIC_HAIKU`
- Add provider-aware `getProviderModelOptions()` — Bedrock reads `providerOptions.bedrock`
  and ignores the `anthropic` namespace
- Remove `temperature: 0` from all nine Sonnet call sites, which Sonnet 5 rejects, and run
  the agent at `effort: 'xhigh'`
- On Bedrock, send `thinking` through `additionalModelRequestFields`: the provider only
  serializes `reasoningConfig` when reasoning is enabled or adaptive, and Bedrock requires
  reasoning off alongside the forced `tool_choice` that web-tools uses
- Add Sonnet 5 pricing in a new `model-pricing.ts`, resolved per call so the introductory
  rates ($2 / $10 per MTok through 2026-08-31) give way to standard without a reload
- Bump `@ai-sdk/anthropic` to 3.0.104 and add a pnpm override pinning nested copies to it:
  earlier 3.x accepts `thinking: {"type": "disabled"}` and then drops it from the request
  body, and google-vertex and anthropic-aws pin older 3.x releases

Typecheck clean, 53 unit tests. Live-verified on the direct Anthropic path — reasoning
disabled at `xhigh` effort, streaming, the tool loop, and a system message at position 0
of `messages` carrying cache-control provider options, matching what the agent sends.
Bedrock, Vertex AI and Claude on AWS are verified at the request level only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Upgraded the Copilot base model to Claude Sonnet 5 across Anthropic, Bedrock, and Vertex AI.
- Added provider-specific model options that disable reasoning and support Anthropic effort settings.
- Removed unsupported `temperature: 0` parameters from Sonnet call sites.
- Updated agent effort configuration to `xhigh`.
- Added time-dependent Sonnet 5 pricing and moved cost calculation into `model-pricing.ts`.
- Added pricing tests for launch rates, standard rates, boundaries, known models, and unknown models.
- Updated `@ai-sdk/anthropic` to `3.0.104` and pinned compatible nested versions.
- Renamed `ANTHROPIC_SONNET_4` to `ANTHROPIC_SONNET`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->