### PR TITLE
Improve the chat sessions dropdown

### DIFF
--- a/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -81,6 +81,7 @@ import {
     ThreadSummary,
     SwitchThreadRequest,
     DeleteThreadRequest,
+    RenameThreadRequest,
     // TODO(auto-memory): temporarily disabled for this release.
     // ClearMemoryRequest,
     // OpenMemoryRequest,
@@ -163,6 +164,7 @@ export interface AIPanelAPI {
     listThreads: () => Promise<ThreadSummary[]>;
     switchThread: (params: SwitchThreadRequest) => Promise<void>;
     deleteThread: (params: DeleteThreadRequest) => Promise<void>;
+    renameThread: (params: RenameThreadRequest) => Promise<void>;
     // TODO(auto-memory): memory management temporarily disabled for this release.
     // clearMemory: (params: ClearMemoryRequest) => Promise<void>;
     // openMemoryFiles: (params: OpenMemoryRequest) => void;

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -551,7 +551,7 @@ export interface ThreadSummary {
     isActive: boolean;
     createdAt: number;
     updatedAt: number;
-    messageCount: number;
+    turnCount: number;
 }
 
 export interface SwitchThreadRequest {

--- a/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -562,6 +562,11 @@ export interface DeleteThreadRequest {
     threadId: string;
 }
 
+export interface RenameThreadRequest {
+    threadId: string;
+    name: string;
+}
+
 // TODO(auto-memory): temporarily disabled for this release — restore once the memory feature is refined.
 // export interface ClearMemoryRequest {
 //     scope: 'workspace' | 'all';

--- a/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/packages/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -82,6 +82,7 @@ import {
     ThreadSummary,
     SwitchThreadRequest,
     DeleteThreadRequest,
+    RenameThreadRequest,
     // TODO(auto-memory): temporarily disabled for this release.
     // ClearMemoryRequest,
     // OpenMemoryRequest,
@@ -181,6 +182,7 @@ export const agentsMdFileInfoChanged: NotificationType<AgentsMdFileInfoDTO> = { 
 export const listThreads: RequestType<void, ThreadSummary[]> = { method: `${_preFix}/listThreads` };
 export const switchThread: RequestType<SwitchThreadRequest, void> = { method: `${_preFix}/switchThread` };
 export const deleteThread: RequestType<DeleteThreadRequest, void> = { method: `${_preFix}/deleteThread` };
+export const renameThread: RequestType<RenameThreadRequest, void> = { method: `${_preFix}/renameThread` };
 // TODO(auto-memory): temporarily disabled for this release.
 // export const clearMemory: RequestType<ClearMemoryRequest, void> = { method: `${_preFix}/clearMemory` };
 // export const openMemoryFiles: NotificationType<OpenMemoryRequest> = { method: `${_preFix}/openMemoryFiles` };

--- a/packages/ballerina-extension/package.json
+++ b/packages/ballerina-extension/package.json
@@ -1292,14 +1292,14 @@
                 "description": "start",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f249"
+                    "fontCharacter": "\\f24a"
                 }
             },
             "ballerina-debug": {
                 "description": "debug",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1c0"
+                    "fontCharacter": "\\f1c1"
                 }
             },
             "ballerina-source-view": {
@@ -1313,7 +1313,7 @@
                 "description": "persist-diagram",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f21f"
+                    "fontCharacter": "\\f220"
                 }
             },
             "ballerina-cached-rounded": {
@@ -1411,7 +1411,7 @@
                 "description": "design-view",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1c5"
+                    "fontCharacter": "\\f1c6"
                 }
             },
             "distro-file-submodule": {

--- a/packages/ballerina-extension/src/features/ai/utils/project/temp-project.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/project/temp-project.ts
@@ -210,19 +210,20 @@ function isOwnedTempDir(tempPath: string): boolean {
  * @param tempPath Path to the temporary project to delete
  */
 export async function cleanupTempProject(tempPath: string): Promise<void> {
-    const baselinePath = getReviewBaselinePath(tempPath);
-    if (!fs.existsSync(tempPath) && !fs.existsSync(baselinePath)) {
+    removeReviewBaseline(getReviewBaselinePath(tempPath));
+
+    if (!fs.existsSync(tempPath)) {
         return;
     }
 
     if (!isOwnedTempDir(tempPath)) {
-        console.error(`[cleanupTempProject] Refusing to delete non-temp path: ${tempPath}`);
+        console.log(`[cleanupTempProject] Keeping non-temp path: ${tempPath}`);
         return;
     }
 
     try {
         // Find all .bal files and send didClose notifications
-        const balFiles = fs.existsSync(tempPath) ? findAllBalFiles(tempPath) : [];
+        const balFiles = findAllBalFiles(tempPath);
         if (balFiles.length > 0) {
             sendAgentDidCloseBatch(tempPath, balFiles); // Handles both file:// and ai:// schemas
             await new Promise(resolve => setTimeout(resolve, 300)); // Wait for LS to process
@@ -230,14 +231,23 @@ export async function cleanupTempProject(tempPath: string): Promise<void> {
     } catch (error) {
         console.error(`Failed to notify the language server before cleaning up ${tempPath}:`, error);
     } finally {
-        // Remove both directories even when an LS notification fails.
-        for (const directory of [tempPath, baselinePath]) {
-            try {
-                fs.rmSync(directory, { recursive: true, force: true });
-            } catch (error) {
-                console.error(`Failed to cleanup temp project artifact at ${directory}:`, error);
-            }
+        try {
+            fs.rmSync(tempPath, { recursive: true, force: true });
+        } catch (error) {
+            console.error(`Failed to cleanup temp project at ${tempPath}:`, error);
         }
+    }
+}
+
+/** Always ours to delete, even when tempPath is the live workspace and must be left in place. */
+function removeReviewBaseline(baselinePath: string): void {
+    if (!path.basename(baselinePath).endsWith(REVIEW_BASELINE_SUFFIX) || !fs.existsSync(baselinePath)) {
+        return;
+    }
+    try {
+        fs.rmSync(baselinePath, { recursive: true, force: true });
+    } catch (error) {
+        console.error(`Failed to cleanup review baseline at ${baselinePath}:`, error);
     }
 }
 

--- a/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
+++ b/packages/ballerina-extension/src/features/ai/utils/run-event-store.ts
@@ -255,6 +255,17 @@ export class RunEventStore {
         return { isRunning: state.isRunning, events, generationId: state.generationId, truncated: state.truncated };
     }
 
+    /** True while any thread in the workspace has a live run. */
+    hasActiveRun(projectRootPath: string): boolean {
+        const prefix = `${projectRootPath}::`;
+        for (const [key, state] of this.runs) {
+            if (state.isRunning && key.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Drops the buffered events for a generation once its transcript has been
      * durably persisted as `uiResponse` (replay is no longer needed). No-op if

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -148,6 +148,8 @@ import {
     SwitchThreadRequest,
     deleteThread,
     DeleteThreadRequest,
+    renameThread,
+    RenameThreadRequest,
     // TODO(auto-memory): temporarily disabled for this release.
     // clearMemory,
     // ClearMemoryRequest,
@@ -256,6 +258,7 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(listThreads, () => rpcManger.listThreads());
     messenger.onRequest(switchThread, (args: SwitchThreadRequest) => rpcManger.switchThread(args));
     messenger.onRequest(deleteThread, (args: DeleteThreadRequest) => rpcManger.deleteThread(args));
+    messenger.onRequest(renameThread, (args: RenameThreadRequest) => rpcManger.renameThread(args));
     // TODO(auto-memory): temporarily disabled for this release.
     // messenger.onRequest(clearMemory, (args: ClearMemoryRequest) => rpcManger.clearMemory(args));
     // messenger.onNotification(openMemoryFiles, (args: OpenMemoryRequest) => rpcManger.openMemoryFiles(args));

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -83,6 +83,7 @@ import {
     ThreadSummary,
     SwitchThreadRequest,
     DeleteThreadRequest,
+    RenameThreadRequest,
     HasPendingReviewRequest,
     CreateManagedConnectionRequest,
     CreateManagedConnectionResponse,
@@ -848,6 +849,10 @@ User reverted the last made changes. The files have been restored to the state b
         const projectRootPath = resolveProjectRootPath();
         if (refuseWhileRunning(projectRootPath, 'deleteThread')) { return; }
         await chatStateStorage.deleteThread(projectRootPath, params.threadId);
+    }
+
+    async renameThread(params: RenameThreadRequest): Promise<void> {
+        chatStateStorage.renameThread(resolveProjectRootPath(), params.threadId, params.name);
     }
 
     // TODO(auto-memory): memory management temporarily disabled for this release — restore once the memory feature is refined.

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -198,6 +198,19 @@ const CONNECTION_FAILURE_MESSAGE: Record<ConnectionSettleReason, string> = {
     superseded: "Connection cancelled — a newer connection attempt was started.",
 };
 
+/**
+ * A run owns the active thread until it ends, so reparenting it mid-turn would strand the
+ * run's writes. The panel already disables these actions; this backstops a webview reload
+ * or a click that races the turn starting.
+ */
+function refuseWhileRunning(projectRootPath: string, action: string): boolean {
+    if (!runEventStore.hasActiveRun(projectRootPath)) {
+        return false;
+    }
+    console.warn(`[RPC] Refused ${action} — a response is still running for: ${projectRootPath}`);
+    return true;
+}
+
 export class AiPanelRpcManager implements AIPanelAPI {
 
     async getLoginMethod(): Promise<LoginMethod> {
@@ -813,6 +826,7 @@ User reverted the last made changes. The files have been restored to the state b
 
     async clearChat(): Promise<void> {
         const projectRootPath = resolveProjectRootPath();
+        if (refuseWhileRunning(projectRootPath, 'clearChat')) { return; }
         // Create a new thread — preserves all existing history
         const newThreadId = chatStateStorage.createNewThread(projectRootPath);
         clearCompactionDisabledWarning(projectRootPath, newThreadId);
@@ -826,11 +840,13 @@ User reverted the last made changes. The files have been restored to the state b
 
     async switchThread(params: SwitchThreadRequest): Promise<void> {
         const projectRootPath = resolveProjectRootPath();
+        if (refuseWhileRunning(projectRootPath, 'switchThread')) { return; }
         chatStateStorage.switchToThread(projectRootPath, params.threadId);
     }
 
     async deleteThread(params: DeleteThreadRequest): Promise<void> {
         const projectRootPath = resolveProjectRootPath();
+        if (refuseWhileRunning(projectRootPath, 'deleteThread')) { return; }
         await chatStateStorage.deleteThread(projectRootPath, params.threadId);
     }
 

--- a/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -38,6 +38,15 @@ import {
     PersistedCodeContext,
 } from '@wso2/copilot-utilities/chat-persistence';
 
+const THREAD_NAME_MAX_LENGTH = 60;
+const UNNAMED_THREAD_NAME = 'New Chat';
+
+/** The label auto-naming would give this thread — its first prompt, or the unnamed sentinel. */
+function deriveThreadName(thread: ChatThread): string {
+    const firstPrompt = thread.generations[0]?.userPrompt?.slice(0, THREAD_NAME_MAX_LENGTH).trim();
+    return firstPrompt || UNNAMED_THREAD_NAME;
+}
+
 /**
  * Resolve a stable workspace identity for persistence hashing.
  *
@@ -523,7 +532,7 @@ export class ChatStateStorage {
         const newThreadId = `thread-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const newThread: ChatThread = {
             id: newThreadId,
-            name: 'New Chat',
+            name: UNNAMED_THREAD_NAME,
             generations: [],
             createdAt: Date.now(),
             updatedAt: Date.now(),
@@ -573,6 +582,23 @@ export class ChatStateStorage {
         workspace.activeThreadId = threadId;
         this.flushWorkspaceMetadata(projectRootPath);
         console.log(`[ChatStateStorage] Switched to thread: ${threadId} in workspace: ${projectRootPath}`);
+    }
+
+    /**
+     * Renames a thread. A blank name falls back to what auto-naming would have produced,
+     * so a cleared field never persists as an empty label. Does not touch updatedAt —
+     * renaming is not activity and would otherwise reshuffle the date grouping.
+     */
+    renameThread(projectRootPath: string, threadId: string, name: string): void {
+        const workspace = this.initializeWorkspace(projectRootPath);
+        const thread = workspace.threads.get(threadId);
+        if (!thread) {
+            console.warn(`[ChatStateStorage] Thread not found for rename: ${threadId}`);
+            return;
+        }
+        const trimmed = name.trim().slice(0, THREAD_NAME_MAX_LENGTH);
+        thread.name = trimmed || deriveThreadName(thread);
+        this.flushThread(projectRootPath, threadId);
     }
 
     /**
@@ -652,8 +678,8 @@ export class ChatStateStorage {
         };
 
         // Auto-name thread from first user message
-        if (thread.name === 'New Chat' && thread.generations.length === 0) {
-            const trimmedName = userPrompt.slice(0, 60).trim();
+        if (thread.name === UNNAMED_THREAD_NAME && thread.generations.length === 0) {
+            const trimmedName = userPrompt.slice(0, THREAD_NAME_MAX_LENGTH).trim();
             if (trimmedName) { thread.name = trimmedName; }
         }
 

--- a/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -850,7 +850,7 @@ export class ChatStateStorage {
 
     /**
      * Get chat history for LLM (model messages only)
-     * Includes ALL generations (generating, done, accepted)
+     * Includes generations in every status, reverted ones as well
      * @param projectRootPath Workspace identifier
      * @param threadId Thread identifier
      * @returns Array of model messages for LLM context

--- a/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -541,7 +541,7 @@ export class ChatStateStorage {
      */
     listThreadsSummary(projectRootPath: string): Array<{
         id: string; name: string; isActive: boolean;
-        createdAt: number; updatedAt: number; messageCount: number;
+        createdAt: number; updatedAt: number; turnCount: number;
     }> {
         const workspace = this.initializeWorkspace(projectRootPath);
         const summaries = [];
@@ -552,7 +552,7 @@ export class ChatStateStorage {
                 isActive: id === workspace.activeThreadId,
                 createdAt: thread.createdAt,
                 updatedAt: thread.updatedAt,
-                messageCount: thread.generations.length,
+                turnCount: thread.generations.length,
             });
         }
         // Newest first

--- a/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/packages/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -171,6 +171,8 @@ import {
     SwitchThreadRequest,
     deleteThread,
     DeleteThreadRequest,
+    renameThread,
+    RenameThreadRequest,
     ThreadSummary,
     // TODO(auto-memory): temporarily disabled for this release.
     // clearMemory,
@@ -528,6 +530,10 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     deleteThread(params: DeleteThreadRequest): Promise<void> {
         return this._messenger.sendRequest(deleteThread, HOST_EXTENSION, params);
+    }
+
+    renameThread(params: RenameThreadRequest): Promise<void> {
+        return this._messenger.sendRequest(renameThread, HOST_EXTENSION, params);
     }
 
     // TODO(auto-memory): temporarily disabled for this release.

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2196,17 +2196,24 @@ const AIChat: React.FC = () => {
         loadThreads();
     }
 
+    // Six call sites fire this without serializing, so a slow earlier response could otherwise
+    // overwrite a newer list — or end the spinner while a newer request is still running.
+    const loadThreadsSeqRef = useRef(0);
+
     async function loadThreads(): Promise<void> {
+        const seq = ++loadThreadsSeqRef.current;
         setThreadsLoading(true);
         setThreadsError(null);
         try {
             const list = await rpcClient.getAiPanelRpcClient().listThreads();
+            if (seq !== loadThreadsSeqRef.current) { return; }
             setThreads(list);
         } catch (error) {
+            if (seq !== loadThreadsSeqRef.current) { return; }
             console.error('[AIChat] Failed to load chat sessions:', error);
             setThreadsError("Couldn't load sessions. Close and reopen to retry.");
         } finally {
-            setThreadsLoading(false);
+            if (seq === loadThreadsSeqRef.current) { setThreadsLoading(false); }
         }
     }
 

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2511,7 +2511,6 @@ const AIChat: React.FC = () => {
                                     appearance="icon"
                                     onClick={() => { loadThreads(); setHistoryOpen(v => !v); }}
                                     tooltip="Chat sessions"
-                                    disabled={isLoading}
                                 >
                                     <Codicon name="history" sx={{ fontSize: "16px", marginRight: 6 }} />
                                     Chats
@@ -2519,6 +2518,7 @@ const AIChat: React.FC = () => {
                                 {historyOpen && (
                                     <SessionHistoryDropdown
                                         threads={threads}
+                                        readOnly={isLoading}
                                         onNewChat={handleClearChat}
                                         onSwitch={handleSwitchThread}
                                         onDelete={handleDeleteThread}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2524,7 +2524,7 @@ const AIChat: React.FC = () => {
                                     onClick={() => { void loadThreads(); setHistoryOpen(v => !v); }}
                                     tooltip="Chat sessions"
                                 >
-                                    <Codicon name="history" sx={{ fontSize: "16px", marginRight: 6 }} />
+                                    <Icon name="CopilotChatRounded" sx={{ fontSize: "18px", marginRight: 6 }} iconSx={{ position: "relative" }} />
                                     Chats
                                 </Button>
                                 {historyOpen && (

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -2246,6 +2246,11 @@ const AIChat: React.FC = () => {
         loadThreads();
     }
 
+    async function handleRenameThread(threadId: string, name: string): Promise<void> {
+        await rpcClient.getAiPanelRpcClient().renameThread({ threadId, name });
+        loadThreads();
+    }
+
     const handleToggleAutoApprove = () => {
         const newValue = !isAutoApproveEnabled;
         setIsAutoApproveEnabled(newValue);
@@ -2522,6 +2527,7 @@ const AIChat: React.FC = () => {
                                         onNewChat={handleClearChat}
                                         onSwitch={handleSwitchThread}
                                         onDelete={handleDeleteThread}
+                                        onRename={handleRenameThread}
                                         onClose={() => setHistoryOpen(false)}
                                     />
                                 )}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -378,6 +378,8 @@ const AIChat: React.FC = () => {
     const [hasActiveReview, setHasActiveReview] = useState(false);
     const [historyOpen, setHistoryOpen] = useState(false);
     const [threads, setThreads] = useState<ThreadSummary[]>([]);
+    const [threadsLoading, setThreadsLoading] = useState(false);
+    const [threadsError, setThreadsError] = useState<string | null>(null);
 
     const [approvalRequest, setApprovalRequest] = useState<TaskApprovalRequest | null>(null);
     const [approvalOverlay, setApprovalOverlay] = useState<ApprovalOverlayState>({ show: false });
@@ -2195,11 +2197,16 @@ const AIChat: React.FC = () => {
     }
 
     async function loadThreads(): Promise<void> {
+        setThreadsLoading(true);
+        setThreadsError(null);
         try {
             const list = await rpcClient.getAiPanelRpcClient().listThreads();
             setThreads(list);
-        } catch {
-            // Non-critical — session history unavailable
+        } catch (error) {
+            console.error('[AIChat] Failed to load chat sessions:', error);
+            setThreadsError("Couldn't load sessions. Close and reopen to retry.");
+        } finally {
+            setThreadsLoading(false);
         }
     }
 
@@ -2514,7 +2521,7 @@ const AIChat: React.FC = () => {
                             <div style={{ position: "relative" }}>
                                 <Button
                                     appearance="icon"
-                                    onClick={() => { loadThreads(); setHistoryOpen(v => !v); }}
+                                    onClick={() => { void loadThreads(); setHistoryOpen(v => !v); }}
                                     tooltip="Chat sessions"
                                 >
                                     <Codicon name="history" sx={{ fontSize: "16px", marginRight: 6 }} />
@@ -2523,6 +2530,8 @@ const AIChat: React.FC = () => {
                                 {historyOpen && (
                                     <SessionHistoryDropdown
                                         threads={threads}
+                                        loading={threadsLoading}
+                                        error={threadsError}
                                         readOnly={isLoading}
                                         onNewChat={handleClearChat}
                                         onSwitch={handleSwitchThread}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -378,7 +378,6 @@ const AIChat: React.FC = () => {
     const [hasActiveReview, setHasActiveReview] = useState(false);
     const [historyOpen, setHistoryOpen] = useState(false);
     const [threads, setThreads] = useState<ThreadSummary[]>([]);
-    const newChatAnchorRef = useRef<HTMLDivElement>(null);
 
     const [approvalRequest, setApprovalRequest] = useState<TaskApprovalRequest | null>(null);
     const [approvalOverlay, setApprovalOverlay] = useState<ApprovalOverlayState>({ show: false });
@@ -2506,20 +2505,16 @@ const AIChat: React.FC = () => {
                             </AuthProviderChip>
                         )}
                         <HeaderButtons>
-                            {/* Single button — click opens session history dropdown. New chat is created from within the dropdown. */}
-                            <div ref={newChatAnchorRef} style={{ position: "relative" }}>
+                            {/* New chat is created from a row inside the dropdown, not from this button. */}
+                            <div style={{ position: "relative" }}>
                                 <Button
                                     appearance="icon"
                                     onClick={() => { loadThreads(); setHistoryOpen(v => !v); }}
                                     tooltip="Chat sessions"
                                     disabled={isLoading}
                                 >
-                                    <Icon name="NewChat" sx={{ fontSize: "16px", marginRight: 4 }} iconSx={{ position: "relative", top: "2px" }} />
-                                    New Chat
-                                    <Codicon
-                                        name={historyOpen ? "chevron-up" : "chevron-down"}
-                                        sx={{ fontSize: "10px", marginLeft: 4, position: "relative", top: "1px" }}
-                                    />
+                                    <Codicon name="history" sx={{ fontSize: "16px", marginRight: 6 }} />
+                                    Chats
                                 </Button>
                                 {historyOpen && (
                                     <SessionHistoryDropdown

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -20,6 +20,7 @@ import React, { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import { ThreadSummary } from "@wso2/ballerina-core";
 import { Codicon } from "@wso2/ui-toolkit";
+import { DangerActionButton, SecondaryActionButton } from "../../styles";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -151,6 +152,34 @@ const SessionItem = styled.div<{ isActive: boolean; isReadOnly: boolean }>(
     })
 );
 
+const ActionButton = SecondaryActionButton;
+const DeleteButton = DangerActionButton;
+
+const ConfirmRow = styled.div`
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    font-size: 12px;
+    color: var(--vscode-foreground);
+    font-family: var(--vscode-font-family);
+`;
+
+const ConfirmText = styled.span`
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    strong { font-weight: 600; }
+`;
+
+const Spacer = styled.div`
+    flex: 1;
+`;
+
 const ReadOnlyHint = styled.div`
     padding: 6px 8px;
     border-top: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
@@ -223,7 +252,6 @@ const NewChatRow = styled.button`
 
 export interface SessionHistoryDropdownProps {
     threads: ThreadSummary[];
-    /** A turn owns its session until it finishes, so the list is browsable but not actionable. */
     readOnly?: boolean;
     onNewChat: () => void;
     onSwitch: (threadId: string) => void;
@@ -240,16 +268,18 @@ export function SessionHistoryDropdown({
     onClose,
 }: SessionHistoryDropdownProps): JSX.Element {
     const [search, setSearch] = useState("");
+    const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         inputRef.current?.focus();
         const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') { onClose(); }
+            if (e.key !== 'Escape') { return; }
+            if (confirmDelete) { setConfirmDelete(null); } else { onClose(); }
         };
         document.addEventListener('keydown', handleKeyDown);
         return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [onClose]);
+    }, [onClose, confirmDelete]);
 
     const filtered = search.trim()
         ? threads.filter(t => t.name.toLowerCase().includes(search.toLowerCase()))
@@ -263,9 +293,12 @@ export function SessionHistoryDropdown({
         onClose();
     };
 
-    const handleDelete = (e: React.MouseEvent, threadId: string) => {
-        e.stopPropagation();
-        onDelete(threadId);
+    const handleDelete = (threadId: string) => {
+        try {
+            onDelete(threadId);
+        } finally {
+            setConfirmDelete(null);
+        }
     };
 
     const handleNewChat = () => {
@@ -295,37 +328,54 @@ export function SessionHistoryDropdown({
                     {groups.map(group => (
                         <div key={group.label}>
                             <GroupLabel>{group.label}</GroupLabel>
-                            {group.items.map(thread => (
-                                <SessionItem
-                                    key={thread.id}
-                                    isActive={thread.isActive}
-                                    isReadOnly={readOnly}
-                                    role="button"
-                                    tabIndex={readOnly ? -1 : 0}
-                                    aria-disabled={readOnly}
-                                    onClick={() => handleSwitch(thread.id)}
-                                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSwitch(thread.id); } }}
-                                >
-                                    <ActiveDot isActive={thread.isActive} />
-                                    <SessionName title={thread.name}>{thread.name}</SessionName>
-                                    <SessionMeta title={promptCountLabel(thread.turnCount)}>
-                                        {formatMeta(thread)}
-                                    </SessionMeta>
-                                    {!readOnly && (
-                                        <DeleteBtn
-                                            className="delete-btn"
-                                            onClick={e => handleDelete(e, thread.id)}
-                                            // Keep keyboard activation of delete from also bubbling to
-                                            // SessionItem's onKeyDown, which would switch threads. The native
-                                            // button still activates (delete) on Enter/Space itself.
-                                            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); } }}
-                                            title="Delete session"
-                                        >
-                                            <Codicon name="trash" sx={{ fontSize: "12px" }} />
-                                        </DeleteBtn>
-                                    )}
-                                </SessionItem>
-                            ))}
+                            {group.items.map(thread => {
+                                const isConfirming = confirmDelete === thread.id;
+                                return (
+                                    <SessionItem
+                                        key={thread.id}
+                                        // Selection background would wreck the action buttons' contrast.
+                                        isActive={thread.isActive && !isConfirming}
+                                        isReadOnly={readOnly || isConfirming}
+                                        role="button"
+                                        tabIndex={readOnly || isConfirming ? -1 : 0}
+                                        aria-disabled={readOnly}
+                                        onClick={() => { if (!isConfirming) { handleSwitch(thread.id); } }}
+                                        onKeyDown={(e) => {
+                                            if (isConfirming) { return; }
+                                            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSwitch(thread.id); }
+                                        }}
+                                    >
+                                        {isConfirming ? (
+                                            <ConfirmRow>
+                                                <ConfirmText>Delete <strong>{thread.name}</strong>?</ConfirmText>
+                                                <Spacer />
+                                                <DeleteButton type="button" onClick={() => handleDelete(thread.id)}>Yes, delete</DeleteButton>
+                                                <ActionButton type="button" onClick={() => setConfirmDelete(null)}>Cancel</ActionButton>
+                                            </ConfirmRow>
+                                        ) : (
+                                            <>
+                                                <ActiveDot isActive={thread.isActive} />
+                                                <SessionName title={thread.name}>{thread.name}</SessionName>
+                                                <SessionMeta title={promptCountLabel(thread.turnCount)}>
+                                                    {formatMeta(thread)}
+                                                </SessionMeta>
+                                                {!readOnly && (
+                                                    <DeleteBtn
+                                                        className="delete-btn"
+                                                        onClick={e => { e.stopPropagation(); setConfirmDelete(thread.id); }}
+                                                        // Keep keyboard activation from also bubbling to SessionItem's
+                                                        // onKeyDown, which would switch threads instead.
+                                                        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); } }}
+                                                        title="Delete session"
+                                                    >
+                                                        <Codicon name="trash" sx={{ fontSize: "12px" }} />
+                                                    </DeleteBtn>
+                                                )}
+                                            </>
+                                        )}
+                                    </SessionItem>
+                                );
+                            })}
                         </div>
                     ))}
                 </SessionList>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -214,11 +214,13 @@ const ReadOnlyHint = styled.div`
     flex-shrink: 0;
 `;
 
+// Selected rows sit on list-activeSelectionBackground, which is a saturated accent in many themes.
+// Anything on that row has to follow the row's own resolved foreground, or it disappears into it.
 const ActiveDot = styled.div<{ isActive: boolean }>(({ isActive }: { isActive: boolean }) => ({
     width: "6px",
     height: "6px",
     borderRadius: "50%",
-    background: isActive ? "var(--vscode-charts-blue, #007acc)" : "var(--vscode-descriptionForeground)",
+    background: isActive ? "currentColor" : "var(--vscode-descriptionForeground)",
     flexShrink: 0,
     opacity: isActive ? 1 : 0.5,
 }));
@@ -231,11 +233,12 @@ const SessionName = styled.span`
     text-overflow: ellipsis;
 `;
 
-const SessionMeta = styled.span`
-    font-size: 10px;
-    color: var(--vscode-descriptionForeground);
-    flex-shrink: 0;
-`;
+const SessionMeta = styled.span<{ isActive: boolean }>(({ isActive }: { isActive: boolean }) => ({
+    fontSize: "10px",
+    color: isActive ? "inherit" : "var(--vscode-descriptionForeground)",
+    opacity: isActive ? 0.85 : 1,
+    flexShrink: 0,
+}));
 
 const RenameInput = styled.input`
     flex: 1;
@@ -266,14 +269,14 @@ const RowIconButton = styled.button<{ isDanger?: boolean }>(({ isDanger }: { isD
     border: "none",
     cursor: "pointer",
     padding: 0,
-    color: "var(--vscode-icon-foreground)",
+    color: "inherit",
     display: "inline-flex",
     alignItems: "center",
     justifyContent: "center",
     borderRadius: "3px",
     flexShrink: 0,
     "&:hover, &:focus-visible": {
-        color: isDanger ? "var(--vscode-errorForeground)" : "var(--vscode-foreground)",
+        color: isDanger ? "var(--vscode-errorForeground)" : "inherit",
         background: "var(--vscode-toolbar-hoverBackground)",
     },
 }));
@@ -442,7 +445,10 @@ export function SessionHistoryDropdown({
                                                 ) : (
                                                     <SessionName title={thread.name}>{thread.name}</SessionName>
                                                 )}
-                                                <SessionMeta title={promptCountLabel(thread.turnCount)}>
+                                                <SessionMeta
+                                                    isActive={thread.isActive}
+                                                    title={promptCountLabel(thread.turnCount)}
+                                                >
                                                     {formatMeta(thread, now)}
                                                 </SessionMeta>
                                                 {!readOnly && !isRenaming && (

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -24,17 +24,44 @@ import { DangerActionButton, SecondaryActionButton } from "../../styles";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function formatRelativeTime(ts: number): string {
-    const diffMs = Date.now() - ts;
-    const diffSec = Math.floor(diffMs / 1000);
-    const diffMin = Math.floor(diffSec / 60);
-    const diffHr = Math.floor(diffMin / 60);
-    const diffDay = Math.floor(diffHr / 24);
-    if (diffSec < 60) { return "Just now"; }
-    if (diffMin < 60) { return `${diffMin}m`; }
-    if (diffHr < 24) { return `${diffHr}h`; }
-    if (diffDay < 7) { return `${diffDay}d`; }
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const RECENT_WINDOW_DAYS = 7;
+const GROUP_ORDER = ["TODAY", "YESTERDAY", "PAST WEEK", "OLDER"] as const;
+
+type GroupLabelText = typeof GROUP_ORDER[number];
+
+function startOfDay(ts: number): number {
+    const date = new Date(ts);
+    date.setHours(0, 0, 0, 0);
+    return date.getTime();
+}
+
+/**
+ * Whole calendar days between two instants. Both the row label and the group heading derive from
+ * this, so they can never disagree the way elapsed-time and calendar-day views of "yesterday" did.
+ * Rounded because a DST boundary makes a local day 23 or 25 hours long.
+ */
+function calendarDaysAgo(ts: number, now: number): number {
+    return Math.round((startOfDay(now) - startOfDay(ts)) / MS_PER_DAY);
+}
+
+function formatRelativeTime(ts: number, now: number): string {
+    const daysAgo = calendarDaysAgo(ts, now);
+    if (daysAgo <= 0) {
+        const diffMin = Math.floor((now - ts) / 60_000);
+        if (diffMin < 1) { return "Just now"; }
+        if (diffMin < 60) { return `${diffMin}m`; }
+        return `${Math.floor(diffMin / 60)}h`;
+    }
+    if (daysAgo < RECENT_WINDOW_DAYS) { return `${daysAgo}d`; }
     return new Date(ts).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function groupLabelFor(ts: number, now: number): GroupLabelText {
+    const daysAgo = calendarDaysAgo(ts, now);
+    if (daysAgo <= 0) { return "TODAY"; }
+    if (daysAgo === 1) { return "YESTERDAY"; }
+    return daysAgo < RECENT_WINDOW_DAYS ? "PAST WEEK" : "OLDER";
 }
 
 function promptCountLabel(turnCount: number): string | undefined {
@@ -42,22 +69,20 @@ function promptCountLabel(turnCount: number): string | undefined {
     return `${turnCount} prompt${turnCount === 1 ? "" : "s"}`;
 }
 
-function formatMeta(thread: ThreadSummary): string {
-    const time = formatRelativeTime(thread.updatedAt);
+function formatMeta(thread: ThreadSummary, now: number): string {
+    const time = formatRelativeTime(thread.updatedAt, now);
     return thread.turnCount > 0 ? `${thread.turnCount} · ${time}` : time;
 }
 
-function groupByDate(threads: ThreadSummary[]): { label: string; items: ThreadSummary[] }[] {
-    const startOfToday = new Date(); startOfToday.setHours(0, 0, 0, 0);
-    const startOfWeek = new Date(startOfToday); startOfWeek.setDate(startOfWeek.getDate() - 6);
-    const groups: Record<string, ThreadSummary[]> = { TODAY: [], "PAST WEEK": [], OLDER: [] };
-    for (const t of threads) {
-        if (t.updatedAt >= startOfToday.getTime()) { groups.TODAY.push(t); }
-        else if (t.updatedAt >= startOfWeek.getTime()) { groups["PAST WEEK"].push(t); }
-        else { groups.OLDER.push(t); }
+function groupByDate(threads: ThreadSummary[], now: number): { label: string; items: ThreadSummary[] }[] {
+    const groups: Record<GroupLabelText, ThreadSummary[]> = {
+        TODAY: [], YESTERDAY: [], "PAST WEEK": [], OLDER: [],
+    };
+    for (const thread of threads) {
+        groups[groupLabelFor(thread.updatedAt, now)].push(thread);
     }
-    return (["TODAY", "PAST WEEK", "OLDER"] as const)
-        .filter(k => groups[k].length > 0)
+    return GROUP_ORDER
+        .filter(label => groups[label].length > 0)
         .map(label => ({ label, items: groups[label] }));
 }
 
@@ -314,7 +339,8 @@ export function SessionHistoryDropdown({
         ? threads.filter(t => t.name.toLowerCase().includes(search.toLowerCase()))
         : threads;
 
-    const groups = groupByDate(filtered);
+    const now = Date.now();
+    const groups = groupByDate(filtered, now);
 
     const handleSwitch = (threadId: string) => {
         if (readOnly) { return; }
@@ -412,7 +438,7 @@ export function SessionHistoryDropdown({
                                                     <SessionName title={thread.name}>{thread.name}</SessionName>
                                                 )}
                                                 <SessionMeta title={promptCountLabel(thread.turnCount)}>
-                                                    {formatMeta(thread)}
+                                                    {formatMeta(thread, now)}
                                                 </SessionMeta>
                                                 {!readOnly && !isRenaming && (
                                                     <RowActions className="row-actions">

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -36,6 +36,16 @@ function formatRelativeTime(ts: number): string {
     return new Date(ts).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
+function promptCountLabel(turnCount: number): string | undefined {
+    if (turnCount === 0) { return undefined; }
+    return `${turnCount} prompt${turnCount === 1 ? "" : "s"}`;
+}
+
+function formatMeta(thread: ThreadSummary): string {
+    const time = formatRelativeTime(thread.updatedAt);
+    return thread.turnCount > 0 ? `${thread.turnCount} · ${time}` : time;
+}
+
 function groupByDate(threads: ThreadSummary[]): { label: string; items: ThreadSummary[] }[] {
     const startOfToday = new Date(); startOfToday.setHours(0, 0, 0, 0);
     const startOfWeek = new Date(startOfToday); startOfWeek.setDate(startOfWeek.getDate() - 6);
@@ -154,7 +164,7 @@ const SessionName = styled.span`
     text-overflow: ellipsis;
 `;
 
-const SessionTime = styled.span`
+const SessionMeta = styled.span`
     font-size: 10px;
     color: var(--vscode-descriptionForeground);
     flex-shrink: 0;
@@ -278,7 +288,9 @@ export function SessionHistoryDropdown({
                                 >
                                     <ActiveDot isActive={thread.isActive} />
                                     <SessionName title={thread.name}>{thread.name}</SessionName>
-                                    <SessionTime>{formatRelativeTime(thread.updatedAt)}</SessionTime>
+                                    <SessionMeta title={promptCountLabel(thread.turnCount)}>
+                                        {formatMeta(thread)}
+                                    </SessionMeta>
                                     <DeleteBtn
                                         className="delete-btn"
                                         onClick={e => handleDelete(e, thread.id)}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -155,6 +155,24 @@ const EmptyState = styled.div`
     font-size: 11px;
 `;
 
+const LoadingState = styled(EmptyState)`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+
+    .codicon-modifier-spin {
+        animation: codicon-spin 1.2s steps(30) infinite;
+    }
+    @keyframes codicon-spin {
+        100% { transform: rotate(360deg); }
+    }
+`;
+
+const ErrorState = styled(EmptyState)`
+    color: var(--vscode-errorForeground);
+`;
+
 const SessionItem = styled.div<{ isActive: boolean; isReadOnly: boolean }>(
     ({ isActive, isReadOnly }: { isActive: boolean; isReadOnly: boolean }) => ({
         display: "flex",
@@ -303,6 +321,8 @@ const NewChatRow = styled.button`
 
 export interface SessionHistoryDropdownProps {
     threads: ThreadSummary[];
+    loading?: boolean;
+    error?: string | null;
     readOnly?: boolean;
     onNewChat: () => void;
     onSwitch: (threadId: string) => void;
@@ -313,6 +333,8 @@ export interface SessionHistoryDropdownProps {
 
 export function SessionHistoryDropdown({
     threads,
+    loading = false,
+    error = null,
     readOnly = false,
     onNewChat,
     onSwitch,
@@ -325,6 +347,8 @@ export function SessionHistoryDropdown({
     const [renaming, setRenaming] = useState<{ threadId: string; name: string } | null>(null);
     const [now, setNow] = useState(() => Date.now());
     const inputRef = useRef<HTMLInputElement>(null);
+    // Enter, Escape and blur can all reach the rename handlers for the same edit.
+    const renameSettledRef = useRef(false);
 
     useEffect(() => {
         inputRef.current?.focus();
@@ -338,7 +362,7 @@ export function SessionHistoryDropdown({
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key !== 'Escape') { return; }
-            if (confirmDelete) { setConfirmDelete(null); } else if (renaming) { setRenaming(null); } else { onClose(); }
+            if (confirmDelete) { setConfirmDelete(null); } else if (renaming) { cancelRename(); } else { onClose(); }
         };
         document.addEventListener('keydown', handleKeyDown);
         return () => document.removeEventListener('keydown', handleKeyDown);
@@ -370,8 +394,19 @@ export function SessionHistoryDropdown({
         onClose();
     };
 
+    const startRename = (threadId: string, name: string) => {
+        renameSettledRef.current = false;
+        setRenaming({ threadId, name });
+    };
+
+    const cancelRename = () => {
+        renameSettledRef.current = true;
+        setRenaming(null);
+    };
+
     const commitRename = () => {
-        if (!renaming) { return; }
+        if (!renaming || renameSettledRef.current) { return; }
+        renameSettledRef.current = true;
         const { threadId, name } = renaming;
         setRenaming(null);
         const current = threads.find(t => t.id === threadId)?.name;
@@ -394,7 +429,15 @@ export function SessionHistoryDropdown({
                 </SearchRow>
 
                 <SessionList>
-                    {groups.length === 0 && (
+                    {error && <ErrorState>{error}</ErrorState>}
+                    {/* Only when there is nothing to show yet — a refresh must not blank the list. */}
+                    {loading && threads.length === 0 && !error && (
+                        <LoadingState>
+                            <span className="codicon codicon-loading codicon-modifier-spin" />
+                            Loading sessions...
+                        </LoadingState>
+                    )}
+                    {!loading && !error && groups.length === 0 && (
                         <EmptyState>{search.trim() ? "No matching sessions" : "No sessions yet"}</EmptyState>
                     )}
                     {groups.map(group => (
@@ -439,7 +482,7 @@ export function SessionHistoryDropdown({
                                                         onKeyDown={e => {
                                                             e.stopPropagation();
                                                             if (e.key === 'Enter') { commitRename(); }
-                                                            if (e.key === 'Escape') { setRenaming(null); }
+                                                            if (e.key === 'Escape') { cancelRename(); }
                                                         }}
                                                     />
                                                 ) : (
@@ -454,7 +497,7 @@ export function SessionHistoryDropdown({
                                                 {!readOnly && !isRenaming && (
                                                     <RowActions className="row-actions">
                                                         <RowIconButton
-                                                            onClick={e => { e.stopPropagation(); setRenaming({ threadId: thread.id, name: thread.name }); }}
+                                                            onClick={e => { e.stopPropagation(); startRename(thread.id, thread.name); }}
                                                             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); } }}
                                                             title="Rename session"
                                                         >

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -129,23 +129,36 @@ const EmptyState = styled.div`
     font-size: 11px;
 `;
 
-const SessionItem = styled.div<{ isActive: boolean }>(({ isActive }: { isActive: boolean }) => ({
-    display: "flex",
-    alignItems: "center",
-    gap: "8px",
-    padding: "4px",
-    borderRadius: "3px",
-    cursor: "pointer",
-    position: "relative" as const,
-    background: isActive ? "var(--vscode-list-activeSelectionBackground)" : "transparent",
-    color: isActive ? "var(--vscode-list-activeSelectionForeground)" : "inherit",
-    outline: "none",
-    "&:hover": {
-        background: isActive ? "var(--vscode-list-activeSelectionBackground)" : "var(--vscode-list-hoverBackground)",
-    },
-    "&:hover .delete-btn, &:focus-within .delete-btn": { opacity: 1 },
-    "&:focus-visible": { outline: "1px solid var(--vscode-focusBorder)" },
-}));
+const SessionItem = styled.div<{ isActive: boolean; isReadOnly: boolean }>(
+    ({ isActive, isReadOnly }: { isActive: boolean; isReadOnly: boolean }) => ({
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "4px",
+        borderRadius: "3px",
+        cursor: isReadOnly ? "default" : "pointer",
+        position: "relative" as const,
+        background: isActive ? "var(--vscode-list-activeSelectionBackground)" : "transparent",
+        color: isActive ? "var(--vscode-list-activeSelectionForeground)" : "inherit",
+        outline: "none",
+        "&:hover": {
+            background: isActive
+                ? "var(--vscode-list-activeSelectionBackground)"
+                : isReadOnly ? "transparent" : "var(--vscode-list-hoverBackground)",
+        },
+        "&:hover .delete-btn, &:focus-within .delete-btn": { opacity: 1 },
+        "&:focus-visible": { outline: "1px solid var(--vscode-focusBorder)" },
+    })
+);
+
+const ReadOnlyHint = styled.div`
+    padding: 6px 8px;
+    border-top: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+    color: var(--vscode-descriptionForeground);
+    font-size: 11px;
+    text-align: center;
+    flex-shrink: 0;
+`;
 
 const ActiveDot = styled.div<{ isActive: boolean }>(({ isActive }: { isActive: boolean }) => ({
     width: "6px",
@@ -210,6 +223,8 @@ const NewChatRow = styled.button`
 
 export interface SessionHistoryDropdownProps {
     threads: ThreadSummary[];
+    /** A turn owns its session until it finishes, so the list is browsable but not actionable. */
+    readOnly?: boolean;
     onNewChat: () => void;
     onSwitch: (threadId: string) => void;
     onDelete: (threadId: string) => void;
@@ -218,6 +233,7 @@ export interface SessionHistoryDropdownProps {
 
 export function SessionHistoryDropdown({
     threads,
+    readOnly = false,
     onNewChat,
     onSwitch,
     onDelete,
@@ -242,6 +258,7 @@ export function SessionHistoryDropdown({
     const groups = groupByDate(filtered);
 
     const handleSwitch = (threadId: string) => {
+        if (readOnly) { return; }
         onSwitch(threadId);
         onClose();
     };
@@ -252,6 +269,7 @@ export function SessionHistoryDropdown({
     };
 
     const handleNewChat = () => {
+        if (readOnly) { return; }
         onNewChat();
         onClose();
     };
@@ -281,8 +299,10 @@ export function SessionHistoryDropdown({
                                 <SessionItem
                                     key={thread.id}
                                     isActive={thread.isActive}
+                                    isReadOnly={readOnly}
                                     role="button"
-                                    tabIndex={0}
+                                    tabIndex={readOnly ? -1 : 0}
+                                    aria-disabled={readOnly}
                                     onClick={() => handleSwitch(thread.id)}
                                     onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSwitch(thread.id); } }}
                                 >
@@ -291,27 +311,33 @@ export function SessionHistoryDropdown({
                                     <SessionMeta title={promptCountLabel(thread.turnCount)}>
                                         {formatMeta(thread)}
                                     </SessionMeta>
-                                    <DeleteBtn
-                                        className="delete-btn"
-                                        onClick={e => handleDelete(e, thread.id)}
-                                        // Keep keyboard activation of delete from also bubbling to
-                                        // SessionItem's onKeyDown, which would switch threads. The native
-                                        // button still activates (delete) on Enter/Space itself.
-                                        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); } }}
-                                        title="Delete session"
-                                    >
-                                        <Codicon name="trash" sx={{ fontSize: "12px" }} />
-                                    </DeleteBtn>
+                                    {!readOnly && (
+                                        <DeleteBtn
+                                            className="delete-btn"
+                                            onClick={e => handleDelete(e, thread.id)}
+                                            // Keep keyboard activation of delete from also bubbling to
+                                            // SessionItem's onKeyDown, which would switch threads. The native
+                                            // button still activates (delete) on Enter/Space itself.
+                                            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); } }}
+                                            title="Delete session"
+                                        >
+                                            <Codicon name="trash" sx={{ fontSize: "12px" }} />
+                                        </DeleteBtn>
+                                    )}
                                 </SessionItem>
                             ))}
                         </div>
                     ))}
                 </SessionList>
 
-                <NewChatRow onClick={handleNewChat}>
-                    <Codicon name="add" sx={{ fontSize: "13px" }} />
-                    New Chat
-                </NewChatRow>
+                {readOnly ? (
+                    <ReadOnlyHint>Finish or stop the current response to switch sessions.</ReadOnlyHint>
+                ) : (
+                    <NewChatRow onClick={handleNewChat}>
+                        <Codicon name="add" sx={{ fontSize: "13px" }} />
+                        New Chat
+                    </NewChatRow>
+                )}
             </DropdownContainer>
         </>
     );

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -147,7 +147,7 @@ const SessionItem = styled.div<{ isActive: boolean; isReadOnly: boolean }>(
                 ? "var(--vscode-list-activeSelectionBackground)"
                 : isReadOnly ? "transparent" : "var(--vscode-list-hoverBackground)",
         },
-        "&:hover .delete-btn, &:focus-within .delete-btn": { opacity: 1 },
+        "&:hover .row-actions, &:focus-within .row-actions": { opacity: 1 },
         "&:focus-visible": { outline: "1px solid var(--vscode-focusBorder)" },
     })
 );
@@ -212,23 +212,46 @@ const SessionMeta = styled.span`
     flex-shrink: 0;
 `;
 
-const DeleteBtn = styled.button`
-    opacity: 0;
-    width: 20px;
-    height: 20px;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    color: var(--vscode-icon-foreground);
+const RenameInput = styled.input`
+    flex: 1;
+    min-width: 0;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-focusBorder);
+    border-radius: 3px;
+    padding: 1px 4px;
+    font-size: 12px;
+    font-family: var(--vscode-font-family);
+    outline: none;
+`;
+
+const RowActions = styled.div`
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    border-radius: 3px;
+    gap: 2px;
     flex-shrink: 0;
+    opacity: 0;
     transition: opacity 0.1s;
-    &:hover, &:focus-visible { color: var(--vscode-errorForeground); background: var(--vscode-toolbar-hoverBackground); opacity: 1; }
 `;
+
+const RowIconButton = styled.button<{ isDanger?: boolean }>(({ isDanger }: { isDanger?: boolean }) => ({
+    width: "20px",
+    height: "20px",
+    background: "transparent",
+    border: "none",
+    cursor: "pointer",
+    padding: 0,
+    color: "var(--vscode-icon-foreground)",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: "3px",
+    flexShrink: 0,
+    "&:hover, &:focus-visible": {
+        color: isDanger ? "var(--vscode-errorForeground)" : "var(--vscode-foreground)",
+        background: "var(--vscode-toolbar-hoverBackground)",
+    },
+}));
 
 const NewChatRow = styled.button`
     display: flex;
@@ -256,6 +279,7 @@ export interface SessionHistoryDropdownProps {
     onNewChat: () => void;
     onSwitch: (threadId: string) => void;
     onDelete: (threadId: string) => void;
+    onRename: (threadId: string, name: string) => void;
     onClose: () => void;
 }
 
@@ -265,21 +289,26 @@ export function SessionHistoryDropdown({
     onNewChat,
     onSwitch,
     onDelete,
+    onRename,
     onClose,
 }: SessionHistoryDropdownProps): JSX.Element {
     const [search, setSearch] = useState("");
     const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+    const [renaming, setRenaming] = useState<{ threadId: string; name: string } | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         inputRef.current?.focus();
+    }, []);
+
+    useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key !== 'Escape') { return; }
-            if (confirmDelete) { setConfirmDelete(null); } else { onClose(); }
+            if (confirmDelete) { setConfirmDelete(null); } else if (renaming) { setRenaming(null); } else { onClose(); }
         };
         document.addEventListener('keydown', handleKeyDown);
         return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [onClose, confirmDelete]);
+    }, [onClose, confirmDelete, renaming]);
 
     const filtered = search.trim()
         ? threads.filter(t => t.name.toLowerCase().includes(search.toLowerCase()))
@@ -307,6 +336,15 @@ export function SessionHistoryDropdown({
         onClose();
     };
 
+    const commitRename = () => {
+        if (!renaming) { return; }
+        const { threadId, name } = renaming;
+        setRenaming(null);
+        const current = threads.find(t => t.id === threadId)?.name;
+        if (name.trim() && name.trim() === current?.trim()) { return; }
+        onRename(threadId, name);
+    };
+
     return (
         <>
             <Overlay onClick={onClose} />
@@ -330,18 +368,20 @@ export function SessionHistoryDropdown({
                             <GroupLabel>{group.label}</GroupLabel>
                             {group.items.map(thread => {
                                 const isConfirming = confirmDelete === thread.id;
+                                const isRenaming = renaming?.threadId === thread.id;
+                                const isBusy = isConfirming || isRenaming;
                                 return (
                                     <SessionItem
                                         key={thread.id}
                                         // Selection background would wreck the action buttons' contrast.
                                         isActive={thread.isActive && !isConfirming}
-                                        isReadOnly={readOnly || isConfirming}
+                                        isReadOnly={readOnly || isBusy}
                                         role="button"
-                                        tabIndex={readOnly || isConfirming ? -1 : 0}
+                                        tabIndex={readOnly || isBusy ? -1 : 0}
                                         aria-disabled={readOnly}
-                                        onClick={() => { if (!isConfirming) { handleSwitch(thread.id); } }}
+                                        onClick={() => { if (!isBusy) { handleSwitch(thread.id); } }}
                                         onKeyDown={(e) => {
-                                            if (isConfirming) { return; }
+                                            if (isBusy) { return; }
                                             if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSwitch(thread.id); }
                                         }}
                                     >
@@ -355,21 +395,43 @@ export function SessionHistoryDropdown({
                                         ) : (
                                             <>
                                                 <ActiveDot isActive={thread.isActive} />
-                                                <SessionName title={thread.name}>{thread.name}</SessionName>
+                                                {isRenaming ? (
+                                                    <RenameInput
+                                                        autoFocus
+                                                        value={renaming.name}
+                                                        onChange={e => setRenaming({ threadId: thread.id, name: e.target.value })}
+                                                        onBlur={commitRename}
+                                                        onClick={e => e.stopPropagation()}
+                                                        onKeyDown={e => {
+                                                            e.stopPropagation();
+                                                            if (e.key === 'Enter') { commitRename(); }
+                                                            if (e.key === 'Escape') { setRenaming(null); }
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    <SessionName title={thread.name}>{thread.name}</SessionName>
+                                                )}
                                                 <SessionMeta title={promptCountLabel(thread.turnCount)}>
                                                     {formatMeta(thread)}
                                                 </SessionMeta>
-                                                {!readOnly && (
-                                                    <DeleteBtn
-                                                        className="delete-btn"
-                                                        onClick={e => { e.stopPropagation(); setConfirmDelete(thread.id); }}
-                                                        // Keep keyboard activation from also bubbling to SessionItem's
-                                                        // onKeyDown, which would switch threads instead.
-                                                        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); } }}
-                                                        title="Delete session"
-                                                    >
-                                                        <Codicon name="trash" sx={{ fontSize: "12px" }} />
-                                                    </DeleteBtn>
+                                                {!readOnly && !isRenaming && (
+                                                    <RowActions className="row-actions">
+                                                        <RowIconButton
+                                                            onClick={e => { e.stopPropagation(); setRenaming({ threadId: thread.id, name: thread.name }); }}
+                                                            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); } }}
+                                                            title="Rename session"
+                                                        >
+                                                            <Codicon name="edit" sx={{ fontSize: "12px" }} />
+                                                        </RowIconButton>
+                                                        <RowIconButton
+                                                            isDanger
+                                                            onClick={e => { e.stopPropagation(); setConfirmDelete(thread.id); }}
+                                                            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); } }}
+                                                            title="Delete session"
+                                                        >
+                                                            <Codicon name="trash" sx={{ fontSize: "12px" }} />
+                                                        </RowIconButton>
+                                                    </RowActions>
                                                 )}
                                             </>
                                         )}

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -55,23 +55,25 @@ function groupByDate(threads: ThreadSummary[]): { label: string; items: ThreadSu
 const Overlay = styled.div`
     position: fixed;
     inset: 0;
-    z-index: 200;
+    z-index: 999;
 `;
 
 const DropdownContainer = styled.div`
     position: absolute;
-    top: 40px;
+    top: calc(100% + 6px);
     right: 0;
-    width: 320px;
+    width: 300px;
     max-height: 420px;
-    background: var(--vscode-editor-background);
-    border: 1px solid var(--vscode-panel-border);
+    background: var(--vscode-editorHoverWidget-background);
+    border: 1px solid var(--vscode-editorHoverWidget-border);
     border-radius: 4px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    color: var(--vscode-editorHoverWidget-foreground);
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    z-index: 201;
+    z-index: 1000;
+    font-size: 12px;
     font-family: var(--vscode-font-family);
 `;
 
@@ -79,8 +81,8 @@ const SearchRow = styled.div`
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 8px 10px;
-    border-bottom: 1px solid var(--vscode-panel-border);
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
     flex-shrink: 0;
 `;
 
@@ -98,27 +100,35 @@ const SearchInput = styled.input`
 const SessionList = styled.div`
     flex: 1;
     overflow-y: auto;
-    padding: 4px 0;
+    padding: 4px;
 `;
 
 const GroupLabel = styled.div`
-    font-size: 10px;
+    font-size: 9px;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.5px;
     color: var(--vscode-descriptionForeground);
-    padding: 8px 12px 4px;
+    padding: 6px 4px 2px;
+`;
+
+const EmptyState = styled.div`
+    padding: 16px 8px;
+    text-align: center;
+    color: var(--vscode-descriptionForeground);
+    font-size: 11px;
 `;
 
 const SessionItem = styled.div<{ isActive: boolean }>(({ isActive }: { isActive: boolean }) => ({
     display: "flex",
     alignItems: "center",
     gap: "8px",
-    padding: "6px 12px",
+    padding: "4px",
+    borderRadius: "3px",
     cursor: "pointer",
     position: "relative" as const,
     background: isActive ? "var(--vscode-list-activeSelectionBackground)" : "transparent",
-    color: isActive ? "var(--vscode-list-activeSelectionForeground)" : "var(--vscode-foreground)",
+    color: isActive ? "var(--vscode-list-activeSelectionForeground)" : "inherit",
     outline: "none",
     "&:hover": {
         background: isActive ? "var(--vscode-list-activeSelectionBackground)" : "var(--vscode-list-hoverBackground)",
@@ -131,7 +141,7 @@ const ActiveDot = styled.div<{ isActive: boolean }>(({ isActive }: { isActive: b
     width: "6px",
     height: "6px",
     borderRadius: "50%",
-    background: isActive ? "var(--vscode-button-background)" : "var(--vscode-descriptionForeground)",
+    background: isActive ? "var(--vscode-charts-blue, #007acc)" : "var(--vscode-descriptionForeground)",
     flexShrink: 0,
     opacity: isActive ? 1 : 0.5,
 }));
@@ -145,35 +155,38 @@ const SessionName = styled.span`
 `;
 
 const SessionTime = styled.span`
-    font-size: 11px;
+    font-size: 10px;
     color: var(--vscode-descriptionForeground);
     flex-shrink: 0;
 `;
 
 const DeleteBtn = styled.button`
     opacity: 0;
+    width: 20px;
+    height: 20px;
     background: transparent;
     border: none;
     cursor: pointer;
-    padding: 2px 4px;
-    color: var(--vscode-descriptionForeground);
-    display: flex;
+    padding: 0;
+    color: var(--vscode-icon-foreground);
+    display: inline-flex;
     align-items: center;
+    justify-content: center;
     border-radius: 3px;
     flex-shrink: 0;
     transition: opacity 0.1s;
-    &:hover, &:focus-visible { color: var(--vscode-errorForeground); background: var(--vscode-list-hoverBackground); opacity: 1; }
+    &:hover, &:focus-visible { color: var(--vscode-errorForeground); background: var(--vscode-toolbar-hoverBackground); opacity: 1; }
 `;
 
 const NewChatRow = styled.button`
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px 12px;
+    gap: 6px;
+    padding: 6px 8px;
     border: none;
-    border-top: 1px solid var(--vscode-panel-border);
+    border-top: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
     background: transparent;
-    color: var(--vscode-button-foreground, var(--vscode-foreground));
+    color: inherit;
     font-size: 12px;
     font-family: var(--vscode-font-family);
     cursor: pointer;
@@ -249,7 +262,7 @@ export function SessionHistoryDropdown({
 
                 <SessionList>
                     {groups.length === 0 && (
-                        <GroupLabel style={{ fontWeight: 400, textTransform: "none" }}>No sessions found</GroupLabel>
+                        <EmptyState>{search.trim() ? "No matching sessions" : "No sessions yet"}</EmptyState>
                     )}
                     {groups.map(group => (
                         <div key={group.label}>

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/SessionHistory/index.tsx
@@ -320,10 +320,16 @@ export function SessionHistoryDropdown({
     const [search, setSearch] = useState("");
     const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
     const [renaming, setRenaming] = useState<{ threadId: string; name: string } | null>(null);
+    const [now, setNow] = useState(() => Date.now());
     const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         inputRef.current?.focus();
+    }, []);
+
+    useEffect(() => {
+        const id = setInterval(() => setNow(Date.now()), 60_000);
+        return () => clearInterval(id);
     }, []);
 
     useEffect(() => {
@@ -339,7 +345,6 @@ export function SessionHistoryDropdown({
         ? threads.filter(t => t.name.toLowerCase().includes(search.toLowerCase()))
         : threads;
 
-    const now = Date.now();
     const groups = groupByDate(filtered, now);
 
     const handleSwitch = (threadId: string) => {


### PR DESCRIPTION
Reworks the chat sessions dropdown in the AI panel so it matches the rest of the panel, and so it behaves correctly around an in-flight response.

- Relabel the header trigger to a single Chats button with a Copilot chat icon
- Align the dropdown with the AI panel popup style
- Show the prompt count on each session row
- Support renaming a session, settling exactly once across Enter / Escape / blur
- Confirm before deleting a session, reusing the in-row confirm pattern from the MCP panel
- Group sessions by calendar day rather than elapsed time, and refresh the times while the list is open
- Keep the selected row legible on light themes
- Show loading and error states, with the loader only when there is nothing already on screen
- Refuse session switching, deletion and new-chat while a response is running

The grouping fix is behavioural, not cosmetic: the row label used elapsed time while the bucket used calendar days, so a session from late yesterday could read "10h" under PAST WEEK.

Also in here:

- Stop reporting an error when temp cleanup skips the workspace — an expected no-op now that generations edit the workspace directly, so it was logging on every session delete
- Bump the submodule for the new `CopilotChatRounded` glyph (wso2/vscode-extensions#2446). Adding an icon shifts every later codepoint, so the four `contributes.icons` entries it displaces are bumped to keep rendering the glyphs they render today — verified glyph-by-glyph against main.

Verified: `tsc --noEmit` clean on core / rpc-client / extension, jest 53 (extension) and 128 (visualizer), webview builds, and a manual light + dark theme pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Reworked the AI panel chat sessions dropdown with “Chats” labeling, updated styling, prompt counts, calendar-day grouping, relative timestamps, and live time refresh.
- Added loading, error, empty, read-only, rename, and delete-confirmation states.
- Added thread renaming across the visualizer, RPC client, RPC types, and extension storage.
- Prevented session switching, deletion, and new-chat actions during active responses.
- Added workspace safeguards for session mutation operations and improved temporary-project cleanup handling.
- Updated icon mappings, the related submodule, and stale documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->