### PR TITLE
chore: sync wso2-vscode-extensions and adopt the new review-status values

### DIFF
--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -711,7 +711,7 @@ export interface Checkpoint {
  */
 export interface GenerationReviewState {
     /** Status of the generation review */
-    status: 'pending' | 'under_review' | 'accepted' | 'error';
+    status: 'generating' | 'done' | 'accepted' | 'reverted' | 'error';
     /** Temp project path while under review (shared across generations in same thread) */
     tempProjectPath?: string;
     /** Files modified in this specific generation */

--- a/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -884,7 +884,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
 
         // Update review state — modifiedFiles is per-generation only
         chatStateStorage.updateReviewState(projectRootPath, threadId, context.messageId, {
-            status: 'under_review',
+            status: 'done',
             tempProjectPath,
             modifiedFiles: generationModifiedFiles,
             affectedPackagePaths: affectedPackagePaths,

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -463,10 +463,10 @@ export class AiPanelRpcManager implements AIPanelAPI {
             const projectRootPath = resolveProjectRootPath();
             const threadId = 'default';
 
-            // Get ALL under_review generations
+            // Get ALL done generations
             const thread = chatStateStorage.getOrCreateThread(projectRootPath, threadId);
             const underReviewGenerations = thread.generations.filter(
-                g => g.reviewState.status === 'under_review'
+                g => g.reviewState.status === 'done'
             );
 
             if (underReviewGenerations.length === 0) {
@@ -478,7 +478,7 @@ export class AiPanelRpcManager implements AIPanelAPI {
             const latestReview = underReviewGenerations[underReviewGenerations.length - 1];
             console.log(`[Review Actions] Accepting generation ${latestReview.id} with ${latestReview.reviewState.modifiedFiles.length} modified file(s)`);
 
-            // Cleanup ALL under_review temp projects (prevents memory leak)
+            // Cleanup ALL done temp projects (prevents memory leak)
             if (!process.env.AI_TEST_ENV) {
                 for (const generation of underReviewGenerations) {
                     if (generation.reviewState.tempProjectPath) {
@@ -487,9 +487,9 @@ export class AiPanelRpcManager implements AIPanelAPI {
                 }
             }
 
-            // Mark ALL under_review generations as accepted (also clears affectedPackagePaths)
+            // Mark ALL done generations as accepted (also clears affectedPackagePaths)
             chatStateStorage.acceptAllReviews(projectRootPath, threadId);
-            console.log("[Review Actions] Marked all under_review generations as accepted");
+            console.log("[Review Actions] Marked all done generations as accepted");
 
             // Send telemetry for generation kept
             sendGenerationKeptTelemetry(latestReview.id);
@@ -510,10 +510,10 @@ export class AiPanelRpcManager implements AIPanelAPI {
             const projectRootPath = resolveProjectRootPath();
             const threadId = 'default';
 
-            // Get ALL under_review generations
+            // Get ALL done generations
             const thread = chatStateStorage.getOrCreateThread(projectRootPath, threadId);
             const underReviewGenerations = thread.generations.filter(
-                g => g.reviewState.status === 'under_review'
+                g => g.reviewState.status === 'done'
             );
 
             if (underReviewGenerations.length === 0) {
@@ -532,7 +532,7 @@ export class AiPanelRpcManager implements AIPanelAPI {
                 console.warn("[Review Actions] No checkpoint found for generation — workspace changes will not be reverted");
             }
 
-            // Cleanup ALL under_review temp projects (prevents memory leak)
+            // Cleanup ALL done temp projects (prevents memory leak)
             if (!process.env.AI_TEST_ENV) {
                 for (const generation of underReviewGenerations) {
                     if (generation.reviewState.tempProjectPath) {
@@ -555,9 +555,9 @@ User reverted the last made changes. The files have been restored to the state b
                 ],
             });
 
-            // Mark ALL under_review generations as error/declined
+            // Mark ALL done generations as error/declined
             chatStateStorage.declineAllReviews(projectRootPath, threadId);
-            console.log("[Review Actions] Marked all under_review generations as declined");
+            console.log("[Review Actions] Marked all done generations as declined");
 
             // Send telemetry for generation discard
             sendGenerationDiscardTelemetry(latestReview.id);

--- a/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -533,7 +533,7 @@ export class ChatStateStorage {
             uiResponse: '',
             timestamp: Date.now(),
             reviewState: {
-                status: 'pending',
+                status: 'generating',
                 modifiedFiles: [],
             },
             currentTaskIndex: -1,
@@ -676,7 +676,7 @@ export class ChatStateStorage {
 
     /**
      * Get chat history for LLM (model messages only)
-     * Includes ALL generations (pending, under_review, accepted)
+     * Includes ALL generations (generating, done, accepted)
      * @param projectRootPath Workspace identifier
      * @param threadId Thread identifier
      * @returns Array of model messages for LLM context
@@ -730,7 +730,7 @@ export class ChatStateStorage {
     // ============================================
 
     /**
-     * Get pending review generation (latest with 'under_review' status)
+     * Get pending review generation (latest with 'done' status)
      * @param projectRootPath Workspace identifier
      * @param threadId Thread identifier
      * @returns Generation or undefined
@@ -741,11 +741,11 @@ export class ChatStateStorage {
     ): Generation | undefined {
         const thread = this.getOrCreateThread(projectRootPath, threadId);
 
-        // Find the LATEST generation with 'under_review' status
+        // Find the LATEST generation with 'done' status
         // Iterate in reverse to get the most recent one
         for (let i = thread.generations.length - 1; i >= 0; i--) {
             const generation = thread.generations[i];
-            if (generation.reviewState.status === 'under_review') {
+            if (generation.reviewState.status === 'done') {
                 console.log(`[ChatStateStorage] Found pending review generation: ${generation.id}`);
                 return generation;
             }
@@ -786,7 +786,7 @@ export class ChatStateStorage {
 
     /**
      * Accept all reviews in a thread
-     * Marks ALL 'under_review' generations as 'accepted' and clears runtime-only
+     * Marks ALL 'done' generations as 'accepted' and clears runtime-only
      * review fields (affectedPackagePaths) in a single operation.
      * @param projectRootPath Workspace identifier
      * @param threadId Thread identifier
@@ -796,7 +796,7 @@ export class ChatStateStorage {
         let count = 0;
 
         for (const generation of thread.generations) {
-            if (generation.reviewState.status === 'under_review') {
+            if (generation.reviewState.status === 'done') {
                 generation.reviewState.status = 'accepted';
                 generation.reviewState.affectedPackagePaths = [];
                 count++;
@@ -812,7 +812,7 @@ export class ChatStateStorage {
 
     /**
      * Decline all reviews in a thread
-     * Marks ALL 'under_review' generations as 'error' and clears runtime-only
+     * Marks ALL 'done' generations as 'error' and clears runtime-only
      * review fields (affectedPackagePaths) in a single operation.
      * @param projectRootPath Workspace identifier
      * @param threadId Thread identifier
@@ -822,7 +822,7 @@ export class ChatStateStorage {
         let count = 0;
 
         for (const generation of thread.generations) {
-            if (generation.reviewState.status === 'under_review') {
+            if (generation.reviewState.status === 'done') {
                 generation.reviewState.status = 'error';
                 generation.reviewState.errorMessage = 'Declined by user';
                 generation.reviewState.affectedPackagePaths = [];


### PR DESCRIPTION
## Purpose

Syncs the `submodules/wso2-vscode-extensions` pointer and adapts this repo to the review-status enum change that came with it.

The persisted review-status enum in `copilot-utilities/chat-persistence` changed in wso2/vscode-extensions#2430 (the revert-model refactor):

| | values |
|---|---|
| before | `'pending' \| 'under_review' \| 'accepted' \| 'error'` |
| after | `'generating' \| 'done' \| 'accepted' \| 'reverted' \| 'error'` |

`chatStateStorage.ts` copies `reviewState.status` straight through in **both** directions between our runtime type (`ballerina-core/state-machine-types.ts`) and the persisted type, so bumping the submodule past that refactor breaks the build:

```
chatStateStorage.ts(117,13) TS2322:
  Type '"error" | "pending" | "under_review" | "accepted"'
  is not assignable to type '"done" | "error" | "accepted" | "generating" | "reverted"'

chatStateStorage.ts(147,13) TS2322:  (the reverse direction)
```

Two `ts-loader` errors are enough to fail the whole webpack compile, so this blocks any submodule bump past that commit — which is why it is split out rather than carried inside a feature PR.

## Approach

Rename our runtime values to match the persisted ones:

- `under_review` → `done` (7 sites: one write in `AgentExecutor`, comparisons in `rpc-manager` and `chatStateStorage`, plus comments)
- `pending` → `generating` (one write in `chatStateStorage`)
- the union in `ballerina-core/state-machine-types.ts` updated to the new set

22 insertions for 22 deletions. No logic touched — every site is a value rename.

### Deliberately not adopting `reverted`

Worth flagging for whoever owns the copilot review feature. Our decline path already reverts the workspace from a checkpoint (`rpc-manager.ts`, `restoreWorkspaceSnapshot`) and then marks the generation **`error`**:

```ts
// chatStateStorage.declineAllReviews
if (generation.reviewState.status === 'done') {
    generation.reviewState.status = 'error';
```

The new `reverted` state looks like exactly what that path wants. I have **not** made that change here, because:

1. it would alter behaviour — anything filtering on `error` would stop seeing declined generations, and
2. whether this extension takes on the new revert state is a feature decision, not part of a submodule sync.

So `reverted` is declared but unused, and decline still writes `error` exactly as before. Happy to follow up separately if that switch is wanted.

### Note on the persisted-data migration

The refactor ships its own v1→v2 file migration, which folds `pending` and `under_review` into `accepted` on load ("no live process resumes across a restart"). That governs data already on disk and is unaffected by this PR; the renames here are runtime-only and 1:1, so no additional migration is needed.

## Release note

No user-facing change. Internal sync of the shared submodule and the review-status value names that came with it.

## Documentation

N/A — internal type/value rename with no behavioural or API change.

## Automation tests

- Unit tests
  > None added; this is a value rename with no behaviour change and no existing harness for these paths.
- Integration tests
  > N/A

**Verified:**
- `copilot-utilities` and `ballerina-core` build at the new pin
- the persisted type resolves to `'generating' | 'done' | 'accepted' | 'reverted' | 'error'`
- `chatStateStorage.ts` typechecks with **zero** errors (was 2 × `TS2322`)
- **no `TS2322` errors remain** in `ballerina-extension`; total drops 34 → 32, the remainder being pre-existing unbuilt-sibling module resolution in a partial local build

Note the check above is `tsc --noEmit` over the same tsconfig `ts-loader` uses, not a full `rush build` — CI will confirm the webpack compile.

## Security checks

- Followed secure coding standards? **yes**
- Ran FindSecurityBugs plugin? **N/A** — TypeScript, not Java
- Confirmed no keys/passwords/tokens committed? **yes**

## Related PRs

- wso2/vscode-extensions#2430 — the refactor that changed the enum
- ballerina-platform/ballerina-vscode#741 — the BI-bridge auth fix, which needs a submodule bump past this refactor and will rebase onto this PR

## Test environment

macOS (darwin 25.5.0), Node 22.21.1, Rush 5.155.1 / pnpm 10.11.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated generation review statuses to the persisted lifecycle values: `generating`, `done`, `accepted`, `reverted`, and `error`.
- Updated related state transitions, comparisons, comments, and review handling while preserving existing decline behavior.
- Resolved `chatStateStorage.ts` type errors without changing user-facing behavior or adding data migration.
- Synchronized the `wso2-vscode-extensions` submodule reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->