### PR TITLE
Add Ballerina Central call to Library Search Tool

### DIFF
--- a/packages/ballerina-extension/src/features/ai/agent/tools/library-search.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/tools/library-search.ts
@@ -35,7 +35,7 @@ const LibrarySearchToolSchema = jsonSchema<{
         keywords: {
             type: "array",
             items: { type: "string" },
-            description: `Array of search keywords to find relevant Ballerina libraries. Keywords are weighted by order - first keyword has highest weight, subsequent keywords have decreasing weight. Maximum ${MAX_SEARCH_KEYWORDS} keywords allowed. Examples: ["GitHub", "API", "integration"], ["Stripe", "payment", "gateway"], ["HTTP", "REST", "service"]`,
+            description: `Array of search keywords to find relevant Ballerina libraries. Keywords are combined with OR, so each additional keyword widens the search rather than narrowing it. Maximum ${MAX_SEARCH_KEYWORDS} keywords allowed. Examples: ["GitHub", "API", "integration"], ["Stripe", "payment", "gateway"], ["HTTP", "REST", "service"]`,
             minItems: 1,
             maxItems: MAX_SEARCH_KEYWORDS,
         },
@@ -132,23 +132,22 @@ export function getLibrarySearchTool(
     eventHandler: CopilotEventHandler
 ) {
     return tool({
-        description: `Searches for Ballerina libraries from Ballerina Central based on weighted keywords.
+        description: `Searches for Ballerina libraries from Ballerina Central based on keywords.
 
 **Purpose:**
-This tool discovers relevant Ballerina libraries using keyword-based search. It searches against library names, descriptions, and function names. Keywords are weighted by order - the first keyword has the highest weight, with decreasing weight for subsequent keywords.
+This tool discovers relevant Ballerina libraries using keyword-based search. It searches against library names, descriptions, package keywords, and documentation. All keywords are combined with OR and the matches are ranked by overall relevance, so each additional keyword widens the search rather than narrowing it.
 
-**Scope - ALL Ballerina Libraries:**
+**Scope:**
 - **ballerina/*** - Standard/core libraries maintained by the Ballerina team
 - **ballerinax/*** - Extended connector packages for third-party services
-- **xlibb/*** - Experimental yet practical Ballerina packages
-- Other organization packages available in Ballerina Central
 
 **Keyword Guidelines:**
-- Provide 1-${MAX_SEARCH_KEYWORDS} keywords ordered by importance
-- First keyword = most important (highest weight in search)
-- Subsequent keywords = less important (decreasing weight)
-- Use specific terms (the service or technology name) before generic ones (the capability or category)
-- Include 'trigger' keyword to indicate webhook related libraries.
+- Prefer FEWER, more distinctive keywords. 1-3 is usually best; the hard maximum is ${MAX_SEARCH_KEYWORDS}.
+- Lead with the service, product, or technology name ("Stripe", "Kafka", "Salesforce") - these are what actually identify a library.
+- Prefer single words over phrases - a multi-word keyword is split into separate words anyway
+- AVOID generic words such as "read", "write", "file", "data", "document", "message", "notification", "client", "service", "api", "integration". Because keywords are OR'd, every generic word drags in dozens of unrelated libraries that push the relevant ones out of the results.
+- Only include 'trigger' when the user wants to LISTEN for events or handle a webhook. Do NOT include it when the user wants to call an API - it matches every trigger.* package and crowds out the connector you actually need.
+- When a task spans several distinct services, run a SEPARATE search per service instead of combining every service into one keyword list.
 
 **When to use this tool:**
 - To discover which libraries are available for a specific use case or integration
@@ -157,14 +156,14 @@ This tool discovers relevant Ballerina libraries using keyword-based search. It 
 - Whenever you need to find relevant libraries but don't know the exact library names
 
 **Important - Two-Step Workflow:**
-1. First, call THIS tool (${LIBRARY_SEARCH_TOOL}) with weighted keywords to discover relevant libraries
+1. First, call THIS tool (${LIBRARY_SEARCH_TOOL}) with relevant keywords to discover relevant libraries
 2. Review the returned library names and descriptions
 3. Select the most appropriate libraries (typically 1-5 libraries)
 4. Then, call ${LIBRARY_GET_TOOL} with the selected library names to get detailed API documentation (functions, types, clients, services, etc.)
 
 **Example Workflow:**
-User query: <a request that may span one or more services, technologies, or capabilities>
-Keywords: [<service or technology name>, <another service name if the query needs more>, <supporting or capability terms>]  // lead with the distinct service names; earlier keywords carry more weight
+User query: <a request involving a service, technology, or capability>
+Keywords: [<service or technology name>, <at most one or two distinctive supporting terms>]  // one search per distinct service; skip generic words entirely
 Call ${LIBRARY_SEARCH_TOOL} with the keywords
 → Returns: [
     { name: "<organization>/<library>", description: "..." },

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/CopilotLibraryManager.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/CopilotLibraryManager.java
@@ -25,6 +25,7 @@ import com.google.gson.reflect.TypeToken;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.flowmodelgenerator.core.InstructionLoader;
+import io.ballerina.flowmodelgenerator.core.copilot.central.CentralLibrarySearchAccessor;
 import io.ballerina.flowmodelgenerator.core.copilot.database.LibraryDatabaseAccessor;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Annotation;
 import io.ballerina.flowmodelgenerator.core.copilot.model.Client;
@@ -53,6 +54,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -63,9 +66,16 @@ import java.util.stream.Collectors;
  */
 public class CopilotLibraryManager {
 
+    private static final Logger LOGGER = Logger.getLogger(CopilotLibraryManager.class.getName());
     private static final Gson GSON = new Gson();
     private static final String EXCLUSION_JSON_PATH = "/copilot/exclusion.json";
     private static final String TYPE_GENERIC = "generic";
+
+    // Maximum number of libraries a keyword search hands back, applied after exclusions.
+    private static final int MAX_SEARCH_RESULTS = 10;
+
+    // When set to "true", keyword search skips Ballerina Central and queries the bundled index only.
+    private static final String USE_LOCAL_INDEX_PROPERTY = "ballerina.copilot.librarySearch.useLocalIndex";
 
     // Libraries for which README content should be included in the filtered response.
     private static final Set<String> README_WHITELIST = Set.of(
@@ -188,26 +198,57 @@ public class CopilotLibraryManager {
     }
 
     /**
-     * Searches libraries by keywords across packages, types, connectors, and functions.
+     * Searches libraries by keywords against the Ballerina Central registry, falling back to the
+     * bundled search index when Central cannot be reached.
      *
      * @param keywords Array of search keywords
-     * @return List of Library objects containing name and description (up to 20 results)
+     * @return List of Library objects containing name and description (up to
+     *         {@value #MAX_SEARCH_RESULTS} results)
      */
     public List<Library> getLibrariesBySearch(String[] keywords) {
-        List<Library> libraries = new ArrayList<>();
+        List<Library> libraries = toLibraries(searchPackageDescriptions(keywords));
+
+        // Exclusions run before truncation so that an excluded library does not consume a result slot.
+        applyLibraryExclusions(libraries);
+        return libraries.size() > MAX_SEARCH_RESULTS
+                ? new ArrayList<>(libraries.subList(0, MAX_SEARCH_RESULTS))
+                : libraries;
+    }
+
+    /**
+     * Resolves keyword matches to a package name to description map, preferring Ballerina Central and
+     * degrading to the bundled search index when the Central lookup fails.
+     *
+     * @param keywords Array of search keywords
+     * @return map of package names to descriptions, in relevance order
+     */
+    private Map<String, String> searchPackageDescriptions(String[] keywords) {
+        if (Boolean.parseBoolean(System.getProperty(USE_LOCAL_INDEX_PROPERTY))) {
+            return searchLocalIndex(keywords);
+        }
 
         try {
-            Map<String, String> packageToDescriptionMap = LibraryDatabaseAccessor.searchLibrariesByKeywords(keywords);
+            return new CentralLibrarySearchAccessor().searchLibrariesByKeywords(keywords);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING,
+                    "Ballerina Central library search failed; falling back to the bundled search index", e);
+            return searchLocalIndex(keywords);
+        }
+    }
 
-            for (Map.Entry<String, String> entry : packageToDescriptionMap.entrySet()) {
-                Library library = new Library(entry.getKey(), entry.getValue());
-                libraries.add(library);
-            }
+    private Map<String, String> searchLocalIndex(String[] keywords) {
+        try {
+            return LibraryDatabaseAccessor.searchLibrariesByKeywords(keywords);
         } catch (SQLException e) {
             throw new RuntimeException("Failed to search libraries by keywords: " + e.getMessage(), e);
         }
+    }
 
-        applyLibraryExclusions(libraries);
+    private static List<Library> toLibraries(Map<String, String> packageToDescriptionMap) {
+        List<Library> libraries = new ArrayList<>();
+        for (Map.Entry<String, String> entry : packageToDescriptionMap.entrySet()) {
+            libraries.add(new Library(entry.getKey(), entry.getValue()));
+        }
         return libraries;
     }
 

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/central/CentralLibrarySearchAccessor.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/central/CentralLibrarySearchAccessor.java
@@ -1,0 +1,242 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.copilot.central;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.ballerina.centralconnector.CentralAPI;
+import io.ballerina.centralconnector.RemoteCentral;
+import io.ballerina.centralconnector.response.PackageResponse;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Searches Ballerina libraries by keyword against the Ballerina Central registry.
+ *
+ * <p>The keywords are joined into a single space separated {@code q} value. Central resolves that
+ * through Solr's {@code edismax} parser with {@code q.op=OR}, so every keyword contributes to the
+ * match independently and the results arrive ordered by Central's own relevance score. That score
+ * already boosts the {@code ballerina} and {@code ballerinax} organizations and factors in the
+ * package pull count, so no further ranking is applied here.
+ *
+ * <p>Central is asked for 30 packages and the response is narrowed locally to the
+ * {@code ballerina} and {@code ballerinax} organizations. Narrowing locally rather than through
+ * Central's {@code org} query parameter is deliberate: supplying {@code org} makes Central switch
+ * its query operator to {@code AND}, which then requires every keyword to match as well and
+ * collapses multi-keyword searches to zero results.
+ *
+ * <p>Matches are then gated on relevance. Central boosts results by package popularity
+ * ({@code bf=log(pullCount)^75}), which is helpful when the text scores are close but takes over
+ * once they are not: a generic keyword such as "issue" or "repository" matches hundreds of packages
+ * weakly through their README text, and the most-pulled ones then crowd out the genuinely relevant
+ * results. The gate keeps a package only when Central highlighted the match in its summary or
+ * keywords, or when the package name itself carries a query term.
+ *
+ * @since 1.7.0
+ */
+public class CentralLibrarySearchAccessor {
+
+    // Number of packages requested from Central before the organization filter is applied. Measured
+    // yields for 30: a single keyword leaves ~14 ballerina/ballerinax packages and multi-keyword
+    // queries leave ~20-25, comfortably above the number of results the caller keeps.
+    static final int CENTRAL_FETCH_LIMIT = 30;
+
+    // Only libraries from these organizations are surfaced to the caller.
+    private static final Set<String> ALLOWED_ORGANIZATIONS = Set.of("ballerina", "ballerinax");
+
+    // Central reads reserved boolean operators out of the query, so they are dropped from keywords.
+    private static final Set<String> SOLR_BOOLEAN_OPERATORS = Set.of("AND", "OR", "NOT");
+
+    // Shortest query term allowed to match a package name segment as a substring rather than in full.
+    private static final int MIN_PARTIAL_NAME_MATCH_LENGTH = 3;
+
+    private static final String QUERY_PARAM = "q";
+    private static final String LIMIT_PARAM = "limit";
+
+    private static final long MAX_CACHE_ENTRIES = 256;
+    private static final Duration CACHE_TTL = Duration.ofMinutes(30);
+
+    // Keyword searches repeat heavily within a session, and Central now sits on the critical path of
+    // every generation. The cache is static because a manager (and therefore an accessor) is created
+    // per request.
+    private static final Cache<String, Map<String, String>> QUERY_CACHE = Caffeine.newBuilder()
+            .maximumSize(MAX_CACHE_ENTRIES)
+            .expireAfterWrite(CACHE_TTL)
+            .build();
+
+    private final CentralAPI centralApi;
+
+    public CentralLibrarySearchAccessor() {
+        this(RemoteCentral.getInstance());
+    }
+
+    CentralLibrarySearchAccessor(CentralAPI centralApi) {
+        this.centralApi = centralApi;
+    }
+
+    /**
+     * Searches Ballerina Central for libraries matching the given keywords.
+     *
+     * @param keywords Array of search keywords
+     * @return map of matching package names ("org/package_name") to descriptions, in Central's
+     *         relevance order
+     */
+    public Map<String, String> searchLibrariesByKeywords(String[] keywords) {
+        if (keywords == null || keywords.length == 0) {
+            return new LinkedHashMap<>();
+        }
+
+        String query = buildQuery(keywords);
+        if (query.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+
+        Map<String, String> cached = QUERY_CACHE.getIfPresent(query);
+        if (cached != null) {
+            return new LinkedHashMap<>(cached);
+        }
+
+        Map<String, String> libraries = fetchFromCentral(query);
+        QUERY_CACHE.put(query, Collections.unmodifiableMap(new LinkedHashMap<>(libraries)));
+        return libraries;
+    }
+
+    private Map<String, String> fetchFromCentral(String query) {
+        PackageResponse response = centralApi.searchPackages(Map.of(
+                QUERY_PARAM, query,
+                LIMIT_PARAM, String.valueOf(CENTRAL_FETCH_LIMIT)));
+
+        Map<String, String> libraries = new LinkedHashMap<>();
+        if (response == null || response.packages() == null) {
+            return libraries;
+        }
+
+        Map<String, PackageResponse.Highlighting> highlighting =
+                response.highlighting() == null ? Map.of() : response.highlighting();
+        // A HashSet rather than Set.of: repeated keywords yield duplicate tokens, which Set.of rejects.
+        Set<String> queryTerms = new HashSet<>(Arrays.asList(query.toLowerCase(Locale.ROOT).split(" ")));
+
+        for (PackageResponse.Package pkg : response.packages()) {
+            String organization = pkg.organization();
+            String name = pkg.name();
+            if (organization == null || name == null
+                    || !ALLOWED_ORGANIZATIONS.contains(organization.toLowerCase(Locale.ROOT))) {
+                continue;
+            }
+            if (!isRelevantMatch(pkg, highlighting, queryTerms)) {
+                continue;
+            }
+            String summary = pkg.summary();
+            libraries.putIfAbsent(organization + "/" + name, summary == null ? "" : summary);
+        }
+        return libraries;
+    }
+
+    /**
+     * Decides whether a package matched a query term meaningfully rather than incidentally.
+     *
+     * @param pkg          the package to test
+     * @param highlighting Central's highlight snippets, keyed by package id
+     * @param queryTerms   lower cased terms of the query sent to Central
+     * @return true when the match is worth surfacing
+     */
+    private static boolean isRelevantMatch(PackageResponse.Package pkg,
+                                           Map<String, PackageResponse.Highlighting> highlighting,
+                                           Set<String> queryTerms) {
+        PackageResponse.Highlighting highlight = highlighting.get(String.valueOf(pkg.id()));
+        if (highlight != null && (hasSnippet(highlight.summary()) || hasSnippet(highlight.keywords()))) {
+            return true;
+        }
+
+        // Central only highlights the summary and keywords fields, so a package whose own name carries a
+        // query term stays even when nothing was highlighted. Substring matching is needed because a name
+        // segment often glues the term to something else ("api2pdf", "pdfbroker" for "pdf"); it is gated on
+        // a minimum term length so that short terms do not match unrelated names by accident.
+        for (String segment : (pkg.organization() + " " + pkg.name()).toLowerCase(Locale.ROOT)
+                .split("[^a-z0-9]+")) {
+            if (segment.isEmpty()) {
+                continue;
+            }
+            for (String term : queryTerms) {
+                if (term.equals(segment)
+                        || (term.length() >= MIN_PARTIAL_NAME_MATCH_LENGTH && segment.contains(term))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasSnippet(List<String> snippets) {
+        if (snippets == null) {
+            return false;
+        }
+        for (String snippet : snippets) {
+            if (snippet != null && !snippet.isBlank()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Builds Central's {@code q} value from the keyword array.
+     *
+     * <p>Every keyword is reduced to alphanumeric tokens. That is not cosmetic: Central reinterprets
+     * a keyword containing {@code :} as a field lookup and silently drops it when the prefix is not a
+     * known field, which can leave the query empty and make Central match every package. A keyword
+     * containing {@code /} is read as an organization plus package pair and switches the whole query
+     * to {@code AND}. Stripping the punctuation turns both cases into ordinary search terms.
+     *
+     * @param keywords Array of search keywords
+     * @return space separated query value, or an empty string when no usable term remains
+     */
+    static String buildQuery(String[] keywords) {
+        List<String> terms = new ArrayList<>();
+        for (String keyword : keywords) {
+            if (keyword == null || keyword.isBlank()) {
+                continue;
+            }
+            for (String token : sanitize(keyword).split(" ")) {
+                if (token.isEmpty() || SOLR_BOOLEAN_OPERATORS.contains(token.toUpperCase(Locale.ROOT))) {
+                    continue;
+                }
+                terms.add(token);
+            }
+        }
+        return String.join(" ", terms);
+    }
+
+    private static String sanitize(String keyword) {
+        return keyword.replaceAll("[^a-zA-Z0-9 ]", " ").trim().replaceAll("\\s+", " ");
+    }
+
+    static void clearCache() {
+        QUERY_CACHE.invalidateAll();
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/database/LibraryDatabaseAccessor.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/copilot/database/LibraryDatabaseAccessor.java
@@ -145,8 +145,10 @@ public class LibraryDatabaseAccessor {
         return Optional.empty();
     }
 
-    // Maximum number of libraries returned by keyword search.
-    private static final int MAX_SEARCH_RESULTS = 9;
+    // Number of libraries fetched by keyword search. This is an over-fetch: the caller applies
+    // exclusions and then truncates to the number of results it actually surfaces, so fetching more
+    // here keeps an excluded library from consuming a result slot.
+    private static final int SEARCH_FETCH_LIMIT = 30;
 
     private static final String SEARCH_SQL =
             "SELECT p.org, p.package_name, p.description, " +
@@ -259,7 +261,7 @@ public class LibraryDatabaseAccessor {
             stmt.setString(11, primaryNameDescQuery);
             stmt.setString(12, allNameDescQuery);
 
-            stmt.setInt(13, MAX_SEARCH_RESULTS);
+            stmt.setInt(13, SEARCH_FETCH_LIMIT);
 
             try (ResultSet rs = stmt.executeQuery()) {
                 populatePackageMap(packageToDescriptionMap, rs);

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/module-info.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/module-info.java
@@ -59,6 +59,7 @@ module io.ballerina.flow.model.generator {
     exports io.ballerina.flowmodelgenerator.core.expressioneditor.semantictokens;
     exports io.ballerina.flowmodelgenerator.core.copilot.adapters;
     exports io.ballerina.flowmodelgenerator.core.copilot.builder;
+    exports io.ballerina.flowmodelgenerator.core.copilot.central;
     exports io.ballerina.flowmodelgenerator.core.copilot.database;
     exports io.ballerina.flowmodelgenerator.core.copilot.model;
     exports io.ballerina.flowmodelgenerator.core.copilot.service;

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/copilot/central/CentralLibrarySearchAccessorTest.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/java/io/ballerina/flowmodelgenerator/core/copilot/central/CentralLibrarySearchAccessorTest.java
@@ -1,0 +1,379 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.copilot.central;
+
+import io.ballerina.centralconnector.CentralAPI;
+import io.ballerina.centralconnector.response.ConnectorResponse;
+import io.ballerina.centralconnector.response.ConnectorsResponse;
+import io.ballerina.centralconnector.response.DependentPackage;
+import io.ballerina.centralconnector.response.FunctionResponse;
+import io.ballerina.centralconnector.response.FunctionsResponse;
+import io.ballerina.centralconnector.response.Listeners;
+import io.ballerina.centralconnector.response.PackageResponse;
+import io.ballerina.centralconnector.response.SymbolResponse;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link CentralLibrarySearchAccessor}.
+ *
+ * @since 1.7.0
+ */
+public class CentralLibrarySearchAccessorTest {
+
+    @BeforeMethod
+    public void resetCache() {
+        CentralLibrarySearchAccessor.clearCache();
+    }
+
+    @Test(description = "Keywords are joined into a single space separated query value.")
+    public void testKeywordsJoinedIntoQuery() {
+        Assert.assertEquals(CentralLibrarySearchAccessor.buildQuery(
+                new String[]{"GitHub", "issue", "webhook"}), "GitHub issue webhook");
+    }
+
+    @Test(description = "A colon in a keyword is stripped so Central does not read it as a field lookup.")
+    public void testColonKeywordIsStripped() {
+        Assert.assertEquals(CentralLibrarySearchAccessor.buildQuery(new String[]{"http:client"}), "http client");
+    }
+
+    @Test(description = "A slash in a keyword is stripped so Central does not switch the query to AND.")
+    public void testSlashKeywordIsStripped() {
+        Assert.assertEquals(CentralLibrarySearchAccessor.buildQuery(
+                new String[]{"ballerinax/github"}), "ballerinax github");
+    }
+
+    @Test(description = "Punctuation collapses to single separators without leaving empty terms.")
+    public void testPunctuationCollapses() {
+        Assert.assertEquals(CentralLibrarySearchAccessor.buildQuery(
+                new String[]{" e-mail ", "sap.s4hana"}), "e mail sap s4hana");
+    }
+
+    @Test(description = "Solr boolean operators are dropped regardless of case.")
+    public void testBooleanOperatorsDropped() {
+        Assert.assertEquals(CentralLibrarySearchAccessor.buildQuery(
+                new String[]{"payment", "not", "AND", "or", "stripe"}), "payment stripe");
+    }
+
+    @Test(description = "Blank and null keywords are skipped.")
+    public void testBlankKeywordsSkipped() {
+        Assert.assertEquals(CentralLibrarySearchAccessor.buildQuery(
+                new String[]{"kafka", "   ", null, "consumer"}), "kafka consumer");
+    }
+
+    @Test(description = "A keyword with no alphanumeric content yields an empty query.")
+    public void testUnusableKeywordsYieldEmptyQuery() {
+        Assert.assertEquals(CentralLibrarySearchAccessor.buildQuery(new String[]{"!!!", "???"}), "");
+    }
+
+    @Test(description = "Only ballerina and ballerinax libraries are surfaced, in Central's order.")
+    public void testOrganizationFilterAndOrdering() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(
+                        Map.of("1", highlight("GitHub trigger"), "3", highlight("GitHub connector"),
+                                "5", highlight("Also mentions GitHub")),
+                        entry(1, "ballerinax", "trigger.github", "GitHub trigger"),
+                        entry(2, "choreo", "github_issue_to_gsheet", "Template"),
+                        entry(3, "ballerinax", "github", "GitHub connector"),
+                        entry(4, "zerohack", "github", "Third party"),
+                        entry(5, "ballerina", "http", "Also mentions GitHub")));
+
+        Map<String, String> result = new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"github"});
+
+        Assert.assertEquals(new ArrayList<>(result.keySet()),
+                List.of("ballerinax/trigger.github", "ballerinax/github", "ballerina/http"));
+        Assert.assertEquals(result.get("ballerinax/github"), "GitHub connector");
+    }
+
+    @Test(description = "Central is asked for the over-fetch limit so the local filters have room.")
+    public void testCentralQueryParameters() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(entry(1, "ballerina", "http", "HTTP library")));
+
+        new CentralLibrarySearchAccessor(central).searchLibrariesByKeywords(new String[]{"REST", "service"});
+
+        Assert.assertEquals(central.lastQueryMap.get("q"), "REST service");
+        Assert.assertEquals(central.lastQueryMap.get("limit"),
+                String.valueOf(CentralLibrarySearchAccessor.CENTRAL_FETCH_LIMIT));
+    }
+
+    @Test(description = "A package Central highlighted on its keywords field is kept.")
+    public void testKeywordHighlightKeepsPackage() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(Map.of("1", new PackageResponse.Highlighting(List.of(), List.of("**payment**"))),
+                        entry(1, "ballerinax", "stripe", "Online payments")));
+
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"payment"}).containsKey("ballerinax/stripe"));
+    }
+
+    @Test(description = "A popular package that only matched incidentally is dropped.")
+    public void testPopularityNoiseDropped() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(Map.of("1", highlight("A GitHub connector")),
+                        entry(1, "ballerinax", "github", "A GitHub connector"),
+                        entry(2, "ballerina", "regex", "Regular expressions"),
+                        entry(3, "ballerina", "jwt", "Authentication framework")));
+
+        Map<String, String> result = new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"github", "issue"});
+
+        Assert.assertEquals(new ArrayList<>(result.keySet()), List.of("ballerinax/github"));
+    }
+
+    @Test(description = "A name match survives even when Central highlighted nothing.")
+    public void testNameMatchSurvivesWithoutHighlight() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(entry(1, "ballerinax", "kafka", "Event streaming")));
+
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"kafka"}).containsKey("ballerinax/kafka"));
+    }
+
+    @Test(description = "A dotted package name matches on any of its segments.")
+    public void testDottedNameSegmentMatches() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(entry(1, "ballerinax", "microsoft.excel", "Spreadsheets")));
+
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"excel"}).containsKey("ballerinax/microsoft.excel"));
+    }
+
+    @Test(description = "A name segment that glues the term to something else still matches.")
+    public void testPartialNameSegmentMatches() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(
+                        entry(1, "ballerinax", "api2pdf", "Connects to the Api2Pdf REST API"),
+                        entry(2, "ballerinax", "pdfbroker", "Connects to PDFBroker.io")));
+
+        Map<String, String> result = new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"pdf"});
+
+        Assert.assertEquals(new ArrayList<>(result.keySet()),
+                List.of("ballerinax/api2pdf", "ballerinax/pdfbroker"));
+    }
+
+    @Test(description = "A short term does not match a name segment by accident.")
+    public void testShortTermDoesNotPartiallyMatchNames() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(entry(1, "ballerina", "email", "Send and receive email")));
+
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"ai"}).isEmpty());
+    }
+
+    @Test(description = "Blank highlight snippets do not count as a match.")
+    public void testBlankHighlightSnippetsIgnored() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(Map.of("1", new PackageResponse.Highlighting(List.of(), List.of(""))),
+                        entry(1, "ballerina", "regex", "Regular expressions")));
+
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"github"}).isEmpty());
+    }
+
+    @Test(description = "Repeated keywords do not break query term collection.")
+    public void testRepeatedKeywordsTolerated() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(entry(1, "ballerina", "http", "HTTP library")));
+
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"http", "http"}).containsKey("ballerina/http"));
+    }
+
+    @Test(description = "A missing summary becomes an empty description rather than a null.")
+    public void testMissingSummaryBecomesEmptyString() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(entry(1, "ballerina", "http", null)));
+
+        Map<String, String> result = new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"http"});
+
+        Assert.assertEquals(result.get("ballerina/http"), "");
+    }
+
+    @Test(description = "Repeated package names keep the highest ranked entry.")
+    public void testDuplicatePackagesDeduplicated() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(
+                        entry(1, "ballerina", "http", "Newest"),
+                        entry(2, "ballerina", "http", "Older")));
+
+        Map<String, String> result = new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"http"});
+
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertEquals(result.get("ballerina/http"), "Newest");
+    }
+
+    @Test(description = "Empty and unusable keyword arrays short circuit without calling Central.")
+    public void testNoCentralCallWithoutUsableKeywords() {
+        RecordingCentralApi central = new RecordingCentralApi(packageResponse());
+
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[0]).isEmpty());
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(null).isEmpty());
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"###"}).isEmpty());
+        Assert.assertEquals(central.callCount, 0);
+    }
+
+    @Test(description = "A repeated query is served from the cache instead of hitting Central again.")
+    public void testRepeatedQueryIsCached() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(entry(1, "ballerina", "http", "HTTP library")));
+        CentralLibrarySearchAccessor accessor = new CentralLibrarySearchAccessor(central);
+
+        Map<String, String> first = accessor.searchLibrariesByKeywords(new String[]{"http", "rest"});
+        Map<String, String> second = accessor.searchLibrariesByKeywords(new String[]{"http", "rest"});
+
+        Assert.assertEquals(central.callCount, 1);
+        Assert.assertEquals(second, first);
+    }
+
+    @Test(description = "Mutating a returned map does not corrupt the cached entry.")
+    public void testCachedResultIsIsolatedFromCallers() {
+        RecordingCentralApi central = new RecordingCentralApi(
+                packageResponse(entry(1, "ballerina", "http", "HTTP library")));
+        CentralLibrarySearchAccessor accessor = new CentralLibrarySearchAccessor(central);
+
+        accessor.searchLibrariesByKeywords(new String[]{"http"}).clear();
+        Map<String, String> second = accessor.searchLibrariesByKeywords(new String[]{"http"});
+
+        Assert.assertEquals(second.size(), 1);
+        Assert.assertEquals(second.get("ballerina/http"), "HTTP library");
+    }
+
+    @Test(description = "An empty Central response yields no libraries.")
+    public void testEmptyCentralResponse() {
+        RecordingCentralApi central = new RecordingCentralApi(packageResponse());
+
+        Assert.assertTrue(new CentralLibrarySearchAccessor(central)
+                .searchLibrariesByKeywords(new String[]{"nothing"}).isEmpty());
+    }
+
+    private static PackageResponse.Highlighting highlight(String summarySnippet) {
+        return new PackageResponse.Highlighting(List.of(summarySnippet), List.of());
+    }
+
+    private static PackageResponse.Package entry(int id, String organization, String name, String summary) {
+        return new PackageResponse.Package(id, organization, name, "1.0.0", "any", "2201.0.0", false, "",
+                "", "", "", "", summary, null, false, List.of(), List.of(), "", List.of(), "", "", "",
+                0L, 0, "public", List.of(), "", "");
+    }
+
+    private static PackageResponse packageResponse(PackageResponse.Package... packages) {
+        return packageResponse(Map.of(), packages);
+    }
+
+    private static PackageResponse packageResponse(Map<String, PackageResponse.Highlighting> highlighting,
+                                                   PackageResponse.Package... packages) {
+        return new PackageResponse(List.of(packages), List.of(), highlighting, packages.length, 0,
+                CentralLibrarySearchAccessor.CENTRAL_FETCH_LIMIT);
+    }
+
+    /**
+     * A {@link CentralAPI} stub that records the query it was called with and replays a fixed response.
+     */
+    private static final class RecordingCentralApi implements CentralAPI {
+
+        private final PackageResponse response;
+        private Map<String, String> lastQueryMap;
+        private int callCount;
+
+        private RecordingCentralApi(PackageResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public PackageResponse searchPackages(Map<String, String> queryMap) {
+            this.lastQueryMap = queryMap;
+            this.callCount++;
+            return response;
+        }
+
+        @Override
+        public SymbolResponse searchSymbols(Map<String, String> queryMap) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FunctionsResponse functions(String organization, String name, String version) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Listeners listeners(String organization, String name, String version) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FunctionResponse function(String organization, String name, String version, String functionName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConnectorsResponse connectors(Map<String, String> queryMap) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConnectorResponse connector(String id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConnectorResponse connector(String organization, String name, String version, String clientName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String latestPackageVersion(String org, String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> allPackageVersions(String org, String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, List<DependentPackage>> dependentPackages(String org, String packageName,
+                                                                    List<String> versions) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, List<String>> packageKeywords(List<DependentPackage> modules) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasAuthorizedAccess() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/test/resources/testng.xml
@@ -6,6 +6,7 @@
             <class name="io.ballerina.flowmodelgenerator.core.AiComponentDiskCacheTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.ConnectionActionProviderTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.DiagnosticHandlerTest"/>
+            <class name="io.ballerina.flowmodelgenerator.core.copilot.central.CentralLibrarySearchAccessorTest"/>
             <class name="io.ballerina.flowmodelgenerator.core.copilot.service.ServiceIndexLoaderTest"/>
         </classes>
     </test>


### PR DESCRIPTION
## Summary

`LibrarySearchTool` now searches Ballerina Central instead of the SQLite index bundled in the LS jar, so library discovery reflects Central's current contents without needing an LS release.

The LSP method, request/response types, tool schema, event shape and `LibraryGetTool` are unchanged.

## What's new

**`CentralLibrarySearchAccessor`** — searches Central and narrows the results:

1. Sanitizes the model's keywords to alphanumeric tokens and joins them into one `q`.
2. Calls `GET /2.0/registry/search-packages?q=…&limit=30`.
3. Filters the 30 results, keeping Central's rank order:
   - **org filter** — `ballerina` and `ballerinax` only
   - **relevance gate** — keeps matches Central highlighted in `summary`/`keywords`, or whose package name carries a query term
   - dedupe by name
4. 30-minute in-memory cache keyed on the query.

**Fallback** — any failure on the Central path logs a warning and falls back to the existing SQLite search. `-Dballerina.copilot.librarySearch.useLocalIndex=true` forces the local path.

**Result cap** — top 10, with `exclusion.json` applied *before* truncation (previously an excluded library silently consumed a slot).

**Tool description** — removed the inaccurate "keywords are positionally weighted" claim, plus two pieces of guidance that were causing result dilution (the blanket `trigger` keyword advice, and encouraging generic terms like "issue"). Replaced with: prefer 1–3 distinctive keywords, avoid generic words, scope `trigger` to event-listening, one search per service.

## Testing

23 unit tests (`CentralLibrarySearchAccessorTest`), mocked via `RemoteCentral.setTestInstance` — no network in CI. Checkstyle and spotbugs clean.

Manually verified end to end: Central reached, org filter holds, search → select → fetch works on packages the model can't guess, generated code compiles, and the fallback returns results with Central blackholed.

