### PR TITLE
Add managed connections to the config collector

### DIFF
--- a/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -39,6 +39,8 @@ import {
     ConnectorSpecCancelRequest,
     ConfigurationProvideRequest,
     ConfigurationCancelRequest,
+    CreateManagedConnectionRequest,
+    CreateManagedConnectionResponse,
     UIChatMessage,
     CheckpointInfo,
     AbortAIGenerationRequest,
@@ -136,6 +138,8 @@ export interface AIPanelAPI {
     cancelConnectorSpec: (params: ConnectorSpecCancelRequest) => Promise<void>;
     provideConfiguration: (params: ConfigurationProvideRequest) => Promise<void>;
     cancelConfiguration: (params: ConfigurationCancelRequest) => Promise<void>;
+    createManagedConnection: (params: CreateManagedConnectionRequest) => Promise<CreateManagedConnectionResponse>;
+    cancelManagedConnection: () => void;
     // ==================================
     // Chat State Management
     // ==================================

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -479,6 +479,26 @@ export interface ConfigurationCancelRequest {
     comment?: string;
 }
 
+export interface CreateManagedConnectionRequest {
+    vendor: string;
+    // Expected grant shape, used to verify the service returned a matching credential kind.
+    authType?: "oauth2RefreshToken" | "staticToken";
+}
+
+export interface CreateManagedConnectionResponse {
+    success: boolean;
+    // Populated per grant shape: refresh fills clientId/clientSecret/refreshToken/refreshUrl,
+    // static fills token.
+    credentials?: {
+        clientId?: string;
+        clientSecret?: string;
+        refreshToken?: string;
+        refreshUrl?: string;
+        token?: string;
+    };
+    error?: string;
+}
+
 export interface WebToolApprovalRequest {
     requestId: string;
 }

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -482,7 +482,7 @@ export interface ConfigurationCancelRequest {
 export interface CreateManagedConnectionRequest {
     vendor: string;
     // Expected grant shape, used to verify the service returned a matching credential kind.
-    authType?: "oauth2RefreshToken" | "staticToken";
+    authType: "oauth2RefreshToken" | "staticToken";
 }
 
 export interface CreateManagedConnectionResponse {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -41,6 +41,8 @@ import {
     ConnectorSpecCancelRequest,
     ConfigurationProvideRequest,
     ConfigurationCancelRequest,
+    CreateManagedConnectionRequest,
+    CreateManagedConnectionResponse,
     UIChatMessage,
     CheckpointInfo,
     AbortAIGenerationRequest,
@@ -127,6 +129,8 @@ export const provideConnectorSpec: RequestType<ConnectorSpecRequest, void> = { m
 export const cancelConnectorSpec: RequestType<ConnectorSpecCancelRequest, void> = { method: `${_preFix}/cancelConnectorSpec` };
 export const provideConfiguration: RequestType<ConfigurationProvideRequest, void> = { method: `${_preFix}/provideConfiguration` };
 export const cancelConfiguration: RequestType<ConfigurationCancelRequest, void> = { method: `${_preFix}/cancelConfiguration` };
+export const createManagedConnection: RequestType<CreateManagedConnectionRequest, CreateManagedConnectionResponse> = { method: `${_preFix}/createManagedConnection` };
+export const cancelManagedConnection: NotificationType<void> = { method: `${_preFix}/cancelManagedConnection` };
 export const getChatMessages: NotificationType<void> = { method: `${_preFix}/getChatMessages` };
 export const getCheckpoints: NotificationType<void> = { method: `${_preFix}/getCheckpoints` };
 export const restoreCheckpoint: RequestType<RestoreCheckpointRequest, void> = { method: `${_preFix}/restoreCheckpoint` };

--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -160,6 +160,23 @@ export interface ArtifactInfo {
     version?: string;
 }
 
+export interface ManagedCredentialMapping {
+    name: string;
+    credentialField: "clientId" | "clientSecret" | "refreshToken" | "token";
+    description: string;
+    secret?: boolean;
+}
+
+export interface ManagedConnectionGroup {
+    // Stable per-payload identity. `vendor` is not unique across groups, so the form keys off this.
+    id: string;
+    vendor: string;
+    authType: "oauth2RefreshToken" | "staticToken";
+    variables: ManagedCredentialMapping[];
+    // Refresh grant only.
+    refreshUrlVar?: string;
+}
+
 export interface ConfigurationCollectorMetadata {
     requestId: string;
     variables: Array<{
@@ -171,6 +188,7 @@ export interface ConfigurationCollectorMetadata {
     existingValues?: Record<string, string>;
     message: string;
     isTestConfig?: boolean;
+    managedConnections?: ManagedConnectionGroup[];
 }
 
 export interface AgentMetadata {

--- a/packages/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -195,6 +195,11 @@ ${getLanglibInstructions()}
 - Initialize any necessary clients with the correct configuration based on the retrieved libraries at the module level (before any function or service declarations).
 - Implement the main function OR service to address the query requirements.
 
+## OAuth refreshUrl configurable
+When a connector authenticates via an OAuth2 refresh-token grant that includes a refreshUrl:
+- Declare a \`configurable string\` for the refreshUrl and reference it in the auth config (e.g. \`refreshUrl: refreshUrl\`).
+- refreshUrl is the one configurable that MAY carry a default: if the library's type definition provides a default refreshUrl (the provider token endpoint), use it (\`configurable string refreshUrl = "<provider-token-endpoint-url>";\`); otherwise use \`configurable string refreshUrl = ?;\`.
+
 ## Coding Rules
 - Use records as canonical representations of data structures. Always define records for data structures instead of using maps or json and navigate using the record fields.
 - Do not invoke methods on json access expressions. Always use separate statements.
@@ -248,6 +253,10 @@ In WSO2 Integrator, a Ballerina workspace is called a **project** and a Ballerin
 - You should only Run or write tests if the user explicitly asks to do so.
 - Providing values to configurables is a runtime task and should only do it before running or executing the tests.
 - For Config.toml configuration value management, use ${CONFIG_COLLECTOR_TOOL}. The codebase listing shows <config_files main="present|absent" tests="present|absent"/> per project indicating whether Config.toml files exist.
+- **Before EVERY ${CONFIG_COLLECTOR_TOOL} COLLECT call, check for connector-auth configurables.** For any connector client whose auth is fed by configurables, group those configurables under \`managedConnections\` keyed by the connector's library ("org/package") instead of leaving them in the plain \`variables\` array — even when a credential looks like an ordinary secret (a bearer/bot/access token used by a connector is a connector auth credential, not a plain variable). Tag each group with authType: \`oauth2RefreshToken\` (map clientId, clientSecret, refreshToken, refreshUrl) or \`staticToken\` (map the single token).
+- The auth structure does NOT change this. Some libraries expose the OAuth config via a directly-named type (e.g. \`oauth2:OAuth2RefreshTokenGrantConfig\`); others wrap it inside the connector's own config record (e.g. a \`ConnectionConfig\` whose \`auth\` field carries the credentials). Both are grouped the same way — look at the credential fields, not where they sit.
+- You do NOT decide which (library, shape) combinations are actually managed — the tool verifies each against the managed registry and silently downgrades unsupported ones to manual entry. So emit a group for ANY connector credential that fits one of the two shapes; grouping a candidate that turns out to be unsupported is harmless. That tolerance covers the library and shape only — every mapped name must be a configurable that already exists in source, spelled exactly as declared. Only leave TRULY non-connector secrets (e.g. a database password, or a standalone API key not tied to any connector) in \`variables\`.
+- Use one managedConnections entry per connector instance (repeat the same library for two clients of it), and put each configurable in EXACTLY ONE place — never list the same name in both a group and \`variables\`.
 - You can call ${BALLERINA_STOP_TOOL_NAME} when you need to restart a service (e.g. after code changes) or when the user explicitly asks to stop it.
 
 ## Test Runner

--- a/packages/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -486,12 +486,32 @@ async function fetchManagedLibraries(): Promise<ManagedLibrariesResponse> {
             return { libraries: [] };
         }
 
+        // Remote JSON: the response type asserts these shapes, nothing validates them. Dropping
+        // malformed entries here keeps one bad entry from degrading anything but its own group.
+        const libraries: ManagedLibraryEntry[] = [];
+        for (const entry of data.libraries) {
+            if (!entry || typeof entry.library !== "string" || !Array.isArray(entry.authOptions)) {
+                continue;
+            }
+            libraries.push({
+                library: entry.library,
+                authOptions: entry.authOptions.filter(
+                    (option) => option && typeof option.grant === "string" && typeof option.provider === "string"
+                ),
+            });
+        }
+        const dropped = data.libraries.length - libraries.length;
+        if (dropped > 0) {
+            console.warn(`[ConfigCollector][managed-connections] dropped ${dropped} malformed catalog ` +
+                `entr${dropped === 1 ? "y" : "ies"} — their groups will fall back to manual entry.`);
+        }
+
         // Cache only a catalog that actually carries entries — an empty one is indistinguishable
         // from a misconfigured or not-yet-deployed service, and is not worth pinning the session to.
-        if (data.libraries.length > 0) {
-            managedLibrariesCache = data;
+        if (libraries.length > 0) {
+            managedLibrariesCache = { libraries };
         }
-        return data;
+        return { libraries };
     } catch (error: any) {
         console.error("[ConfigCollector][managed-connections] Failed to load the managed-libraries catalog " +
             "(unreachable, erroring, or not deployed) — treating all candidate groups as unmanaged:",
@@ -509,10 +529,28 @@ interface ResolvedManagedConnections {
     degradedVariables: ConfigVariable[];
 }
 
+// Configurables a group contributes when collected by hand — no managed provider matched its
+// (library, shape), or the registry check failed.
+function manualVariablesFor(group: ManagedConnectionInput): ConfigVariable[] {
+    if (group.authType === "oauth2RefreshToken") {
+        return [
+            { name: group.clientId, description: "Client ID", type: "string", secret: true },
+            { name: group.clientSecret, description: "Client Secret", type: "string", secret: true },
+            { name: group.refreshToken, description: "Refresh Token", type: "string", secret: true },
+            { name: group.refreshUrl, description: "Refresh URL", type: "string", secret: false },
+        ];
+    }
+    return [
+        { name: group.token, description: "Token", type: "string", secret: true },
+    ];
+}
+
 // Partitions groups: those whose (library, shape) is a registered managed provider become
 // managed metas, everything else degrades to manual configurables. The
 // credentialField → variable mapping is taken as-is from the LLM, which has the code context;
 // this only confirms the (library, shape) and applies the beta gate.
+//
+// Never throws: any failure degrades every group to manual entry rather than failing the collect.
 async function resolveManagedConnections(groups: ManagedConnectionInput[]): Promise<ResolvedManagedConnections> {
     const result: ResolvedManagedConnections = { metas: [], managedVariables: [], degradedVariables: [] };
     if (groups.length === 0) { return result; }
@@ -520,76 +558,73 @@ async function resolveManagedConnections(groups: ManagedConnectionInput[]): Prom
     console.log(`[ConfigCollector][managed-connections] resolving ${groups.length} oauth group(s):`,
         groups.map((g) => ({ library: g.library, authType: g.authType })));
 
-    const registry = await fetchManagedLibraries();
-    const entriesByLibrary = new Map<string, ManagedLibraryEntry>(
-        registry.libraries.map((e) => [e.library, e])
-    );
-
-    const experimentalEnabled = extension.ballerinaExtInstance.enabledExperimentalFeatures();
-
-    for (const [index, group] of groups.entries()) {
-        const entry = entriesByLibrary.get(group.library);
-        const option = entry?.authOptions.find(
-            (o) => o.grant === group.authType && (!o.beta || experimentalEnabled)
+    try {
+        const registry = await fetchManagedLibraries();
+        const entriesByLibrary = new Map<string, ManagedLibraryEntry>(
+            registry.libraries.map((e) => [e.library, e])
         );
 
-        // `vendor` cannot be the key — two clients of one connector share a provider, and several
-        // libraries can too. The index disambiguates and is stable for a metadata payload.
-        const id = `${group.library}#${index}`;
+        const experimentalEnabled = extension.ballerinaExtInstance.enabledExperimentalFeatures();
 
-        if (option) {
-            const vendor = option.provider;
-            console.log(`[ConfigCollector][managed-connections] '${group.library}' (${group.authType}) → MANAGED (provider: '${vendor}', id: '${id}')`);
-            if (group.authType === "oauth2RefreshToken") {
-                result.metas.push({
-                    id,
-                    vendor,
-                    authType: "oauth2RefreshToken",
-                    variables: [
-                        { name: group.clientId, credentialField: "clientId", description: "Client ID", secret: true },
-                        { name: group.clientSecret, credentialField: "clientSecret", description: "Client Secret", secret: true },
-                        { name: group.refreshToken, credentialField: "refreshToken", description: "Refresh Token", secret: true },
-                    ],
-                    refreshUrlVar: group.refreshUrl,
-                });
-                result.managedVariables.push(
-                    { name: group.clientId, description: "Client ID", type: "string", secret: true },
-                    { name: group.clientSecret, description: "Client Secret", type: "string", secret: true },
-                    { name: group.refreshToken, description: "Refresh Token", type: "string", secret: true },
-                    // Must be collected so it reaches Config.toml (the writer only writes declared
-                    // variables), but it is not in meta.variables, so the form renders it as an
-                    // ordinary editable field rather than a proxied secret.
-                    { name: group.refreshUrl, description: "Refresh URL", type: "string", secret: false },
-                );
+        for (const [index, group] of groups.entries()) {
+            const entry = entriesByLibrary.get(group.library);
+            const option = entry?.authOptions.find(
+                (o) => o.grant === group.authType && (!o.beta || experimentalEnabled)
+            );
+
+            // `vendor` cannot be the key — two clients of one connector share a provider, and several
+            // libraries can too. The index disambiguates and is stable for a metadata payload.
+            const id = `${group.library}#${index}`;
+
+            if (option) {
+                const vendor = option.provider;
+                console.log(`[ConfigCollector][managed-connections] '${group.library}' (${group.authType}) → MANAGED (provider: '${vendor}', id: '${id}')`);
+                if (group.authType === "oauth2RefreshToken") {
+                    result.metas.push({
+                        id,
+                        vendor,
+                        authType: "oauth2RefreshToken",
+                        variables: [
+                            { name: group.clientId, credentialField: "clientId", description: "Client ID", secret: true },
+                            { name: group.clientSecret, credentialField: "clientSecret", description: "Client Secret", secret: true },
+                            { name: group.refreshToken, credentialField: "refreshToken", description: "Refresh Token", secret: true },
+                        ],
+                        refreshUrlVar: group.refreshUrl,
+                    });
+                    result.managedVariables.push(
+                        { name: group.clientId, description: "Client ID", type: "string", secret: true },
+                        { name: group.clientSecret, description: "Client Secret", type: "string", secret: true },
+                        { name: group.refreshToken, description: "Refresh Token", type: "string", secret: true },
+                        // Must be collected so it reaches Config.toml (the writer only writes declared
+                        // variables), but it is not in meta.variables, so the form renders it as an
+                        // ordinary editable field rather than a proxied secret.
+                        { name: group.refreshUrl, description: "Refresh URL", type: "string", secret: false },
+                    );
+                } else {
+                    result.metas.push({
+                        id,
+                        vendor,
+                        authType: "staticToken",
+                        variables: [
+                            { name: group.token, credentialField: "token", description: "Token", secret: true },
+                        ],
+                    });
+                    result.managedVariables.push(
+                        { name: group.token, description: "Token", type: "string", secret: true },
+                    );
+                }
             } else {
-                result.metas.push({
-                    id,
-                    vendor,
-                    authType: "staticToken",
-                    variables: [
-                        { name: group.token, credentialField: "token", description: "Token", secret: true },
-                    ],
-                });
-                result.managedVariables.push(
-                    { name: group.token, description: "Token", type: "string", secret: true },
-                );
-            }
-        } else {
-            // No matching managed (library, shape) option → collect the group's field(s) manually.
-            console.warn(`[ConfigCollector][managed-connections] '${group.library}' (${group.authType}) → NOT managed; falling back to manual entry.`);
-            if (group.authType === "oauth2RefreshToken") {
-                result.degradedVariables.push(
-                    { name: group.clientId, description: "Client ID", type: "string", secret: true },
-                    { name: group.clientSecret, description: "Client Secret", type: "string", secret: true },
-                    { name: group.refreshToken, description: "Refresh Token", type: "string", secret: true },
-                    { name: group.refreshUrl, description: "Refresh URL", type: "string", secret: false },
-                );
-            } else {
-                result.degradedVariables.push(
-                    { name: group.token, description: "Token", type: "string", secret: true },
-                );
+                // No matching managed (library, shape) option → collect the group's field(s) manually.
+                console.warn(`[ConfigCollector][managed-connections] '${group.library}' (${group.authType}) → NOT managed; falling back to manual entry.`);
+                result.degradedVariables.push(...manualVariablesFor(group));
             }
         }
+    } catch (error: any) {
+        // Partial results are discarded: a half-built one would render Connect cards backed by a
+        // lookup that did not finish.
+        console.error("[ConfigCollector][managed-connections] failed to resolve managed connections — " +
+            "falling back to manual entry for all candidate groups:", error?.message || error);
+        return { metas: [], managedVariables: [], degradedVariables: groups.flatMap(manualVariablesFor) };
     }
 
     console.log(

--- a/packages/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -34,9 +34,16 @@ import {
     isPlaceholderValue,
     computeCollectStatus,
 } from "../../../../utils/toml-utils";
+import { ManagedConnectionGroup } from "@wso2/ballerina-core/lib/state-machine-types";
 import { RecoverableAgentError, resolveContained, resolvePackageBasePath } from "./path-utils";
 import { getOrgPackageName } from "../../../../utils/config";
 import { langClient } from "../../activator";
+import { extension } from "../../../../BalExtensionContext";
+import {
+    getManagedLibraries,
+    ManagedLibrariesResponse,
+    ManagedLibraryEntry,
+} from "../../../../rpc-managers/platform-ext/managed-connections";
 
 export const CONFIG_COLLECTOR_TOOL = "ConfigCollector";
 
@@ -55,6 +62,28 @@ const ConfigKeyRenameSchema = z.object({
     to: z.string().describe("New variable name — must match the renamed configurable identifier in source"),
 });
 
+// Managed connections, discriminated by `authType` and `.strict()` so a partial or mixed group
+// is rejected at the schema level rather than silently half-configured.
+const RefreshTokenConnectionSchema = z.object({
+    authType: z.literal("oauth2RefreshToken").describe("Discriminator: OAuth2 refresh-token grant"),
+    library: z.string().describe("Connector library in 'org/package' form, e.g. '<org>/<connector>'"),
+    clientId: z.string().describe("Configurable identifier holding the OAuth client ID"),
+    clientSecret: z.string().describe("Configurable identifier holding the OAuth client secret"),
+    refreshToken: z.string().describe("Configurable identifier holding the OAuth refresh token"),
+    refreshUrl: z.string().describe("Configurable identifier holding the OAuth refresh URL"),
+}).strict();
+
+// A single long-lived token (bearer / bot / static). Any one-field client auth is a candidate;
+// the registry decides whether it is actually managed.
+const StaticTokenConnectionSchema = z.object({
+    authType: z.literal("staticToken").describe("Discriminator: single static/bearer token"),
+    library: z.string().describe("Connector library in 'org/package' form, e.g. '<org>/<connector>'"),
+    token: z.string().describe("Configurable identifier holding the static/bearer token"),
+}).strict();
+
+// Exactly one shape per group; .strict() blocks mixing fields across shapes.
+const ManagedConnectionSchema = z.discriminatedUnion("authType", [RefreshTokenConnectionSchema, StaticTokenConnectionSchema]);
+
 const ConfigCollectorSchema = z.object({
     mode: z.enum(["collect", "check", "remove", "rename"]).describe("Operation mode"),
     filePath: z.string().optional().describe("Path to config file (for check mode)"),
@@ -66,12 +95,30 @@ const ConfigCollectorSchema = z.object({
         "Rename pairs for 'rename' mode. The 'to' name must already exist as a configurable in source."
     ),
     isTestConfig: z.boolean().optional().describe("Set to true when collecting configuration for tests. Tool will automatically read from Config.toml and write to tests/Config.toml"),
+    managedConnections: z.array(ManagedConnectionSchema).optional().describe("Managed connections, one per connector instance. Each is tagged with authType: 'oauth2RefreshToken' (clientId/clientSecret/refreshToken/refreshUrl) or 'staticToken' (a single token field). Repeat the same library for two clients of it. The tool verifies the (library, shape) is a managed provider; unsupported combinations fall back to manual entry."),
     packagePath: z.string().optional().describe(
         "Relative path to the target package within the workspace project (e.g., \"pkg1\"). " +
         "Required for workspace projects so Config.toml is written inside the correct package, not the workspace root. " +
         "Omit for single-package (non-workspace) projects."
     ),
 });
+
+interface RefreshTokenConnection {
+    authType: "oauth2RefreshToken";
+    library: string;
+    clientId: string;
+    clientSecret: string;
+    refreshToken: string;
+    refreshUrl: string;
+}
+
+interface StaticTokenConnection {
+    authType: "staticToken";
+    library: string;
+    token: string;
+}
+
+type ManagedConnectionInput = RefreshTokenConnection | StaticTokenConnection;
 
 interface ConfigCollectorInput {
     mode: "collect" | "check" | "remove" | "rename";
@@ -80,6 +127,7 @@ interface ConfigCollectorInput {
     variableNames?: string[];
     renames?: ConfigKeyRename[];
     isTestConfig?: boolean;
+    managedConnections?: ManagedConnectionInput[];
     packagePath?: string;
 }
 
@@ -195,6 +243,16 @@ Operation Modes:
    - Example (test): { mode: "collect", variables: [...], isTestConfig: true }
    - Example (workspace): { mode: "collect", variables: [...], packagePath: "pkg1" }
 
+   Managed Connections:
+   - If a CONNECTOR authenticates using credentials (configurables passed into the connector's ConnectionConfig / auth), pass those configurables as an entry in managedConnections — do NOT leave them in the plain variables array. This applies EVEN when the credential looks like an ordinary secret: a bearer token / bot token / access token used by a connector is a connector auth credential, not a plain variable. Tag each entry with authType:
+       * authType: "oauth2RefreshToken" — OAuth2 refresh-token grant. Map all four configurables: clientId, clientSecret, refreshToken, refreshUrl (all required).
+       * authType: "staticToken" — the connector authenticates with a SINGLE long-lived token (bearer token, bot token, access token, static token). Map the one configurable as token.
+   - Key each group by the connector library in "org/package" form (e.g. "<org>/<connector>")
+   - One entry per connector instance; repeat the same library if there are two clients of it
+   - Put each configurable in EXACTLY ONE place: if it belongs to a managedConnections entry, it goes ONLY there and must NOT also appear in the variables array (and vice versa). Never list the same configurable name twice.
+   - Be liberal: emit a group for ANY connector credential that fits one of these two shapes. You do NOT decide which are actually supported — the tool checks each (library, shape) against the managed registry and silently downgrades unsupported ones to manual entry, so grouping a candidate that turns out to be unsupported is harmless. That tolerance covers the library and shape only — every mapped name must be a configurable that already exists in source, spelled exactly as declared. Only leave TRULY non-connector secrets (e.g. a database password, or a standalone API key not tied to any connector) in the variables array
+   - Example (refresh + static + standalone): { mode: "collect", managedConnections: [{ authType: "oauth2RefreshToken", library: "<org>/<connectorA>", clientId: "<clientIdVar>", clientSecret: "<clientSecretVar>", refreshToken: "<refreshTokenVar>", refreshUrl: "<refreshUrlVar>" }, { authType: "staticToken", library: "<org>/<connectorB>", token: "<tokenVar>" }], variables: [{ name: "serverPort", description: "HTTP listener port" }] }
+
 2. CHECK: Inspect which values are filled or missing — can be called at any time
    - Returns variable names and status; never actual values
    - For workspace projects, pass packagePath to inspect the Config.toml of a specific package
@@ -283,16 +341,35 @@ export async function ConfigCollectorTool(
 
     try {
         switch (input.mode) {
-            case "collect":
+            case "collect": {
+                const { metas, managedVariables, degradedVariables } =
+                    await resolveManagedConnections(input.managedConnections || []);
+
+                // First-occurrence wins (managed → degraded → plain): the LLM sometimes lists a
+                // credential in both a group and `variables`, and the group entry must win so the
+                // field stays attached to its Connect card.
+                const seenVarNames = new Set<string>();
+                const allVariables = [
+                    ...managedVariables,
+                    ...degradedVariables,
+                    ...(input.variables || []),
+                ].filter((v) => {
+                    if (seenVarNames.has(v.name)) { return false; }
+                    seenVarNames.add(v.name);
+                    return true;
+                });
+
                 return await handleCollectMode(
-                    input.variables,
+                    allVariables,
                     paths,
                     eventHandler,
                     requestId,
                     input.isTestConfig,
                     modifiedFiles,
-                    input.packagePath
+                    input.packagePath,
+                    metas.length > 0 ? metas : undefined
                 );
+            }
 
             case "check":
                 return await handleCheckMode(
@@ -372,6 +449,158 @@ async function getConfigurableTypesFromSource(
     }
 }
 
+// -----------------------------------------------------------------------------
+// Managed-connection registry. The catalog lists which connector libraries can be brokered and under
+// which grant shapes; a library is managed for a shape iff it lists a matching auth option, each
+// pairing a `grant` with the provider key that brokers it. One library may list several options
+// (e.g. Slack as a static token today, a refresh grant later). The HTTP call lives in
+// rpc-managers/platform-ext/managed-connections.ts; this file only interprets the result.
+// -----------------------------------------------------------------------------
+
+// Only non-empty catalogs are cached — the common failure is "not signed in yet", and caching
+// that would keep every group demoted for the rest of the session.
+let managedLibrariesCache: ManagedLibrariesResponse | undefined;
+
+// Never throws: on any failure an empty catalog demotes every candidate group to manual entry,
+// which is the pre-feature behaviour, rather than blocking config collection.
+async function fetchManagedLibraries(): Promise<ManagedLibrariesResponse> {
+    if (managedLibrariesCache) {
+        console.log(`[ConfigCollector][managed-connections] using cached managed-libraries catalog ` +
+            `(${managedLibrariesCache.libraries.length} librar${managedLibrariesCache.libraries.length === 1 ? "y" : "ies"}).`);
+        return managedLibrariesCache;
+    }
+
+    // Checked before any credential is read, so with the flag off nothing is contacted.
+    if (!extension.ballerinaExtInstance.enabledExperimentalFeatures()) {
+        console.log("[ConfigCollector][managed-connections] experimental features are off — skipping the " +
+            "managed-libraries lookup; all candidate groups will be treated as unmanaged.");
+        return { libraries: [] };
+    }
+
+    try {
+        const data = await getManagedLibraries();
+
+        if (!data || !Array.isArray(data.libraries)) {
+            console.warn("[ConfigCollector][managed-connections] managed-libraries endpoint returned an unexpected " +
+                "response shape — treating all candidate groups as unmanaged.");
+            return { libraries: [] };
+        }
+
+        // Cache only a catalog that actually carries entries — an empty one is indistinguishable
+        // from a misconfigured or not-yet-deployed service, and is not worth pinning the session to.
+        if (data.libraries.length > 0) {
+            managedLibrariesCache = data;
+        }
+        return data;
+    } catch (error: any) {
+        console.error("[ConfigCollector][managed-connections] Failed to load the managed-libraries catalog " +
+            "(unreachable, erroring, or not deployed) — treating all candidate groups as unmanaged:",
+            error?.message || error);
+        return { libraries: [] };
+    }
+}
+
+interface ResolvedManagedConnections {
+    // Metadata for groups that are managed (drives the grouped UI + proxy).
+    metas: ManagedConnectionGroup[];
+    // Credential configurables for managed groups (collected/proxied).
+    managedVariables: ConfigVariable[];
+    // Configurables for groups that fell back to manual entry.
+    degradedVariables: ConfigVariable[];
+}
+
+// Partitions groups: those whose (library, shape) is a registered managed provider become
+// managed metas, everything else degrades to manual configurables. The
+// credentialField → variable mapping is taken as-is from the LLM, which has the code context;
+// this only confirms the (library, shape) and applies the beta gate.
+async function resolveManagedConnections(groups: ManagedConnectionInput[]): Promise<ResolvedManagedConnections> {
+    const result: ResolvedManagedConnections = { metas: [], managedVariables: [], degradedVariables: [] };
+    if (groups.length === 0) { return result; }
+
+    console.log(`[ConfigCollector][managed-connections] resolving ${groups.length} oauth group(s):`,
+        groups.map((g) => ({ library: g.library, authType: g.authType })));
+
+    const registry = await fetchManagedLibraries();
+    const entriesByLibrary = new Map<string, ManagedLibraryEntry>(
+        registry.libraries.map((e) => [e.library, e])
+    );
+
+    const experimentalEnabled = extension.ballerinaExtInstance.enabledExperimentalFeatures();
+
+    for (const [index, group] of groups.entries()) {
+        const entry = entriesByLibrary.get(group.library);
+        const option = entry?.authOptions.find(
+            (o) => o.grant === group.authType && (!o.beta || experimentalEnabled)
+        );
+
+        // `vendor` cannot be the key — two clients of one connector share a provider, and several
+        // libraries can too. The index disambiguates and is stable for a metadata payload.
+        const id = `${group.library}#${index}`;
+
+        if (option) {
+            const vendor = option.provider;
+            console.log(`[ConfigCollector][managed-connections] '${group.library}' (${group.authType}) → MANAGED (provider: '${vendor}', id: '${id}')`);
+            if (group.authType === "oauth2RefreshToken") {
+                result.metas.push({
+                    id,
+                    vendor,
+                    authType: "oauth2RefreshToken",
+                    variables: [
+                        { name: group.clientId, credentialField: "clientId", description: "Client ID", secret: true },
+                        { name: group.clientSecret, credentialField: "clientSecret", description: "Client Secret", secret: true },
+                        { name: group.refreshToken, credentialField: "refreshToken", description: "Refresh Token", secret: true },
+                    ],
+                    refreshUrlVar: group.refreshUrl,
+                });
+                result.managedVariables.push(
+                    { name: group.clientId, description: "Client ID", type: "string", secret: true },
+                    { name: group.clientSecret, description: "Client Secret", type: "string", secret: true },
+                    { name: group.refreshToken, description: "Refresh Token", type: "string", secret: true },
+                    // Must be collected so it reaches Config.toml (the writer only writes declared
+                    // variables), but it is not in meta.variables, so the form renders it as an
+                    // ordinary editable field rather than a proxied secret.
+                    { name: group.refreshUrl, description: "Refresh URL", type: "string", secret: false },
+                );
+            } else {
+                result.metas.push({
+                    id,
+                    vendor,
+                    authType: "staticToken",
+                    variables: [
+                        { name: group.token, credentialField: "token", description: "Token", secret: true },
+                    ],
+                });
+                result.managedVariables.push(
+                    { name: group.token, description: "Token", type: "string", secret: true },
+                );
+            }
+        } else {
+            // No matching managed (library, shape) option → collect the group's field(s) manually.
+            console.warn(`[ConfigCollector][managed-connections] '${group.library}' (${group.authType}) → NOT managed; falling back to manual entry.`);
+            if (group.authType === "oauth2RefreshToken") {
+                result.degradedVariables.push(
+                    { name: group.clientId, description: "Client ID", type: "string", secret: true },
+                    { name: group.clientSecret, description: "Client Secret", type: "string", secret: true },
+                    { name: group.refreshToken, description: "Refresh Token", type: "string", secret: true },
+                    { name: group.refreshUrl, description: "Refresh URL", type: "string", secret: false },
+                );
+            } else {
+                result.degradedVariables.push(
+                    { name: group.token, description: "Token", type: "string", secret: true },
+                );
+            }
+        }
+    }
+
+    console.log(
+        `[ConfigCollector][managed-connections] result — managed groups: [${result.metas.map((m) => `${m.id} → ${m.vendor}`).join(", ") || "none"}]; ` +
+        `managed vars: [${result.managedVariables.map((v) => v.name).join(", ") || "none"}]; ` +
+        `degraded vars: [${result.degradedVariables.map((v) => v.name).join(", ") || "none"}]`
+    );
+
+    return result;
+}
+
 async function handleCollectMode(
     variables: ConfigVariable[] | undefined,
     paths: ConfigCollectorPaths,
@@ -379,7 +608,8 @@ async function handleCollectMode(
     requestId: string,
     isTestConfig?: boolean,
     modifiedFiles?: string[],
-    packagePath?: string
+    packagePath?: string,
+    managedConnections?: ManagedConnectionGroup[]
 ): Promise<ConfigCollectorResult> {
     const validationError = validateConfigVariables(variables);
     if (validationError) { return validationError; }
@@ -453,13 +683,16 @@ async function handleCollectMode(
     console.log(`[ConfigCollector] collect requested=${enrichedVariables.length} preFilled=${analysis.filledCount} file=${configFileName}`);
 
     // Determine the message to show to user
-    const userMessage = isTestConfig
-        ? (analysis.hasActualValues
-            ? "Found values from main config. You can reuse or update them for testing."
-            : "Test configuration values needed")
-        : (analysis.hasActualValues
-            ? "Update configuration values"
-            : "Configuration values needed");
+    // Vendors are deduped — several groups can share one provider.
+    const userMessage = managedConnections?.length
+        ? `Configure ${[...new Set(managedConnections.map(g => g.vendor))].join(", ")} credentials`
+        : isTestConfig
+            ? (analysis.hasActualValues
+                ? "Found values from main config. You can reuse or update them for testing."
+                : "Test configuration values needed")
+            : (analysis.hasActualValues
+                ? "Update configuration values"
+                : "Configuration values needed");
 
     // Request configuration values from user via ApprovalManager
     // This returns ACTUAL values (not exposed to agent)
@@ -469,7 +702,8 @@ async function handleCollectMode(
         existingValues,
         eventHandler,
         isTestConfig,
-        userMessage
+        userMessage,
+        managedConnections
     );
 
     if (!userResponse.provided) {

--- a/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/ApprovalManager.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Task, MACHINE_VIEW, ClarifyQuestion } from "@wso2/ballerina-core/lib/state-machine-types";
+import { Task, MACHINE_VIEW, ClarifyQuestion, ManagedConnectionGroup } from "@wso2/ballerina-core/lib/state-machine-types";
 import { SkillEnableStage } from "@wso2/ballerina-core";
 import { CopilotEventHandler } from "../utils/events";
 import { ConfigVariable } from "../../../utils/toml-utils";
@@ -365,9 +365,10 @@ export class ApprovalManager {
         existingValues: Record<string, string>,
         eventHandler: CopilotEventHandler,
         isTestConfig?: boolean,
-        message?: string
+        message?: string,
+        managedConnections?: ManagedConnectionGroup[]
     ): Promise<ConfigurationResponse> {
-        console.log(`[ApprovalManager] Requesting ${isTestConfig ? 'test ' : ''}configuration: ${requestId}`);
+        console.log(`[ApprovalManager] Requesting ${isTestConfig ? 'test ' : ''}configuration: ${requestId}${managedConnections?.length ? ` (OAuth vendors: ${managedConnections.map(g => g.vendor).join(', ')})` : ''}`);
 
         // Use provided message or generate default
         const displayMessage = message || `Please provide ${variables.length} configuration value(s)`;
@@ -399,6 +400,7 @@ export class ApprovalManager {
                         existingValues,
                         message: displayMessage,
                         isTestConfig,
+                        managedConnections,
                     },
                 },
             }

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -78,6 +78,9 @@ import {
     promptForLogin,
     promptGithubAuthorize,
     provideConfiguration,
+    createManagedConnection,
+    cancelManagedConnection,
+    CreateManagedConnectionRequest,
     provideConnectorSpec,
     RequirementSpecification,
     restoreCheckpoint,
@@ -197,6 +200,8 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(cancelConnectorSpec, (args: ConnectorSpecCancelRequest) => rpcManger.cancelConnectorSpec(args));
     messenger.onRequest(provideConfiguration, (args: ConfigurationProvideRequest) => rpcManger.provideConfiguration(args));
     messenger.onRequest(cancelConfiguration, (args: ConfigurationCancelRequest) => rpcManger.cancelConfiguration(args));
+    messenger.onRequest(createManagedConnection, (args: CreateManagedConnectionRequest) => rpcManger.createManagedConnection(args));
+    messenger.onNotification(cancelManagedConnection, () => rpcManger.cancelManagedConnection());
     messenger.onRequest(getChatMessages, () => rpcManger.getChatMessages());
     messenger.onRequest(getCheckpoints, () => rpcManger.getCheckpoints());
     messenger.onRequest(restoreCheckpoint, (args: RestoreCheckpointRequest) => rpcManger.restoreCheckpoint(args));

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -84,6 +84,8 @@ import {
     SwitchThreadRequest,
     DeleteThreadRequest,
     HasPendingReviewRequest,
+    CreateManagedConnectionRequest,
+    CreateManagedConnectionResponse,
     // TODO(auto-memory): temporarily disabled for this release.
     // ClearMemoryRequest,
     // OpenMemoryRequest,
@@ -127,6 +129,8 @@ import { enhancePrompt as enhancePromptService } from "../../features/ai/service
 import { StateMachine, updateView } from "../../stateMachine";
 import { isInDevant, isInWI } from "../../utils";
 import { getLoginMethod, isPlatformExtensionAvailable, loginGithubCopilot } from "../../utils/ai/auth";
+import { cancelConnectionCallback, createConnectionState, waitForConnectionCallback } from "../../utils/uri-handlers";
+import { exchangeManagedConnection, initiateManagedConnection } from "../platform-ext/managed-connections";
 import { normalizeCodeContext } from "../../views/ai-panel/codeContextUtils";
 import { resolveActiveFilePath } from "../../views/ai-panel/activeFileContext";
 import { refreshDataMapper } from "../data-mapper/utils";
@@ -181,6 +185,8 @@ function validateMcpServerConfig(cfg: any): string | null {
 function getActiveThreadId(projectRootPath?: string): string {
     return chatStateStorage.getActiveThreadId(projectRootPath ?? resolveProjectRootPath());
 }
+
+const OAUTH_CALLBACK_TIMEOUT_MS = 3 * 60 * 1_000;
 
 export class AiPanelRpcManager implements AIPanelAPI {
 
@@ -617,6 +623,132 @@ User reverted the last made changes. The files have been restored to the state b
 
     async cancelConfiguration(params: { requestId: string; comment?: string }): Promise<void> {
         approvalManager.resolveConfiguration(params.requestId, false, undefined, params.comment);
+    }
+
+    async createManagedConnection(params: CreateManagedConnectionRequest): Promise<CreateManagedConnectionResponse> {
+        console.log(`[ManagedConnection] start — vendor='${params.vendor}'`);
+
+        // Unreachable in practice — no managed group means no button — but guard anyway.
+        if (!extension.ballerinaExtInstance.enabledExperimentalFeatures()) {
+            console.log("[ManagedConnection] experimental features are off — managed connections are unavailable. Aborting.");
+            return { success: false, error: "Managed connections are an experimental feature." };
+        }
+
+        try {
+            // 1. Ask the service which URL to open. `params.vendor` is already the backend
+            //    provider key, resolved from the managed registry.
+            //
+            // The redirect URI carries a per-flow nonce (see uri-handlers). NOTE: this makes it
+            // carry a query string, so the service's allow-listed redirect check must tolerate
+            // the extra `state` param and append its own id with '&'.
+            const connectionState = createConnectionState();
+            const redirectUri = `${vscode.env.uriScheme}://wso2.ballerina/oauth-callback?state=${connectionState}`;
+            console.log(`[ManagedConnection] step 1 — initiate: provider='${params.vendor}', redirectUri='${redirectUri}'`);
+            const initiate = await initiateManagedConnection({ provider: params.vendor, redirectUri });
+            console.log(`[ManagedConnection] step 1 done — next='${initiate?.next}'`);
+
+            // `next` decides which URL to open. "select" means the org already has a connection
+            // for this provider, so the service offers the selection page to reuse it rather than
+            // authorizing a duplicate; that page delivers a connection id to the same redirect,
+            // so from here both branches are identical.
+            const nextUrl = initiate?.next === "select" ? initiate.selectionUrl : initiate?.authorizeUrl;
+            if (!nextUrl) {
+                console.log(`[ManagedConnection] initiate returned next='${initiate?.next}' with no matching URL. Aborting.`);
+                return { success: false, error: `Could not start a managed connection for '${params.vendor}'.` };
+            }
+
+            // 2. Open the browser and wait for the redirect callback carrying the connection id.
+            //    The service 302s back to redirectUri with the id appended.
+            //
+            //    The waiter is registered before the browser opens: a callback that arrives with
+            //    no flow pending is dropped, and the service can redirect straight back.
+            console.log(`[ManagedConnection] step 2 — opening ${initiate.next === "select" ? "connection selection" : "vendor consent"} and waiting for oauth-callback...`);
+            const callback = waitForConnectionCallback(connectionState, OAUTH_CALLBACK_TIMEOUT_MS);
+            let browserOpened = false;
+            try {
+                browserOpened = await vscode.env.openExternal(vscode.Uri.parse(nextUrl));
+            } catch (err) {
+                console.error("[ManagedConnection] step 2 — openExternal threw:", (err as Error)?.message ?? err);
+            }
+            if (!browserOpened) {
+                // Release the waiter, otherwise the user sits out the full timeout and is told the
+                // OAuth flow timed out when it never started.
+                cancelConnectionCallback();
+                return { success: false, error: "Could not open a browser to complete the connection." };
+            }
+
+            const connectionId = await callback;
+            if (!connectionId) {
+                console.log(`[ManagedConnection] step 2 — callback NOT received within ${OAUTH_CALLBACK_TIMEOUT_MS}ms. Aborting.`);
+                return { success: false, error: "Timed out waiting for OAuth flow to complete. Please try again." };
+            }
+            console.log(`[ManagedConnection] step 2 done — received connectionId='${connectionId}'.`);
+
+            // 3. Exchange the connection id for the credentials.
+            console.log("[ManagedConnection] step 3 — exchange...");
+            const credentials = await exchangeManagedConnection(connectionId);
+            console.log(`[ManagedConnection] step 3 done — kind='${credentials?.kind}'.`);
+
+            // Never write bot-token creds into a refresh config (or vice-versa) if the group was
+            // mislabeled upstream.
+            const expectedKind = params.authType === "staticToken" ? "bearer"
+                : params.authType === "oauth2RefreshToken" ? "oauth2_refresh"
+                    : undefined;
+            if (expectedKind && credentials.kind !== expectedKind) {
+                console.log(`[ManagedConnection] kind mismatch — expected '${expectedKind}', got '${credentials.kind}'. Aborting.`);
+                return { success: false, error: `Expected ${expectedKind} credentials but the service returned '${credentials.kind}'.` };
+            }
+
+            if (credentials.kind === "oauth2_refresh") {
+                if (!credentials.clientId || !credentials.clientSecret || !credentials.refreshToken || !credentials.tokenEndpoint) {
+                    console.log("[ManagedConnection] incomplete refresh credentials in exchange response. Aborting.");
+                    return { success: false, error: "Managed token service returned incomplete OAuth credentials." };
+                }
+                console.log("[ManagedConnection] success — returning refresh credentials to the config collector.");
+                return {
+                    success: true,
+                    credentials: {
+                        clientId: credentials.clientId,
+                        clientSecret: credentials.clientSecret,
+                        refreshToken: credentials.refreshToken,
+                        // The proxy /token endpoint the connector uses to refresh — returned by
+                        // the service per connection rather than hardcoded.
+                        refreshUrl: credentials.tokenEndpoint,
+                    },
+                };
+            }
+
+            if (credentials.kind === "bearer") {
+                if (!credentials.accessToken) {
+                    console.log("[ManagedConnection] empty bearer token in exchange response. Aborting.");
+                    return { success: false, error: "Managed token service returned an empty static token." };
+                }
+                console.log("[ManagedConnection] success — returning static token to the config collector.");
+                return {
+                    success: true,
+                    credentials: {
+                        // Auto-fills the connector's single token configurable (bot/bearer/static).
+                        token: credentials.accessToken,
+                    },
+                };
+            }
+
+            console.log(`[ManagedConnection] unsupported credential kind '${credentials.kind}'. Aborting.`);
+            return { success: false, error: `Unsupported credential kind '${credentials.kind}'.` };
+        } catch (err) {
+            // managed-connections.ts has already logged the URL, HTTP status and response body — the
+            // detail the bare message drops. What surfaces here is the user-facing summary.
+            console.error("[ManagedConnection] flow failed:", (err as Error)?.message ?? err);
+            return { success: false, error: (err as Error).message };
+        }
+    }
+
+    cancelManagedConnection(): void {
+        // The user closed the consent tab (or gave up). Release the waiting
+        // createManagedConnection immediately instead of holding them for the full callback
+        // timeout; it returns a failure the webview discards as a user-initiated cancel.
+        console.log("[ManagedConnection] cancelled by user — abandoning the pending callback wait.");
+        cancelConnectionCallback();
     }
 
     async approveWebTool(params: WebToolApprovalRequest): Promise<void> {

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -129,7 +129,7 @@ import { enhancePrompt as enhancePromptService } from "../../features/ai/service
 import { StateMachine, updateView } from "../../stateMachine";
 import { isInDevant, isInWI } from "../../utils";
 import { getLoginMethod, isPlatformExtensionAvailable, loginGithubCopilot } from "../../utils/ai/auth";
-import { cancelConnectionCallback, createConnectionState, waitForConnectionCallback } from "../../utils/uri-handlers";
+import { cancelConnectionCallback, ConnectionSettleReason, createConnectionState, waitForConnectionCallback } from "../../utils/uri-handlers";
 import { exchangeManagedConnection, initiateManagedConnection } from "../platform-ext/managed-connections";
 import { normalizeCodeContext } from "../../views/ai-panel/codeContextUtils";
 import { resolveActiveFilePath } from "../../views/ai-panel/activeFileContext";
@@ -187,6 +187,16 @@ function getActiveThreadId(projectRootPath?: string): string {
 }
 
 const OAUTH_CALLBACK_TIMEOUT_MS = 3 * 60 * 1_000;
+
+// Shown when a flow ends without a connection id. "cancelled" and "superseded" are dropped by the
+// webview's run-id guard, so those only reach the log.
+const CONNECTION_FAILURE_MESSAGE: Record<ConnectionSettleReason, string> = {
+    callback: "Managed connection failed.",
+    timeout: "Timed out waiting for the connection to be authorized. Please try again.",
+    denied: "The connection was not authorized. Please try again and approve access.",
+    cancelled: "Connection cancelled.",
+    superseded: "Connection cancelled — a newer connection attempt was started.",
+};
 
 export class AiPanelRpcManager implements AIPanelAPI {
 
@@ -677,10 +687,10 @@ User reverted the last made changes. The files have been restored to the state b
                 return { success: false, error: "Could not open a browser to complete the connection." };
             }
 
-            const connectionId = await callback;
+            const { connectionId, reason } = await callback;
             if (!connectionId) {
-                console.log(`[ManagedConnection] step 2 — callback NOT received within ${OAUTH_CALLBACK_TIMEOUT_MS}ms. Aborting.`);
-                return { success: false, error: "Timed out waiting for OAuth flow to complete. Please try again." };
+                console.log(`[ManagedConnection] step 2 — no connection id (reason='${reason}'). Aborting.`);
+                return { success: false, error: CONNECTION_FAILURE_MESSAGE[reason] };
             }
             console.log(`[ManagedConnection] step 2 done — received connectionId='${connectionId}'.`);
 
@@ -691,10 +701,8 @@ User reverted the last made changes. The files have been restored to the state b
 
             // Never write bot-token creds into a refresh config (or vice-versa) if the group was
             // mislabeled upstream.
-            const expectedKind = params.authType === "staticToken" ? "bearer"
-                : params.authType === "oauth2RefreshToken" ? "oauth2_refresh"
-                    : undefined;
-            if (expectedKind && credentials.kind !== expectedKind) {
+            const expectedKind = params.authType === "staticToken" ? "bearer" : "oauth2_refresh";
+            if (credentials.kind !== expectedKind) {
                 console.log(`[ManagedConnection] kind mismatch — expected '${expectedKind}', got '${credentials.kind}'. Aborting.`);
                 return { success: false, error: `Expected ${expectedKind} credentials but the service returned '${credentials.kind}'.` };
             }
@@ -738,8 +746,9 @@ User reverted the last made changes. The files have been restored to the state b
         } catch (err) {
             // managed-connections.ts has already logged the URL, HTTP status and response body — the
             // detail the bare message drops. What surfaces here is the user-facing summary.
-            console.error("[ManagedConnection] flow failed:", (err as Error)?.message ?? err);
-            return { success: false, error: (err as Error).message };
+            const message = (err as Error)?.message ?? String(err);
+            console.error("[ManagedConnection] flow failed:", message);
+            return { success: false, error: message || "Failed to create a managed connection." };
         }
     }
 

--- a/packages/ballerina-extension/src/rpc-managers/platform-ext/managed-connections.ts
+++ b/packages/ballerina-extension/src/rpc-managers/platform-ext/managed-connections.ts
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The only place that talks to the managed-token-service.
+//
+// Every other Choreo control-plane call goes through the choreo-cli binary
+// (IWso2PlatformExtensionAPI → choreo-rpc → CLI → HTTPS), which owns endpoint tables, the token
+// store and retry. This service is too new to be wrapped there, so we call it directly with the
+// token the CLI hands out (`auth/getStsToken` — the same one it puts in its own Authorization
+// header). Host table, headers and retry below are transcribed from that reference client;
+// once the service is wrapped, these three functions become platformExt delegations.
+//
+// Reference (wso2-enterprise/choreo-cli @ main): pkg/api/http-client.go,
+// internal/auth/auth.go:138, internal/region/{us,eu}_config.go
+
+import axios, { AxiosRequestConfig } from "axios";
+import { getPlatformExtensionAPI } from "../../utils/ai/auth";
+
+// Copy of the `apiHost` argument to BuildChoreoEnvConfig in internal/region/{us,eu}_config.go.
+// Region and env are separate hostnames, so the host must be resolved before any request —
+// no gateway routes by identity. Treat the Go files as the source of truth.
+const CHOREO_API_HOST: Record<"US" | "EU", Record<string, string>> = {
+    US: {
+        prod: "https://apis.choreo.dev",
+        stage: "https://apis.st.choreo.dev",
+        dev: "https://apis.preview-dv.choreo.dev",
+    },
+    EU: {
+        prod: "https://apis.eu.choreo.dev",
+        stage: "https://apis.st.eu.choreo.dev",
+        dev: "https://apis.dv.eu.choreo.dev",
+    },
+};
+
+// Paths from the service's openapi.yaml. If it ends up fronted by the Choreo gateway under a
+// `/<service>/<version>` prefix like its neighbours, prepend that here.
+const MANAGED_SERVICE_BASE_PATH = "/api/v1";
+const MANAGED_LIBRARIES_PATH = "/managed-libraries";
+const MANAGED_CONNECTIONS_PATH = "/managed-connections";
+
+async function resolveHost(): Promise<string | undefined> {
+    const api = await getPlatformExtensionAPI();
+    if (!api) {
+        console.warn("[managed-connections] WSO2 platform extension unavailable — cannot resolve a service host.");
+        return undefined;
+    }
+
+    const region = api.getAuthState()?.region ?? "US";
+    const env = api.getWebviewStateStore()?.choreoEnv ?? "prod";
+    const host = CHOREO_API_HOST[region]?.[env];
+    if (!host) {
+        console.warn(`[managed-connections] no known Choreo API host for region='${region}' env='${env}'.`);
+    }
+    return host;
+}
+
+const BASE_HEADERS = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/plain, */*",
+    "User-Agent": "WSO2 Integrator VSCode",
+};
+
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 3_000;
+
+// The catalog lookup gates showing the config form, so it fails fast; the connection calls are
+// user-driven and allowed longer.
+const CATALOG_TIMEOUT_MS = 15_000;
+const CONNECTION_TIMEOUT_MS = 60_000;
+
+class ManagedConnectionError extends Error {
+    constructor(message: string, readonly status?: number) {
+        super(message);
+        this.name = "ManagedConnectionError";
+    }
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * One authenticated call. The token is read per attempt, never held by the caller: the OAuth
+ * flow spans a browser round-trip that can outlive a token, and getStsToken() refreshes on read.
+ *
+ * Retries are GET-only — a POST that timed out may already have created a connection upstream.
+ */
+async function request<T>(
+    method: "GET" | "POST",
+    path: string,
+    timeoutMs: number,
+    body?: unknown
+): Promise<T> {
+    const host = await resolveHost();
+    if (!host) {
+        throw new ManagedConnectionError("Managed connections are not available in this environment.");
+    }
+
+    const url = `${host}${MANAGED_SERVICE_BASE_PATH}${path}`;
+    const isIdempotent = method === "GET";
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= (isIdempotent ? MAX_ATTEMPTS : 1); attempt++) {
+        const token = await getStsTokenOrThrow();
+        const config: AxiosRequestConfig = {
+            headers: { ...BASE_HEADERS, Authorization: `Bearer ${token}` },
+            timeout: timeoutMs,
+        };
+
+        try {
+            const response = method === "GET"
+                ? await axios.get<T>(url, config)
+                : await axios.post<T>(url, body ?? {}, config);
+            return response.data;
+        } catch (err) {
+            lastError = err;
+            const status = (err as any)?.response?.status as number | undefined;
+
+            if (isIdempotent && attempt < MAX_ATTEMPTS && status && RETRYABLE_STATUS.has(status)) {
+                console.warn(`[managed-connections] ${method} ${url} → ${status}; retrying (${attempt}/${MAX_ATTEMPTS - 1}).`);
+                await delay(RETRY_DELAY_MS);
+                continue;
+            }
+            break;
+        }
+    }
+
+    throw toManagedConnectionError(lastError, method, url);
+}
+
+async function getStsTokenOrThrow(): Promise<string> {
+    const api = await getPlatformExtensionAPI();
+    if (!api) {
+        throw new ManagedConnectionError("WSO2 platform extension is not installed.");
+    }
+    const token = await api.getStsToken();
+    if (!token) {
+        throw new ManagedConnectionError("Not signed in to Devant. Please sign in to use managed connections.");
+    }
+    return token;
+}
+
+// Logs the status and body, which the bare axios message drops and which identify the failure.
+function toManagedConnectionError(err: unknown, method: string, url: string): ManagedConnectionError {
+    if (err instanceof ManagedConnectionError) {
+        return err;
+    }
+    const ax = err as any;
+    if (ax?.isAxiosError) {
+        const status = ax.response?.status as number | undefined;
+        const bodyText = ax.response?.data ? safeStringify(ax.response.data) : "none";
+        console.error(
+            `[managed-connections] ${method} ${url} FAILED — message='${ax.message}', code='${ax.code}', ` +
+            `httpStatus=${status ?? "none"}, responseBody=${bodyText}`
+        );
+        return new ManagedConnectionError(
+            status ? `Managed connection request failed with status ${status}.` : ax.message,
+            status
+        );
+    }
+    console.error(`[managed-connections] ${method} ${url} failed with a non-HTTP error: ${err}`);
+    return new ManagedConnectionError((err as Error)?.message ?? "Managed connection request failed.");
+}
+
+function safeStringify(value: unknown): string {
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}
+
+export type ManagedGrant = "oauth2RefreshToken" | "staticToken";
+
+export interface ManagedAuthOption {
+    grant: ManagedGrant;
+    provider: string;
+    beta?: boolean;
+}
+
+export interface ManagedLibraryEntry {
+    library: string;
+    authOptions: ManagedAuthOption[];
+}
+
+export interface ManagedLibrariesResponse {
+    libraries: ManagedLibraryEntry[];
+}
+
+export interface InitiateManagedConnectionResponse {
+    // Which URL was returned: "authorize" → vendor consent, "select" → the org already has a
+    // connection for this provider and may reuse it.
+    next: "authorize" | "select";
+    authorizeUrl?: string;
+    selectionUrl?: string;
+}
+
+export interface ManagedConnectionCredentials {
+    kind: string;
+    clientId?: string;
+    clientSecret?: string;
+    refreshToken?: string;
+    tokenEndpoint?: string;
+    accessToken?: string;
+}
+
+export async function getManagedLibraries(): Promise<ManagedLibrariesResponse> {
+    return request<ManagedLibrariesResponse>("GET", MANAGED_LIBRARIES_PATH, CATALOG_TIMEOUT_MS);
+}
+
+/**
+ * `skipSelection` is deliberately not sent — it forces a fresh connect, so an org that already
+ * has a connection for this provider would authorize a duplicate instead of reusing it.
+ * `critical: false` is required: exchange is non-critical-only by design.
+ */
+export async function initiateManagedConnection(params: {
+    provider: string;
+    redirectUri: string;
+}): Promise<InitiateManagedConnectionResponse> {
+    return request<InitiateManagedConnectionResponse>(
+        "POST",
+        `${MANAGED_CONNECTIONS_PATH}/initiate`,
+        CONNECTION_TIMEOUT_MS,
+        { provider: params.provider, critical: false, redirectUri: params.redirectUri }
+    );
+}
+
+export async function exchangeManagedConnection(
+    connectionId: string
+): Promise<ManagedConnectionCredentials> {
+    return request<ManagedConnectionCredentials>(
+        "POST",
+        `${MANAGED_CONNECTIONS_PATH}/${encodeURIComponent(connectionId)}/exchange`,
+        CONNECTION_TIMEOUT_MS,
+        { critical: false }
+    );
+}

--- a/packages/ballerina-extension/src/rpc-managers/platform-ext/managed-connections.ts
+++ b/packages/ballerina-extension/src/rpc-managers/platform-ext/managed-connections.ts
@@ -22,30 +22,21 @@
 // (IWso2PlatformExtensionAPI → choreo-rpc → CLI → HTTPS), which owns endpoint tables, the token
 // store and retry. This service is too new to be wrapped there, so we call it directly with the
 // token the CLI hands out (`auth/getStsToken` — the same one it puts in its own Authorization
-// header). Host table, headers and retry below are transcribed from that reference client;
-// once the service is wrapped, these three functions become platformExt delegations.
-//
-// Reference (wso2-enterprise/choreo-cli @ main): pkg/api/http-client.go,
-// internal/auth/auth.go:138, internal/region/{us,eu}_config.go
+// header). Once the service is wrapped, these three functions become platformExt delegations and
+// the host resolution below goes away with them.
 
 import axios, { AxiosRequestConfig } from "axios";
 import { getPlatformExtensionAPI } from "../../utils/ai/auth";
 
-// Copy of the `apiHost` argument to BuildChoreoEnvConfig in internal/region/{us,eu}_config.go.
-// Region and env are separate hostnames, so the host must be resolved before any request —
-// no gateway routes by identity. Treat the Go files as the source of truth.
-const CHOREO_API_HOST: Record<"US" | "EU", Record<string, string>> = {
-    US: {
-        prod: "https://apis.choreo.dev",
-        stage: "https://apis.st.choreo.dev",
-        dev: "https://apis.preview-dv.choreo.dev",
-    },
-    EU: {
-        prod: "https://apis.eu.choreo.dev",
-        stage: "https://apis.st.eu.choreo.dev",
-        dev: "https://apis.dv.eu.choreo.dev",
-    },
+// Production endpoints only. Each region is a separate hostname — no gateway routes by identity —
+// so the host is resolved per request.
+const CHOREO_PROD_API_HOST: Record<"US" | "EU", string> = {
+    US: "https://apis.choreo.dev",
+    EU: "https://apis.eu.choreo.dev",
 };
+
+// Non-production hosts are not listed here; set this to target one.
+const API_HOST_OVERRIDE_VAR = "VSCODE_CHOREO_API_HOST";
 
 // Paths from the service's openapi.yaml. If it ends up fronted by the Choreo gateway under a
 // `/<service>/<version>` prefix like its neighbours, prepend that here.
@@ -54,19 +45,25 @@ const MANAGED_LIBRARIES_PATH = "/managed-libraries";
 const MANAGED_CONNECTIONS_PATH = "/managed-connections";
 
 async function resolveHost(): Promise<string | undefined> {
+    const override = process.env[API_HOST_OVERRIDE_VAR]?.trim();
+    if (override) {
+        console.log(`[managed-connections] using ${API_HOST_OVERRIDE_VAR}='${override}'.`);
+        return override;
+    }
+
     const api = await getPlatformExtensionAPI();
     if (!api) {
         console.warn("[managed-connections] WSO2 platform extension unavailable — cannot resolve a service host.");
         return undefined;
     }
 
-    const region = api.getAuthState()?.region ?? "US";
+    const region = api.getAuthState()?.region === "EU" ? "EU" : "US";
     const env = api.getWebviewStateStore()?.choreoEnv ?? "prod";
-    const host = CHOREO_API_HOST[region]?.[env];
-    if (!host) {
-        console.warn(`[managed-connections] no known Choreo API host for region='${region}' env='${env}'.`);
+    if (env !== "prod") {
+        console.warn(`[managed-connections] no host is listed for env='${env}' — set ${API_HOST_OVERRIDE_VAR} ` +
+            `to target it. Falling back to ${region} production.`);
     }
-    return host;
+    return CHOREO_PROD_API_HOST[region];
 }
 
 const BASE_HEADERS = {

--- a/packages/ballerina-extension/src/utils/uri-handlers.ts
+++ b/packages/ballerina-extension/src/utils/uri-handlers.ts
@@ -23,12 +23,25 @@ import { handleOpenFile, handleOpenRepo } from ".";
 import { CMP_OPEN_VSCODE_URL, TM_EVENT_OPEN_FILE_URL_START, TM_EVENT_OPEN_REPO_URL_START, sendTelemetryEvent } from "../features/telemetry";
 import { IOpenCompSrcCmdParams, WICommandIds } from "@wso2/wso2-platform-core";
 
+// Why a flow ended — a denied consent and a silent timeout are both "no connection id".
+export type ConnectionSettleReason =
+    | "callback"    // redirected back with an id; the only success
+    | "timeout"
+    | "cancelled"   // user hit Cancel on the connection card
+    | "denied"      // redirected back without an id
+    | "superseded"; // a newer flow took the single pending slot
+
+export interface ConnectionCallbackResult {
+    connectionId: string | null; // non-null only when reason is "callback"
+    reason: ConnectionSettleReason;
+}
+
 // Bridges the managed-connection browser round-trip back to the awaiting extension code:
 // createManagedConnection awaits waitForConnectionCallback, and the redirect lands on the
 // '/oauth-callback' route below.
 interface PendingConnectionFlow {
     state: string;
-    settle: (connectionId: string | null) => void;
+    settle: (connectionId: string | null, reason: ConnectionSettleReason) => void;
 }
 
 let pendingConnectionFlow: PendingConnectionFlow | null = null;
@@ -42,30 +55,30 @@ export function createConnectionState(): string {
 
 /** Releases a waiting caller immediately; any connection already created is left unused. */
 export function cancelConnectionCallback(): void {
-    pendingConnectionFlow?.settle(null);
+    pendingConnectionFlow?.settle(null, "cancelled");
 }
 
-export function waitForConnectionCallback(state: string, timeoutMs: number): Promise<string | null> {
+export function waitForConnectionCallback(state: string, timeoutMs: number): Promise<ConnectionCallbackResult> {
     return new Promise((resolve) => {
         let timer: NodeJS.Timeout;
         const flow: PendingConnectionFlow = {
             state,
-            settle: (connectionId) => {
+            settle: (connectionId, reason) => {
                 clearTimeout(timer);
                 // Only release the slot if this flow still owns it, so a late timer cannot
                 // cancel a newer flow.
                 if (pendingConnectionFlow === flow) {
                     pendingConnectionFlow = null;
                 }
-                resolve(connectionId);
+                resolve({ connectionId, reason });
             },
         };
 
         // Settle any superseded flow rather than orphaning it — its slot is gone, so nothing
         // could ever resolve it.
-        pendingConnectionFlow?.settle(null);
+        pendingConnectionFlow?.settle(null, "superseded");
 
-        timer = setTimeout(() => flow.settle(null), timeoutMs);
+        timer = setTimeout(() => flow.settle(null, "timeout"), timeoutMs);
         pendingConnectionFlow = flow;
     });
 }
@@ -115,10 +128,10 @@ export function activateUriHandlers(ballerinaExtInstance: BallerinaExtension) {
                         // Right flow, no id — e.g. consent denied. Fail now rather than making
                         // the caller sit out the full timeout.
                         console.warn("[ManagedConnection] callback carried no connection_id — treating as a failed flow.");
-                        pendingConnectionFlow.settle(null);
+                        pendingConnectionFlow.settle(null, "denied");
                         break;
                     }
-                    pendingConnectionFlow.settle(connectionId);
+                    pendingConnectionFlow.settle(connectionId, "callback");
                     break;
                 }
                 case '/open':

--- a/packages/ballerina-extension/src/utils/uri-handlers.ts
+++ b/packages/ballerina-extension/src/utils/uri-handlers.ts
@@ -15,12 +15,60 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import * as crypto from "crypto";
 import { URLSearchParams } from "url";
 import { window, Uri, ProviderResult, commands } from "vscode";
 import { BallerinaExtension } from "../core";
 import { handleOpenFile, handleOpenRepo } from ".";
 import { CMP_OPEN_VSCODE_URL, TM_EVENT_OPEN_FILE_URL_START, TM_EVENT_OPEN_REPO_URL_START, sendTelemetryEvent } from "../features/telemetry";
 import { IOpenCompSrcCmdParams, WICommandIds } from "@wso2/wso2-platform-core";
+
+// Bridges the managed-connection browser round-trip back to the awaiting extension code:
+// createManagedConnection awaits waitForConnectionCallback, and the redirect lands on the
+// '/oauth-callback' route below.
+interface PendingConnectionFlow {
+    state: string;
+    settle: (connectionId: string | null) => void;
+}
+
+let pendingConnectionFlow: PendingConnectionFlow | null = null;
+
+// Per-flow nonce, carried on the redirect URI and matched on return. The '/oauth-callback'
+// route is invocable by any local process, so without it a foreign or stale callback is
+// consumed by whichever flow happens to be pending.
+export function createConnectionState(): string {
+    return crypto.randomBytes(16).toString("hex");
+}
+
+/** Releases a waiting caller immediately; any connection already created is left unused. */
+export function cancelConnectionCallback(): void {
+    pendingConnectionFlow?.settle(null);
+}
+
+export function waitForConnectionCallback(state: string, timeoutMs: number): Promise<string | null> {
+    return new Promise((resolve) => {
+        let timer: NodeJS.Timeout;
+        const flow: PendingConnectionFlow = {
+            state,
+            settle: (connectionId) => {
+                clearTimeout(timer);
+                // Only release the slot if this flow still owns it, so a late timer cannot
+                // cancel a newer flow.
+                if (pendingConnectionFlow === flow) {
+                    pendingConnectionFlow = null;
+                }
+                resolve(connectionId);
+            },
+        };
+
+        // Settle any superseded flow rather than orphaning it — its slot is gone, so nothing
+        // could ever resolve it.
+        pendingConnectionFlow?.settle(null);
+
+        timer = setTimeout(() => flow.settle(null), timeoutMs);
+        pendingConnectionFlow = flow;
+    });
+}
 
 export function activateUriHandlers(ballerinaExtInstance: BallerinaExtension) {
     window.registerUriHandler({
@@ -53,6 +101,26 @@ export function activateUriHandlers(ballerinaExtInstance: BallerinaExtension) {
                     // Authentication is now handled via Devant platform extension
                     console.log("Legacy /signin route called - authentication now uses Devant platform extension");
                     break;
+                case '/oauth-callback': {
+                    const connectionId = urlParams.get('connection_id');
+                    if (!pendingConnectionFlow) {
+                        console.warn("[ManagedConnection] callback received with no flow pending — ignoring.");
+                        break;
+                    }
+                    if (urlParams.get('state') !== pendingConnectionFlow.state) {
+                        console.warn("[ManagedConnection] callback state does not match the pending flow — ignoring.");
+                        break;
+                    }
+                    if (!connectionId) {
+                        // Right flow, no id — e.g. consent denied. Fail now rather than making
+                        // the caller sit out the full timeout.
+                        console.warn("[ManagedConnection] callback carried no connection_id — treating as a failed flow.");
+                        pendingConnectionFlow.settle(null);
+                        break;
+                    }
+                    pendingConnectionFlow.settle(connectionId);
+                    break;
+                }
                 case '/open':
                     const org = urlParams.get("org");
                     const project = urlParams.get("project");

--- a/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -105,6 +105,10 @@ import {
     promptForLogin,
     promptGithubAuthorize,
     provideConfiguration,
+    createManagedConnection,
+    cancelManagedConnection,
+    CreateManagedConnectionRequest,
+    CreateManagedConnectionResponse,
     provideConnectorSpec,
     restoreCheckpoint,
     showSignInAlert,
@@ -331,6 +335,14 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     cancelConfiguration(params: ConfigurationCancelRequest): Promise<void> {
         return this._messenger.sendRequest(cancelConfiguration, HOST_EXTENSION, params);
+    }
+
+    createManagedConnection(params: CreateManagedConnectionRequest): Promise<CreateManagedConnectionResponse> {
+        return this._messenger.sendRequest(createManagedConnection, HOST_EXTENSION, params);
+    }
+
+    cancelManagedConnection(): void {
+        return this._messenger.sendNotification(cancelManagedConnection, HOST_EXTENSION);
     }
 
     getChatMessages(): Promise<UIChatMessage[]> {

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import styled from "@emotion/styled";
 import { Button, Codicon, ThemeColors } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
-import { ConfigurationCollectorMetadata, ParentPopupData } from "@wso2/ballerina-core";
+import { ConfigurationCollectorMetadata, ManagedConnectionGroup, ParentPopupData } from "@wso2/ballerina-core";
 import {
     PopupOverlay,
     PopupContainer,
@@ -176,6 +176,67 @@ const FooterHint = styled.span`
 
 const ActionButton = styled(Button)``;
 
+// One managed group per card: the Connect action, then the configurables it fills.
+const GroupCard = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px;
+    border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    border-radius: 8px;
+`;
+
+const ManagedAction = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 4px 0;
+`;
+
+// Holds the glyph outside the Button's slot — a Codicon there renders in a 14px box around a
+// 16px glyph and overlaps the label.
+const ManagedNote = styled.div<{ connected: boolean }>`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    text-align: center;
+    color: ${(props: { connected: boolean }) =>
+        props.connected ? ThemeColors.PRIMARY : ThemeColors.ON_SURFACE_VARIANT};
+`;
+
+const ConnectionErrorText = styled.div`
+    font-size: 12px;
+    color: ${ThemeColors.ERROR};
+    text-align: center;
+`;
+
+const Divider = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    font-size: 12px;
+
+    &::before,
+    &::after {
+        content: "";
+        flex: 1;
+        border-bottom: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    }
+`;
+
+const GroupFields = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+`;
+
 const LoadingContainer = styled.div`
     display: flex;
     align-items: center;
@@ -250,6 +311,16 @@ function getFieldConfig(type: string | undefined): FieldConfig {
 
 function isPlaceholderValue(value: string | undefined | null): boolean {
     return typeof value === "string" && /^\$\{[^}]+\}$/.test(value);
+}
+
+// Providers arrive as catalog slugs ("google-sheets"). Done in JS, not `text-transform`, because
+// the label sits in a web-component slot and capitalize would mangle "GitHub".
+function formatVendor(vendor: string): string {
+    return vendor
+        .split(/[-_.\s]+/)
+        .filter(Boolean)
+        .map((word) => (word === word.toLowerCase() ? word.charAt(0).toUpperCase() + word.slice(1) : word))
+        .join(" ");
 }
 
 function getEmptyFieldNames(
@@ -368,6 +439,11 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
     const [mode, setMode] = useState<CollectorMode>("editing");
     const [visibleFields, setVisibleFields] = useState<Record<string, boolean>>({});
     const [submitError, setSubmitError] = useState<string | null>(null);
+    // Every write replaces the whole entry, so loading/connected/error never disagree.
+    const [connectionState, setConnectionState] = useState<Record<string, { loading: boolean; connected?: boolean; error?: string }>>({});
+    // Bumped by cancel or a new attempt, so an in-flight attempt can tell its result is no longer
+    // wanted — a cancelled attempt still resolves, as a failure the user didn't cause.
+    const connectionRunId = useRef(0);
 
     useEffect(() => {
         setConfigValues(buildInitialValues(data));
@@ -375,7 +451,77 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
         setErrors({});
         setMode("editing");
         setSubmitError(null);
+        setConnectionState({});
     }, [data]);
+
+    // Takes the group, not a key: `vendor` is not unique across groups, so looking up by vendor
+    // would fill the wrong client's fields. All per-group state is keyed by `group.id`.
+    const handleConnect = useCallback(async (group: ManagedConnectionGroup) => {
+        const runId = ++connectionRunId.current;
+        setConnectionState((prev) => ({ ...prev, [group.id]: { loading: true } }));
+
+        try {
+            const response = await rpcClient.getAiPanelRpcClient().createManagedConnection({
+                vendor: group.vendor,
+                authType: group.authType,
+            });
+
+            // Superseded by a cancel or a newer attempt — drop this result entirely rather
+            // than filling fields or reporting a failure the user already walked away from.
+            if (connectionRunId.current !== runId) { return; }
+
+            if (response.success && response.credentials) {
+                // Functional update: the consent round-trip takes minutes, so a snapshot from
+                // click time would silently revert any edits made meanwhile.
+                setConfigValues((prev) => {
+                    const next = { ...prev };
+                    for (const variable of group.variables) {
+                        const value = response.credentials[variable.credentialField];
+                        if (value) {
+                            next[variable.name] = value;
+                        }
+                    }
+                    // The proxy /token endpoint, returned per connection. Refresh grant only.
+                    if (group.refreshUrlVar && response.credentials.refreshUrl) {
+                        next[group.refreshUrlVar] = response.credentials.refreshUrl;
+                    }
+                    return next;
+                });
+                setErrors((prev) => {
+                    const next = { ...prev };
+                    for (const variable of group.variables) {
+                        delete next[variable.name];
+                    }
+                    if (group.refreshUrlVar) {
+                        delete next[group.refreshUrlVar];
+                    }
+                    return next;
+                });
+                setMode((current) => (current === "confirming" ? "editing" : current));
+                setSubmitError(null);
+                setConnectionState((prev) => ({ ...prev, [group.id]: { loading: false, connected: true } }));
+            } else {
+                setConnectionState((prev) => ({
+                    ...prev,
+                    [group.id]: { loading: false, error: response.error || "Could not create the managed connection." },
+                }));
+            }
+        } catch (error: any) {
+            if (connectionRunId.current !== runId) { return; }
+            setConnectionState((prev) => ({
+                ...prev,
+                [group.id]: { loading: false, error: error.message || "Could not create the managed connection." },
+            }));
+        }
+    }, [rpcClient]);
+
+    // Invalidate the run id first so the abandoned attempt returns to an already-reset card
+    // instead of flashing an error.
+    const handleCancelConnect = useCallback((group: ManagedConnectionGroup) => {
+        connectionRunId.current++;
+        setConnectionState((prev) => ({ ...prev, [group.id]: { loading: false } }));
+        rpcClient.getAiPanelRpcClient().cancelManagedConnection();
+    }, [rpcClient]);
 
     const handleInputChange = (variableName: string, value: string) => {
         setConfigValues((prev) => ({ ...prev, [variableName]: value }));
@@ -506,18 +652,95 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
                 </PopupHeader>
                 <PopupContent>
                     <FormSection>
-                        {data.variables?.map((variable) => (
-                            <ConfigField
-                                key={variable.name}
-                                variable={variable}
-                                value={configValues[variable.name] ?? ""}
-                                error={errors[variable.name]}
-                                isVisible={visibleFields[variable.name] ?? false}
-                                onToggleVisibility={() => setVisibleFields((prev) => ({ ...prev, [variable.name]: !prev[variable.name] }))}
-                                onChange={handleInputChange}
-                                onKeyDown={handleKeyDown}
-                            />
-                        ))}
+                        {data.managedConnections?.map((group) => {
+                            const vendorState = connectionState[group.id] || { loading: false };
+                            const anyConnectionLoading = Object.values(connectionState).some((s) => s.loading);
+                            const groupVarNames = new Set(group.variables.map((v) => v.name));
+                            // refreshUrl is auto-filled by Connect but still user-editable, so it
+                            // belongs to the group's field list.
+                            const groupFields = (data.variables ?? []).filter(
+                                (v) => groupVarNames.has(v.name) || v.name === group.refreshUrlVar
+                            );
+                            return (
+                                <GroupCard key={group.id}>
+                                    {/* Above the fields: Connect populates them, so below it would
+                                        read as the form's submit button. */}
+                                    <ManagedAction>
+                                        {vendorState.loading ? (
+                                            <Button
+                                                appearance="secondary"
+                                                onClick={() => handleCancelConnect(group)}
+                                            >
+                                                Cancel
+                                            </Button>
+                                        ) : (
+                                            <Button
+                                                appearance="primary"
+                                                onClick={() => handleConnect(group)}
+                                                disabled={anyConnectionLoading || mode === "processing"}
+                                            >
+                                                {`Connect ${formatVendor(group.vendor)}`}
+                                            </Button>
+                                        )}
+                                        <ManagedNote connected={!!vendorState.connected}>
+                                            <Codicon name={vendorState.connected ? "check" : "plug"} />
+                                            <span>
+                                                {vendorState.loading
+                                                    ? "Complete the sign-in in your browser."
+                                                    : vendorState.connected
+                                                        ? "Connected"
+                                                        : "Creates a WSO2-managed connection."}
+                                            </span>
+                                        </ManagedNote>
+                                        {vendorState.error && (
+                                            <ConnectionErrorText>{vendorState.error}</ConnectionErrorText>
+                                        )}
+                                    </ManagedAction>
+                                    <Divider>or enter custom credentials</Divider>
+                                    <GroupFields>
+                                        {groupFields.map((variable) => (
+                                            <ConfigField
+                                                key={variable.name}
+                                                variable={variable}
+                                                value={configValues[variable.name] ?? ""}
+                                                error={errors[variable.name]}
+                                                isVisible={visibleFields[variable.name] ?? false}
+                                                onToggleVisibility={() => setVisibleFields((prev) => ({ ...prev, [variable.name]: !prev[variable.name] }))}
+                                                onChange={handleInputChange}
+                                                onKeyDown={handleKeyDown}
+                                            />
+                                        ))}
+                                    </GroupFields>
+                                </GroupCard>
+                            );
+                        })}
+                        {(() => {
+                            const managedVarNames = new Set(
+                                (data.managedConnections || []).flatMap((g) => [
+                                    ...g.variables.map((v) => v.name),
+                                    ...(g.refreshUrlVar ? [g.refreshUrlVar] : []),
+                                ])
+                            );
+                            const remainingVars = data.variables?.filter((v) => !managedVarNames.has(v.name)) || [];
+                            if (remainingVars.length === 0) return null;
+                            return (
+                                <>
+                                    {data.managedConnections?.length ? <Divider>Other Configuration</Divider> : null}
+                                    {remainingVars.map((variable) => (
+                                        <ConfigField
+                                            key={variable.name}
+                                            variable={variable}
+                                            value={configValues[variable.name] ?? ""}
+                                            error={errors[variable.name]}
+                                            isVisible={visibleFields[variable.name] ?? false}
+                                            onToggleVisibility={() => setVisibleFields((prev) => ({ ...prev, [variable.name]: !prev[variable.name] }))}
+                                            onChange={handleInputChange}
+                                            onKeyDown={handleKeyDown}
+                                        />
+                                    ))}
+                                </>
+                            );
+                        })()}
                     </FormSection>
                 </PopupContent>
                 {mode === "confirming" && emptyNames.length > 0 && (

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
@@ -444,6 +444,9 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
     // Bumped by cancel or a new attempt, so an in-flight attempt can tell its result is no longer
     // wanted — a cancelled attempt still resolves, as a failure the user didn't cause.
     const connectionRunId = useRef(0);
+    // `data` is rebuilt on every visualizer-location fetch, so only requestId tells a new request
+    // apart from a refetch of the same one.
+    const shownRequestId = useRef(data?.requestId);
 
     useEffect(() => {
         setConfigValues(buildInitialValues(data));
@@ -452,6 +455,12 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
         setMode("editing");
         setSubmitError(null);
         setConnectionState({});
+        // A new request invalidates any in-flight connect from the previous one, so its result
+        // cannot write stale credentials into this form.
+        if (data?.requestId !== shownRequestId.current) {
+            shownRequestId.current = data?.requestId;
+            connectionRunId.current++;
+        }
     }, [data]);
 
     // Takes the group, not a key: `vendor` is not unique across groups, so looking up by vendor


### PR DESCRIPTION

## Purpose
Introduces the updated config collector. when there are connectors with the support for managed connections a connect button that allows for configuring with a sign in.

The support for managed connections for connectors are check against a back end service and in case of an error or unavailability the configurable variables will fall back to usual config collector view.

https://github.com/wso2-enterprise/integration-engineering/issues/163
 
Config collector when there are managed connections:

<img width="1128" height="974" alt="Screenshot 2026-07-31 114149" src="https://github.com/user-attachments/assets/306dcbf6-6701-4ac2-b475-3b40a14efd3b" />


<img width="1121" height="975" alt="Screenshot 2026-07-31 114222" src="https://github.com/user-attachments/assets/de6f0017-31bf-4803-b45e-e090a1fef36b" />


The flow:

<img width="1920" height="1038" alt="Recording 2026-07-31 113802low2" src="https://github.com/user-attachments/assets/aafe8bb5-5acd-414d-9d44-007f8ce88673" />



## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added managed-connection support to the configuration collector for OAuth2 refresh-token and static-token authentication.
- Introduced RPC interfaces, client methods, and handlers for creating and cancelling managed connections.
- Added platform integration for discovering providers, initiating authorization, exchanging credentials, and handling regional endpoints, retries, and timeouts.
- Updated the approval flow and configuration metadata to track managed connection groups and prioritize their credentials.
- Added callback state, cancellation, timeout, and validation handling for authorization flows.
- Updated the AI panel UI with managed-connection cards, connection actions, status feedback, credential population, and validation handling.
- Extended prompts and shared types with managed connection requirements and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->