### PR TITLE
Auto-enable MCP tools from project config, with a scalable config-path list

### DIFF
--- a/packages/ballerina-extension/src/features/ai/activator.ts
+++ b/packages/ballerina-extension/src/features/ai/activator.ts
@@ -273,8 +273,6 @@ export function activateAIFeatures(ballerinaExternalInstance: BallerinaExtension
     });
 }
 
-let mcpTrustDisposable: { dispose(): void } | null = null;
-
 // MCP runs when the user enabled it, or when the project carries a `.mcp.json`.
 function isMcpEnabled(): boolean {
     return isMcpToolsEnabled(resolveProjectRootPath() || undefined);
@@ -293,10 +291,12 @@ function pushMcpUpdate(manager: McpClientManager): void {
     }
 }
 
-function setupMcp(): void {
+// Returns the manager's initial-refresh promise so callers can await first setup finishing
+// before a subsequent queued transition (e.g. a rapid disable) is allowed to run.
+function setupMcp(): Promise<void> {
     if (getMcpClientManager()) {
         // Already set up; nothing to do.
-        return;
+        return Promise.resolve();
     }
     // Override store keys are `${scope}:${name}` (e.g. `workspace:foo`).
     function readMcpOverrideMap(): Record<string, boolean> {
@@ -356,23 +356,16 @@ function setupMcp(): void {
     const workspacePath = resolveProjectRootPath() || undefined;
     const workspaceTrusted = vscodeWorkspace.isTrusted;
     const manager = initMcpClientManager(overrides, workspacePath, workspaceTrusted);
-    // Initial connect — fire and forget; failures are recorded per-server, not thrown.
-    manager.refresh()
+    // Trust changes and file edits both flow through reevaluate()'s single reconciler
+    // below, which keeps an already-running manager's trust flag and config in sync —
+    // no separate trust listener needed here.
+    return manager.refresh()
         .then(() => manager.pruneOrphanOverrides())
         .then(() => pushMcpUpdate(manager))
         .catch(err => console.warn('[mcp] Initial refresh failed:', err));
-    // React to workspace trust being granted mid-session — workspace-scope
-    // servers come online without a window reload.
-    mcpTrustDisposable = vscodeWorkspace.onDidGrantWorkspaceTrust(() => {
-        manager.setWorkspaceTrusted(true).then(() => pushMcpUpdate(manager)).catch(err => console.warn('[mcp] Trust-grant refresh failed:', err));
-    });
 }
 
 async function teardownMcp(): Promise<void> {
-    if (mcpTrustDisposable) {
-        try { mcpTrustDisposable.dispose(); } catch { /* ignore */ }
-        mcpTrustDisposable = null;
-    }
     await disposeMcpClientManager();
     try {
         notifyMcpServersChanged([]);
@@ -404,10 +397,15 @@ function activateMcp(): void {
             const existing = getMcpClientManager();
             if (enabled) {
                 if (existing) {
-                    await existing.refresh().then(() => pushMcpUpdate(existing))
+                    // Sync the trust flag first (a cheap no-op if it hasn't changed — see
+                    // McpClientManager.setWorkspaceTrusted), then always refresh so a plain
+                    // file edit still picks up, regardless of what triggered this reconcile.
+                    await existing.setWorkspaceTrusted(vscodeWorkspace.isTrusted)
+                        .then(() => existing.refresh())
+                        .then(() => pushMcpUpdate(existing))
                         .catch(err => console.warn('[mcp] Watch-triggered refresh failed:', err));
                 } else {
-                    setupMcp();
+                    await setupMcp();
                 }
             } else if (existing) {
                 await teardownMcp();

--- a/packages/ballerina-extension/src/features/ai/activator.ts
+++ b/packages/ballerina-extension/src/features/ai/activator.ts
@@ -41,7 +41,16 @@ import { resolveProjectPath } from '../../utils/project-utils';
 import { MESSAGES } from '../project';
 import { AICommandConfig } from './executors/base/AICommandExecutor';
 import { AgentExecutor } from './agent/AgentExecutor';
-import { initMcpClientManager, disposeMcpClientManager, watchMcpConfig, getMcpClientManager, type EnabledOverrideStore } from './agent/mcp';
+import {
+    initMcpClientManager,
+    disposeMcpClientManager,
+    watchMcpConfig,
+    watchProjectMcpConfigPresence,
+    getMcpClientManager,
+    isMcpToolsEnabled,
+    MCP_ENABLE_SETTING_KEY,
+    type EnabledOverrideStore
+} from './agent/mcp';
 import { registerAgentsMdWatcher } from './agent/agents-md';
 import { resolveProjectRootPath } from './agent';
 import { extension } from '../../BalExtensionContext';
@@ -264,14 +273,12 @@ export function activateAIFeatures(ballerinaExternalInstance: BallerinaExtension
     });
 }
 
-const MCP_ENABLE_SETTING = 'copilot.enableMcpTools';
-
 let mcpWatchDisposer: (() => void) | null = null;
 let mcpTrustDisposable: { dispose(): void } | null = null;
 
-// MCP runs only when the user enabled it.
+// MCP runs when the user enabled it, or when the project carries a `.mcp.json`.
 function isMcpEnabled(): boolean {
-    return vscodeWorkspace.getConfiguration('ballerina').get<boolean>(MCP_ENABLE_SETTING, false);
+    return isMcpToolsEnabled(resolveProjectRootPath() || undefined);
 }
 
 function setupMcp(): void {
@@ -398,19 +405,31 @@ function activateMcp(): void {
     if (isMcpEnabled()) {
         setupMcp();
     }
-    const disposable = vscodeWorkspace.onDidChangeConfiguration((e) => {
-        const enableChanged = e.affectsConfiguration(`ballerina.${MCP_ENABLE_SETTING}`);
-        if (!enableChanged) {
-            return;
-        }
+    const reevaluate = () => {
+        const enabled = isMcpEnabled();
         queueMcpLifecycleTransition(async () => {
-            if (isMcpEnabled()) {
+            if (enabled) {
                 setupMcp();
             } else {
                 await teardownMcp();
             }
         });
-        sendConfigChangeNotification('mcpToolsEnabled', isMcpEnabled());
-    });
-    extension.context?.subscriptions.push(disposable);
+        sendConfigChangeNotification('mcpToolsEnabled', enabled);
+    };
+    const subscriptions: vscode.Disposable[] = [
+        vscodeWorkspace.onDidChangeConfiguration((e) => {
+            if (e.affectsConfiguration(MCP_ENABLE_SETTING_KEY)) {
+                reevaluate();
+            }
+        }),
+        // Trust unlocks the project `.mcp.json`, which may be the only opt-in signal.
+        vscodeWorkspace.onDidGrantWorkspaceTrust(() => reevaluate()),
+    ];
+    // A `.mcp.json` appearing or being removed flips the implicit opt-in, so it has to
+    // be watched even while MCP is off and no manager (with its own watcher) exists.
+    const projectRoot = resolveProjectRootPath();
+    if (projectRoot) {
+        subscriptions.push(watchProjectMcpConfigPresence(projectRoot, reevaluate));
+    }
+    extension.context?.subscriptions.push(...subscriptions);
 }

--- a/packages/ballerina-extension/src/features/ai/activator.ts
+++ b/packages/ballerina-extension/src/features/ai/activator.ts
@@ -45,11 +45,11 @@ import {
     initMcpClientManager,
     disposeMcpClientManager,
     watchMcpConfig,
-    watchProjectMcpConfigPresence,
     getMcpClientManager,
     isMcpToolsEnabled,
     MCP_ENABLE_SETTING_KEY,
-    type EnabledOverrideStore
+    type EnabledOverrideStore,
+    type McpClientManager
 } from './agent/mcp';
 import { registerAgentsMdWatcher } from './agent/agents-md';
 import { resolveProjectRootPath } from './agent';
@@ -273,12 +273,24 @@ export function activateAIFeatures(ballerinaExternalInstance: BallerinaExtension
     });
 }
 
-let mcpWatchDisposer: (() => void) | null = null;
 let mcpTrustDisposable: { dispose(): void } | null = null;
 
 // MCP runs when the user enabled it, or when the project carries a `.mcp.json`.
 function isMcpEnabled(): boolean {
     return isMcpToolsEnabled(resolveProjectRootPath() || undefined);
+}
+
+/** Pushes the given manager's current state to the webview, unless it's since been torn down. */
+function pushMcpUpdate(manager: McpClientManager): void {
+    if (getMcpClientManager() !== manager) {
+        return;
+    }
+    try {
+        notifyMcpServersChanged(manager.listServers());
+        notifyMcpLoadErrorsChanged(manager.getLoadErrors());
+    } catch (err) {
+        console.warn('[mcp] Failed to push servers-changed notification:', err);
+    }
 }
 
 function setupMcp(): void {
@@ -344,42 +356,19 @@ function setupMcp(): void {
     const workspacePath = resolveProjectRootPath() || undefined;
     const workspaceTrusted = vscodeWorkspace.isTrusted;
     const manager = initMcpClientManager(overrides, workspacePath, workspaceTrusted);
-    const pushUpdate = () => {
-        // A refresh in flight at teardown could otherwise re-publish this disposed
-        // manager's state after the empty disabled state was already sent.
-        if (getMcpClientManager() !== manager) {
-            return;
-        }
-        try {
-            notifyMcpServersChanged(manager.listServers());
-            notifyMcpLoadErrorsChanged(manager.getLoadErrors());
-        } catch (err) {
-            console.warn('[mcp] Failed to push servers-changed notification:', err);
-        }
-    };
     // Initial connect — fire and forget; failures are recorded per-server, not thrown.
     manager.refresh()
         .then(() => manager.pruneOrphanOverrides())
-        .then(pushUpdate)
+        .then(() => pushMcpUpdate(manager))
         .catch(err => console.warn('[mcp] Initial refresh failed:', err));
-    // Project-tree .mcp.json is watched too; the watcher fires whether or not
-    // workspace trust has been granted, but loadMcpConfig will skip the file
-    // until trust + workspace path are both set.
-    mcpWatchDisposer = watchMcpConfig(workspacePath, () => {
-        manager.refresh().then(pushUpdate).catch(err => console.warn('[mcp] Watch-triggered refresh failed:', err));
-    });
     // React to workspace trust being granted mid-session — workspace-scope
     // servers come online without a window reload.
     mcpTrustDisposable = vscodeWorkspace.onDidGrantWorkspaceTrust(() => {
-        manager.setWorkspaceTrusted(true).then(pushUpdate).catch(err => console.warn('[mcp] Trust-grant refresh failed:', err));
+        manager.setWorkspaceTrusted(true).then(() => pushMcpUpdate(manager)).catch(err => console.warn('[mcp] Trust-grant refresh failed:', err));
     });
 }
 
 async function teardownMcp(): Promise<void> {
-    if (mcpWatchDisposer) {
-        try { mcpWatchDisposer(); } catch { /* ignore */ }
-        mcpWatchDisposer = null;
-    }
     if (mcpTrustDisposable) {
         try { mcpTrustDisposable.dispose(); } catch { /* ignore */ }
         mcpTrustDisposable = null;
@@ -405,12 +394,22 @@ function activateMcp(): void {
     if (isMcpEnabled()) {
         setupMcp();
     }
+    // Single reconciler for every trigger: a setting change, trust being granted, or a
+    // project-scope file being created/edited/deleted. Recomputes whether MCP should be
+    // running and, if it already is, opportunistically refreshes it (covers edits that
+    // don't flip the on/off decision — e.g. adding a server to an already-loaded file).
     const reevaluate = () => {
         const enabled = isMcpEnabled();
         queueMcpLifecycleTransition(async () => {
+            const existing = getMcpClientManager();
             if (enabled) {
-                setupMcp();
-            } else {
+                if (existing) {
+                    await existing.refresh().then(() => pushMcpUpdate(existing))
+                        .catch(err => console.warn('[mcp] Watch-triggered refresh failed:', err));
+                } else {
+                    setupMcp();
+                }
+            } else if (existing) {
                 await teardownMcp();
             }
         });
@@ -425,11 +424,10 @@ function activateMcp(): void {
         // Trust unlocks the project `.mcp.json`, which may be the only opt-in signal.
         vscodeWorkspace.onDidGrantWorkspaceTrust(() => reevaluate()),
     ];
-    // A `.mcp.json` appearing or being removed flips the implicit opt-in, so it has to
-    // be watched even while MCP is off and no manager (with its own watcher) exists.
-    const projectRoot = resolveProjectRootPath();
-    if (projectRoot) {
-        subscriptions.push(watchProjectMcpConfigPresence(projectRoot, reevaluate));
-    }
+    // One watcher covers the user-global file plus every project-scope path (primary and
+    // additional), whether or not MCP is currently on — a file appearing/disappearing may
+    // flip the implicit opt-in, and an edit to an already-loaded file needs a refresh.
+    const disposeMcpWatcher = watchMcpConfig(resolveProjectRootPath() || undefined, reevaluate);
+    subscriptions.push({ dispose: disposeMcpWatcher });
     extension.context?.subscriptions.push(...subscriptions);
 }

--- a/packages/ballerina-extension/src/features/ai/agent/mcp/configLoader.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/mcp/configLoader.ts
@@ -38,6 +38,18 @@ export function workspaceMcpConfigPath(workspacePath: string): string {
     return path.join(path.resolve(workspacePath), PROJECT_MCP_FILENAME);
 }
 
+/** Presence of the project-tree `.mcp.json` — the implicit opt-in signal for MCP tool support. */
+export function hasProjectMcpConfig(workspacePath?: string): boolean {
+    if (!workspacePath) {
+        return false;
+    }
+    try {
+        return fs.existsSync(workspaceMcpConfigPath(workspacePath));
+    } catch {
+        return false;
+    }
+}
+
 /** Returns the on-disk path for the given scope. Throws if scope=workspace without a workspace path. */
 export function configFilePath(scope: McpScope, workspacePath?: string): string {
     if (scope === "user") {
@@ -302,4 +314,17 @@ export function watchMcpConfig(workspacePath: string | undefined, onChange: () =
     return () => {
         for (const d of disposers) { d(); }
     };
+}
+
+/**
+ * Watches only for the project `.mcp.json` appearing or disappearing (edits are
+ * ignored). Kept separate from `watchMcpConfig` because this one has to run even
+ * while MCP is off — the file's presence is what flips the implicit opt-in.
+ */
+export function watchProjectMcpConfigPresence(workspacePath: string, onChange: () => void): vscode.Disposable {
+    const pattern = new vscode.RelativePattern(vscode.Uri.file(workspacePath), PROJECT_MCP_FILENAME);
+    const watcher = vscode.workspace.createFileSystemWatcher(pattern, false, true, false);
+    watcher.onDidCreate(() => onChange());
+    watcher.onDidDelete(() => onChange());
+    return watcher;
 }

--- a/packages/ballerina-extension/src/features/ai/agent/mcp/configLoader.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/mcp/configLoader.ts
@@ -197,7 +197,7 @@ export function loadMcpConfig(workspacePath?: string, allowWorkspace: boolean = 
         for (const filePath of projectPaths) {
             const read = readConfigFile(filePath);
             if (read.error) {
-                workspaceErrors.push(read.error);
+                workspaceErrors.push(`${filePath}: ${read.error}`);
             }
             const fresh = normaliseEntries("workspace", read.file).filter(e => !claimedNames.has(e.name));
             fresh.forEach(e => claimedNames.add(e.name));
@@ -336,7 +336,6 @@ export function watchMcpConfig(workspacePath: string | undefined, onChange: () =
     if (workspacePath) {
         for (const relative of projectMcpRelativePatterns()) {
             const filePath = path.join(path.resolve(workspacePath), relative);
-            try { fs.mkdirSync(path.dirname(filePath), { recursive: true }); } catch { /* ignore */ }
             try {
                 const pattern = new vscode.RelativePattern(vscode.Uri.file(workspacePath), relative);
                 const watcher = vscode.workspace.createFileSystemWatcher(pattern);

--- a/packages/ballerina-extension/src/features/ai/agent/mcp/configLoader.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/mcp/configLoader.ts
@@ -25,26 +25,41 @@ import { McpConfigFile, McpScope, McpServerConfig } from "./types";
 
 const COPILOT_ROOT = path.join(os.homedir(), ".ballerina", "copilot");
 export const USER_MCP_CONFIG_PATH = path.join(COPILOT_ROOT, "mcp.json");
-/** Bare-name `.mcp.json` matches Claude Code / Cline convention for tool-agnostic config. */
+/** Bare-name `.mcp.json` matches Claude Code / Cline convention for tool-agnostic config. This is the
+ *  one project-scope file the UI writes to — every other project-scope path is read-only. */
 export const PROJECT_MCP_FILENAME = ".mcp.json";
+/** Extra project-scope locations, read-only and merged into the same "workspace" scope as
+ *  `.mcp.json`. Append future locations here — nothing else needs to change to support one. */
+export const ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS: readonly string[] = [
+    path.join(".wso2", "mcp.json"),
+];
 
 export const EMPTY_CONFIG: McpConfigFile = { mcpServers: {} };
 
 /**
  * Project-scope MCP config lives in the user's workspace tree (versioned with
  * the repo), at `<workspacePath>/.mcp.json`. Standard adopted from Claude Code.
+ * This is the sole read+write target — the UI's add/edit/delete and "edit raw
+ * JSON" affordances always resolve here regardless of what else is being read.
  */
 export function workspaceMcpConfigPath(workspacePath: string): string {
     return path.join(path.resolve(workspacePath), PROJECT_MCP_FILENAME);
 }
 
-/** Presence of the project-tree `.mcp.json` — the implicit opt-in signal for MCP tool support. */
+/** Absolute paths for `ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS`, resolved against a workspace. */
+export function workspaceAdditionalMcpConfigPaths(workspacePath: string): string[] {
+    const root = path.resolve(workspacePath);
+    return ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS.map(relative => path.join(root, relative));
+}
+
+/** Presence of the primary file or any additional one — the implicit opt-in signal for MCP tool support. */
 export function hasProjectMcpConfig(workspacePath?: string): boolean {
     if (!workspacePath) {
         return false;
     }
     try {
-        return fs.existsSync(workspaceMcpConfigPath(workspacePath));
+        const paths = [workspaceMcpConfigPath(workspacePath), ...workspaceAdditionalMcpConfigPaths(workspacePath)];
+        return paths.some(p => fs.existsSync(p));
     } catch {
         return false;
     }
@@ -140,12 +155,18 @@ function normaliseEntries(scope: McpScope, file: McpConfigFile): Array<{ name: s
 
 /**
  * Reads the user-global mcp.json plus, when both a workspace path is provided
- * and `allowWorkspace` is true, the project-tree `<workspacePath>/.mcp.json`.
- * Returns a flat list tagged with scope. The two scopes are independent:
+ * and `allowWorkspace` is true, every project-scope file — `.mcp.json` plus each
+ * of `ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS` — merged into one "workspace" scope.
+ * Returns a flat list tagged with scope. The two top-level scopes are independent:
  * `{user, foo}` and `{workspace, foo}` can coexist.
  *
+ * Within "workspace", earlier files win: `.mcp.json` is read first and always
+ * keeps its entries; each additional path is then folded in, in list order,
+ * dropping any name already claimed by a file read before it — so every scope
+ * keeps exactly one entry per name no matter how many project-scope files exist.
+ *
  * `allowWorkspace` is the workspace-trust gate — callers pass `false` for
- * untrusted workspaces so arbitrary `command` entries in a cloned `.mcp.json`
+ * untrusted workspaces so arbitrary `command` entries in a cloned project file
  * don't auto-spawn processes.
  */
 export interface McpLoadErrors {
@@ -169,12 +190,22 @@ export function loadMcpConfig(workspacePath?: string, allowWorkspace: boolean = 
     entries.push(...normaliseEntries("user", userRead.file));
 
     if (workspacePath && allowWorkspace) {
-        const wsFile = workspaceMcpConfigPath(workspacePath);
-        const wsRead = readConfigFile(wsFile);
-        if (wsRead.error) {
-            errors.workspace = wsRead.error;
+        const projectPaths = [workspaceMcpConfigPath(workspacePath), ...workspaceAdditionalMcpConfigPaths(workspacePath)];
+        const workspaceErrors: string[] = [];
+        const claimedNames = new Set<string>();
+
+        for (const filePath of projectPaths) {
+            const read = readConfigFile(filePath);
+            if (read.error) {
+                workspaceErrors.push(read.error);
+            }
+            const fresh = normaliseEntries("workspace", read.file).filter(e => !claimedNames.has(e.name));
+            fresh.forEach(e => claimedNames.add(e.name));
+            entries.push(...fresh);
         }
-        entries.push(...normaliseEntries("workspace", wsRead.file));
+        if (workspaceErrors.length) {
+            errors.workspace = workspaceErrors.join("; ");
+        }
     }
     return { entries, errors };
 }
@@ -272,6 +303,11 @@ export function deleteMcpServer(name: string, scope: McpScope = "user", workspac
     }
 }
 
+/** Relative glob for every project-scope file — the primary plus each additional path. */
+function projectMcpRelativePatterns(): string[] {
+    return [PROJECT_MCP_FILENAME, ...ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS];
+}
+
 /**
  * Subscribes to config file changes. Returns a single disposer.
  *
@@ -279,8 +315,9 @@ export function deleteMcpServer(name: string, scope: McpScope = "user", workspac
  *   workspace, so the editor's `createFileSystemWatcher` can't see it. We use
  *   `fs.watchFile` polling — reliable across atomic-save (rename) patterns
  *   that `fs.watch` would miss.
- * - **Project-tree file** (`<workspace>/.mcp.json`) lives inside the open
- *   workspace, so we use the editor's OS-event-based watcher — no polling.
+ * - **Project-tree files** (`<workspace>/.mcp.json` and each additional path)
+ *   live inside the open workspace, so each gets its own editor OS-event-based
+ *   watcher — no polling.
  */
 export function watchMcpConfig(workspacePath: string | undefined, onChange: () => void): () => void {
     if (!fs.existsSync(COPILOT_ROOT)) {
@@ -294,20 +331,21 @@ export function watchMcpConfig(workspacePath: string | undefined, onChange: () =
     ];
 
     if (workspacePath) {
-        const wsFile = workspaceMcpConfigPath(workspacePath);
-        const wsDir = path.dirname(wsFile);
-        try { fs.mkdirSync(wsDir, { recursive: true }); } catch { /* ignore */ }
-        try {
-            const pattern = new vscode.RelativePattern(vscode.Uri.file(workspacePath), PROJECT_MCP_FILENAME);
-            const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-            watcher.onDidChange(listener);
-            watcher.onDidCreate(listener);
-            watcher.onDidDelete(listener);
-            disposers.push(() => watcher.dispose());
-        } catch (err) {
-            console.warn("[mcp] Failed to set up workspace .mcp.json watcher, falling back to polling:", err);
-            fs.watchFile(wsFile, { interval: 3000 }, listener);
-            disposers.push(() => { try { fs.unwatchFile(wsFile, listener); } catch { /* ignore */ } });
+        for (const relative of projectMcpRelativePatterns()) {
+            const filePath = path.join(path.resolve(workspacePath), relative);
+            try { fs.mkdirSync(path.dirname(filePath), { recursive: true }); } catch { /* ignore */ }
+            try {
+                const pattern = new vscode.RelativePattern(vscode.Uri.file(workspacePath), relative);
+                const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+                watcher.onDidChange(listener);
+                watcher.onDidCreate(listener);
+                watcher.onDidDelete(listener);
+                disposers.push(() => watcher.dispose());
+            } catch (err) {
+                console.warn(`[mcp] Failed to set up workspace '${relative}' watcher, falling back to polling:`, err);
+                fs.watchFile(filePath, { interval: 3000 }, listener);
+                disposers.push(() => { try { fs.unwatchFile(filePath, listener); } catch { /* ignore */ } });
+            }
         }
     }
 
@@ -317,14 +355,18 @@ export function watchMcpConfig(workspacePath: string | undefined, onChange: () =
 }
 
 /**
- * Watches only for the project `.mcp.json` appearing or disappearing (edits are
- * ignored). Kept separate from `watchMcpConfig` because this one has to run even
- * while MCP is off — the file's presence is what flips the implicit opt-in.
+ * Watches only for a project-scope file appearing or disappearing (edits are
+ * ignored), across the primary path and every additional one. Kept separate from
+ * `watchMcpConfig` because this one has to run even while MCP is off — a file's
+ * presence is what flips the implicit opt-in.
  */
 export function watchProjectMcpConfigPresence(workspacePath: string, onChange: () => void): vscode.Disposable {
-    const pattern = new vscode.RelativePattern(vscode.Uri.file(workspacePath), PROJECT_MCP_FILENAME);
-    const watcher = vscode.workspace.createFileSystemWatcher(pattern, false, true, false);
-    watcher.onDidCreate(() => onChange());
-    watcher.onDidDelete(() => onChange());
-    return watcher;
+    const watchers = projectMcpRelativePatterns().map(relative => {
+        const pattern = new vscode.RelativePattern(vscode.Uri.file(workspacePath), relative);
+        const watcher = vscode.workspace.createFileSystemWatcher(pattern, false, true, false);
+        watcher.onDidCreate(() => onChange());
+        watcher.onDidDelete(() => onChange());
+        return watcher;
+    });
+    return { dispose: () => watchers.forEach(w => w.dispose()) };
 }

--- a/packages/ballerina-extension/src/features/ai/agent/mcp/configLoader.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/mcp/configLoader.ts
@@ -309,7 +309,10 @@ function projectMcpRelativePatterns(): string[] {
 }
 
 /**
- * Subscribes to config file changes. Returns a single disposer.
+ * Subscribes to every config file's change/create/delete events. Returns a single disposer.
+ * This is the one watcher over MCP config — callers use the same `onChange` for both
+ * "does MCP need to be enabled/disabled" and "refresh an already-running manager", since
+ * a single file event can mean either depending on current state.
  *
  * - **User-global file** (`~/.ballerina/copilot/mcp.json`) lives outside any
  *   workspace, so the editor's `createFileSystemWatcher` can't see it. We use
@@ -352,21 +355,4 @@ export function watchMcpConfig(workspacePath: string | undefined, onChange: () =
     return () => {
         for (const d of disposers) { d(); }
     };
-}
-
-/**
- * Watches only for a project-scope file appearing or disappearing (edits are
- * ignored), across the primary path and every additional one. Kept separate from
- * `watchMcpConfig` because this one has to run even while MCP is off — a file's
- * presence is what flips the implicit opt-in.
- */
-export function watchProjectMcpConfigPresence(workspacePath: string, onChange: () => void): vscode.Disposable {
-    const watchers = projectMcpRelativePatterns().map(relative => {
-        const pattern = new vscode.RelativePattern(vscode.Uri.file(workspacePath), relative);
-        const watcher = vscode.workspace.createFileSystemWatcher(pattern, false, true, false);
-        watcher.onDidCreate(() => onChange());
-        watcher.onDidDelete(() => onChange());
-        return watcher;
-    });
-    return { dispose: () => watchers.forEach(w => w.dispose()) };
 }

--- a/packages/ballerina-extension/src/features/ai/agent/mcp/enablement.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/mcp/enablement.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as vscode from "vscode";
+
+import { hasProjectMcpConfig } from "./configLoader";
+
+/** Key within the `ballerina` configuration section. */
+export const MCP_ENABLE_SETTING = "copilot.enableMcpTools";
+/** Fully qualified key, for `affectsConfiguration` checks. */
+export const MCP_ENABLE_SETTING_KEY = `ballerina.${MCP_ENABLE_SETTING}`;
+
+function readExplicitEnableSetting(): boolean | undefined {
+    const inspected = vscode.workspace.getConfiguration("ballerina").inspect<boolean>(MCP_ENABLE_SETTING);
+    return inspected?.workspaceFolderValue ?? inspected?.workspaceValue ?? inspected?.globalValue;
+}
+
+/**
+ * MCP tool support runs when the user turned it on, or — with the setting never
+ * touched — when the project ships a `.mcp.json`. An explicit setting always
+ * wins, so an opt-out survives that file being present.
+ *
+ * The implicit path requires workspace trust: an untrusted project's `.mcp.json`
+ * is never read, so treating it as an opt-in would enable nothing.
+ */
+export function isMcpToolsEnabled(workspacePath?: string): boolean {
+    const explicit = readExplicitEnableSetting();
+    if (typeof explicit === "boolean") {
+        return explicit;
+    }
+    return vscode.workspace.isTrusted && hasProjectMcpConfig(workspacePath);
+}

--- a/packages/ballerina-extension/src/features/ai/agent/mcp/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/mcp/index.ts
@@ -28,7 +28,6 @@ export {
     hasProjectMcpConfig,
     configFilePath,
     watchMcpConfig,
-    watchProjectMcpConfigPresence,
     writeMcpServer,
     updateMcpServer,
     deleteMcpServer,

--- a/packages/ballerina-extension/src/features/ai/agent/mcp/index.ts
+++ b/packages/ballerina-extension/src/features/ai/agent/mcp/index.ts
@@ -23,13 +23,17 @@ export {
     ensureMcpConfigFileExists,
     loadMcpConfig,
     USER_MCP_CONFIG_PATH,
+    PROJECT_MCP_FILENAME,
     workspaceMcpConfigPath,
+    hasProjectMcpConfig,
     configFilePath,
     watchMcpConfig,
+    watchProjectMcpConfigPresence,
     writeMcpServer,
     updateMcpServer,
     deleteMcpServer,
 } from "./configLoader";
+export { isMcpToolsEnabled, MCP_ENABLE_SETTING, MCP_ENABLE_SETTING_KEY } from "./enablement";
 export {
     McpClientManager,
     initMcpClientManager,

--- a/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -96,7 +96,7 @@ import {
     openOrCreateAgentsMd as openOrCreateAgentsMdImpl,
 } from "../../features/ai/agent/agents-md";
 import { ConfigurationTarget } from "vscode";
-import { getMcpClientManager, ensureMcpConfigFileExists, writeMcpServer, updateMcpServer, deleteMcpServer } from "../../features/ai/agent/mcp";
+import { getMcpClientManager, ensureMcpConfigFileExists, writeMcpServer, updateMcpServer, deleteMcpServer, isMcpToolsEnabled, MCP_ENABLE_SETTING } from "../../features/ai/agent/mcp";
 import { notifyMcpServersChanged, notifyMcpLoadErrorsChanged } from "../../RPCLayer";
 import * as os from "os";
 import * as fs from 'fs';
@@ -1449,7 +1449,7 @@ User reverted the last made changes. The files have been restored to the state b
     }
 
     async getMcpToolsEnabled(): Promise<boolean> {
-        return workspace.getConfiguration('ballerina').get<boolean>('copilot.enableMcpTools', false);
+        return isMcpToolsEnabled(resolveProjectRootPath() || undefined);
     }
 
 
@@ -1558,7 +1558,7 @@ User reverted the last made changes. The files have been restored to the state b
 
     async setMcpToolsEnabled(params: SetMcpToolsEnabledRequest): Promise<void> {
         await workspace.getConfiguration('ballerina')
-            .update('copilot.enableMcpTools', !!params?.enabled, ConfigurationTarget.Global);
+            .update(MCP_ENABLE_SETTING, !!params?.enabled, ConfigurationTarget.Global);
     }
 
     async getAgentsMdFileInfo(): Promise<AgentsMdFileInfoDTO> {

--- a/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
+++ b/packages/ballerina-extension/src/test-support/__mocks__/vscode.ts
@@ -28,9 +28,11 @@ export const window = {
 };
 
 export const workspace = {
-    getConfiguration: () => ({ get: () => undefined, update: () => Promise.resolve() }),
+    getConfiguration: () => ({ get: () => undefined, update: () => Promise.resolve(), inspect: () => undefined }),
     workspaceFolders: [] as unknown[],
+    isTrusted: true,
     onDidChangeConfiguration: () => ({ dispose() {} }),
+    onDidGrantWorkspaceTrust: () => ({ dispose() {} }),
 };
 
 export const commands = {

--- a/packages/ballerina-extension/src/test-support/mcpConfigLoader.test.ts
+++ b/packages/ballerina-extension/src/test-support/mcpConfigLoader.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+    loadMcpConfig,
+    PROJECT_MCP_FILENAME,
+    ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS,
+} from "../features/ai/agent/mcp/configLoader";
+
+let projectRoot: string;
+
+beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-configloader-"));
+});
+
+afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+function writePrimary(mcpServers: Record<string, unknown>): void {
+    fs.writeFileSync(path.join(projectRoot, PROJECT_MCP_FILENAME), JSON.stringify({ mcpServers }), "utf8");
+}
+
+function writeAdditionalRaw(content: string): void {
+    const filePath = path.join(projectRoot, ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS[0]);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, "utf8");
+}
+
+function writeAdditional(mcpServers: Record<string, unknown>): void {
+    writeAdditionalRaw(JSON.stringify({ mcpServers }));
+}
+
+function workspaceEntries(workspacePath: string) {
+    return loadMcpConfig(workspacePath, true).entries.filter(e => e.scope === "workspace");
+}
+
+describe("loadMcpConfig — project-scope multi-path merge", () => {
+    it("reads entries from only the additional path when the primary file is absent", () => {
+        writeAdditional({ fromWso2: { command: "wso2-server" } });
+        const entries = workspaceEntries(projectRoot);
+        expect(entries.map(e => e.name)).toEqual(["fromWso2"]);
+    });
+
+    it("unions distinctly named entries from the primary and additional files", () => {
+        writePrimary({ fromPrimary: { command: "primary-server" } });
+        writeAdditional({ fromWso2: { command: "wso2-server" } });
+        const names = workspaceEntries(projectRoot).map(e => e.name).sort();
+        expect(names).toEqual(["fromPrimary", "fromWso2"]);
+    });
+
+    it("lets the primary file win a same-named collision with an additional file", () => {
+        writePrimary({ shared: { command: "primary-wins" } });
+        writeAdditional({ shared: { command: "wso2-loses" } });
+        const entries = workspaceEntries(projectRoot);
+        expect(entries).toHaveLength(1);
+        expect((entries[0].config as { command: string }).command).toBe("primary-wins");
+    });
+
+    it("still loads the primary's entries when the additional file is malformed", () => {
+        writePrimary({ fromPrimary: { command: "primary-server" } });
+        writeAdditionalRaw("{ not valid json");
+        const { entries, errors } = loadMcpConfig(projectRoot, true);
+        expect(entries.filter(e => e.scope === "workspace").map(e => e.name)).toEqual(["fromPrimary"]);
+        expect(errors.workspace).toContain("Invalid JSON");
+    });
+
+    it("returns no workspace entries or errors with no project files at all", () => {
+        const { entries, errors } = loadMcpConfig(projectRoot, true);
+        expect(entries.filter(e => e.scope === "workspace")).toEqual([]);
+        expect(errors.workspace).toBeUndefined();
+    });
+});

--- a/packages/ballerina-extension/src/test-support/mcpEnablement.test.ts
+++ b/packages/ballerina-extension/src/test-support/mcpEnablement.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { isMcpToolsEnabled } from "../features/ai/agent/mcp/enablement";
+import { PROJECT_MCP_FILENAME } from "../features/ai/agent/mcp/configLoader";
+
+const ws = vscode.workspace as any;
+const originalGetConfiguration = ws.getConfiguration;
+const originalIsTrusted = ws.isTrusted;
+
+function stubEnableSetting(explicit: boolean | undefined): void {
+    ws.getConfiguration = () => ({
+        get: () => explicit,
+        update: () => Promise.resolve(),
+        inspect: () => ({ defaultValue: false, globalValue: explicit }),
+    });
+}
+
+let projectRoot: string;
+
+beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-enablement-"));
+    ws.isTrusted = true;
+});
+
+afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+    ws.getConfiguration = originalGetConfiguration;
+    ws.isTrusted = originalIsTrusted;
+});
+
+function writeProjectConfig(): void {
+    fs.writeFileSync(path.join(projectRoot, PROJECT_MCP_FILENAME), JSON.stringify({ mcpServers: {} }), "utf8");
+}
+
+describe("isMcpToolsEnabled", () => {
+    it("turns on for a project carrying .mcp.json while the setting is untouched", () => {
+        stubEnableSetting(undefined);
+        writeProjectConfig();
+        expect(isMcpToolsEnabled(projectRoot)).toBe(true);
+    });
+
+    it("stays off without a project .mcp.json", () => {
+        stubEnableSetting(undefined);
+        expect(isMcpToolsEnabled(projectRoot)).toBe(false);
+    });
+
+    it("honours an explicit opt-out even when .mcp.json exists", () => {
+        stubEnableSetting(false);
+        writeProjectConfig();
+        expect(isMcpToolsEnabled(projectRoot)).toBe(false);
+    });
+
+    it("honours an explicit opt-in without any .mcp.json", () => {
+        stubEnableSetting(true);
+        expect(isMcpToolsEnabled(projectRoot)).toBe(true);
+    });
+
+    it("ignores .mcp.json in an untrusted workspace", () => {
+        stubEnableSetting(undefined);
+        writeProjectConfig();
+        ws.isTrusted = false;
+        expect(isMcpToolsEnabled(projectRoot)).toBe(false);
+    });
+
+    it("stays off with no project open", () => {
+        stubEnableSetting(undefined);
+        expect(isMcpToolsEnabled(undefined)).toBe(false);
+    });
+});

--- a/packages/ballerina-extension/src/test-support/mcpEnablement.test.ts
+++ b/packages/ballerina-extension/src/test-support/mcpEnablement.test.ts
@@ -22,7 +22,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { isMcpToolsEnabled } from "../features/ai/agent/mcp/enablement";
-import { PROJECT_MCP_FILENAME } from "../features/ai/agent/mcp/configLoader";
+import { PROJECT_MCP_FILENAME, ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS } from "../features/ai/agent/mcp/configLoader";
 
 const ws = vscode.workspace as any;
 const originalGetConfiguration = ws.getConfiguration;
@@ -51,6 +51,13 @@ afterEach(() => {
 
 function writeProjectConfig(): void {
     fs.writeFileSync(path.join(projectRoot, PROJECT_MCP_FILENAME), JSON.stringify({ mcpServers: {} }), "utf8");
+}
+
+function writeAdditionalProjectConfig(): void {
+    const relative = ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS[0];
+    const filePath = path.join(projectRoot, relative);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify({ mcpServers: {} }), "utf8");
 }
 
 describe("isMcpToolsEnabled", () => {
@@ -86,5 +93,11 @@ describe("isMcpToolsEnabled", () => {
     it("stays off with no project open", () => {
         stubEnableSetting(undefined);
         expect(isMcpToolsEnabled(undefined)).toBe(false);
+    });
+
+    it("turns on for a project carrying only an additional config path (e.g. .wso2/mcp.json)", () => {
+        stubEnableSetting(undefined);
+        writeAdditionalProjectConfig();
+        expect(isMcpToolsEnabled(projectRoot)).toBe(true);
     });
 });


### PR DESCRIPTION
fixes https://github.com/wso2/product-integrator/issues/1937
fixes https://github.com/wso2/product-integrator/issues/1981

- Auto-enable MCP tool support when a trusted project ships a `.mcp.json` — an untouched `ballerina.copilot.enableMcpTools` setting now falls back to file presence; an explicit setting still wins either way
- Also read project-scope MCP servers from `.wso2/mcp.json` via a generic, appendable `ADDITIONAL_PROJECT_MCP_RELATIVE_PATHS` list — `.mcp.json` stays the sole file the UI reads and writes to; additional paths are read-only and merge into the same "workspace" scope, with earlier files winning name collisions
- Consolidate the two separate file watchers (one for the enable/disable decision, one for refreshing an already-running manager) into the single watcher `activateMcp()` already owns, removing the redundant `watchProjectMcpConfigPresence`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Auto-enable MCP tools for trusted projects that contain `.mcp.json`, unless `ballerina.copilot.enableMcpTools` has an explicit value.
- Load and merge additional read-only project configurations, including `.wso2/mcp.json`.
- Preserve earlier configuration paths when server names conflict.
- Consolidate MCP file watching, enablement checks, trust changes, and manager refresh into one lifecycle reconciler.
- Add coverage for configuration loading and MCP enablement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->