### PR TITLE
Fix duplicate `designModelService/projectInfo` calls and missing-scheme LSP notification errors

### DIFF
--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -72,6 +72,10 @@ export let history: History;
 export let undoRedoManager: IUndoRedoManager;
 let pendingProjectRootUpdateResolvers: Array<() => void> = [];
 let scaffoldPromptTriggered = false;
+// Single-flight: concurrent REFRESH_PROJECT_INFO triggers (e.g. addProjectToWorkspace and a
+// pending-artifact resolution firing close together) would otherwise each fetch project info
+// independently. Share one in-flight fetch instead of one per trigger.
+let projectInfoRefreshInFlight: Promise<void> | null = null;
 
 const stateMachine = createMachine<MachineContext>(
     {
@@ -126,27 +130,39 @@ const stateMachine = createMachine<MachineContext>(
             REFRESH_PROJECT_INFO: {
                 actions: [
                     async (context, event) => {
-                        try {
-                            const projectPath = context.workspacePath || context.projectPath;
-                            if (!projectPath) {
-                                console.warn("No project path available for refreshing project info");
-                                return;
-                            }
-
-                            // Fetch updated project info from language server
-                            const projectInfo = await context.langClient.getProjectInfo({ projectPath });
-
-                            // Update context with new project info. `silent` is carried
-                            // through so a caller that has already navigated somewhere
-                            // deliberate isn't bounced to the workspace overview below.
-                            stateService.send({
-                                type: 'UPDATE_PROJECT_INFO',
-                                projectInfo,
-                                silent: event.silent
-                            });
-                        } catch (error) {
-                            console.error("Error refreshing project info:", error);
+                        // Single-flight: a burst of REFRESH_PROJECT_INFO triggers piling up
+                        // while a fetch is already in progress share that fetch's result
+                        // instead of each firing their own `getProjectInfo` request.
+                        if (projectInfoRefreshInFlight) {
+                            await projectInfoRefreshInFlight;
+                            return;
                         }
+                        projectInfoRefreshInFlight = (async () => {
+                            try {
+                                const projectPath = context.workspacePath || context.projectPath;
+                                if (!projectPath) {
+                                    console.warn("No project path available for refreshing project info");
+                                    return;
+                                }
+
+                                // Fetch updated project info from language server
+                                const projectInfo = await context.langClient.getProjectInfo({ projectPath });
+
+                                // Update context with new project info. `silent` is carried
+                                // through so a caller that has already navigated somewhere
+                                // deliberate isn't bounced to the workspace overview below.
+                                stateService.send({
+                                    type: 'UPDATE_PROJECT_INFO',
+                                    projectInfo,
+                                    silent: event.silent
+                                });
+                            } catch (error) {
+                                console.error("Error refreshing project info:", error);
+                            } finally {
+                                projectInfoRefreshInFlight = null;
+                            }
+                        })();
+                        await projectInfoRefreshInFlight;
                     }
                 ]
             },

--- a/packages/ballerina-extension/src/utils/modification.ts
+++ b/packages/ballerina-extension/src/utils/modification.ts
@@ -82,8 +82,9 @@ export function writeBallerinaFileDidOpenTemp(filePath: string, content: string)
     }
     const contentWithNewline = ensureTrailingNewline(content);
     writeFileSync(filePath, contentWithNewline);
+    const fileUri = Uri.file(filePath).toString();
     StateMachine.langClient().didChange({
-        textDocument: { uri: filePath, version: 1 },
+        textDocument: { uri: fileUri, version: 1 },
         contentChanges: [
             {
                 text: contentWithNewline,
@@ -92,7 +93,7 @@ export function writeBallerinaFileDidOpenTemp(filePath: string, content: string)
     });
     StateMachine.langClient().didOpen({
         textDocument: {
-            uri: Uri.file(filePath).toString(),
+            uri: fileUri,
             languageId: 'ballerina',
             version: 1,
             text: contentWithNewline
@@ -103,8 +104,9 @@ export function writeBallerinaFileDidOpenTemp(filePath: string, content: string)
 export async function writeBallerinaFileDidOpen(filePath: string, content: string) {
     const contentWithNewline = ensureTrailingNewline(content);
     writeFileSync(filePath, contentWithNewline);
+    const fileUri = Uri.file(filePath).toString();
     StateMachine.langClient().didChange({
-        textDocument: { uri: filePath, version: 1 },
+        textDocument: { uri: fileUri, version: 1 },
         contentChanges: [
             {
                 text: contentWithNewline,
@@ -113,7 +115,7 @@ export async function writeBallerinaFileDidOpen(filePath: string, content: strin
     });
     StateMachine.langClient().didOpen({
         textDocument: {
-            uri: Uri.file(filePath).toString(),
+            uri: fileUri,
             languageId: 'ballerina',
             version: 1,
             text: contentWithNewline

--- a/packages/ballerina-extension/src/utils/project-artifacts.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts.ts
@@ -37,6 +37,19 @@ let artifactRecoveryInProgress = false;
 // otherwise rebuild concurrently, each run racing the others' structure updates.
 let pendingStructureRebuild: Promise<ProjectStructureResponse | undefined> = Promise.resolve(undefined);
 
+// Single-flight: `updateProjectArtifacts` runs fire-and-forget per notification, so a burst
+// of notifications arriving before the first one resolves would otherwise each fetch project
+// info independently. Share one in-flight fetch instead of one per notification.
+let pendingProjectInfoFetch: Promise<ProjectInfo | undefined> | null = null;
+
+function fetchProjectInfoSingleFlight(projectPath: string): Promise<ProjectInfo | undefined> {
+    if (!pendingProjectInfoFetch) {
+        pendingProjectInfoFetch = StateMachine.langClient().getProjectInfo({ projectPath })
+            .finally(() => { pendingProjectInfoFetch = null; });
+    }
+    return pendingProjectInfoFetch;
+}
+
 export async function buildProjectsStructure(
     projectInfo: ProjectInfo,
     langClient: ExtendedLangClient,
@@ -175,7 +188,7 @@ export async function updateProjectArtifacts(publishedArtifacts: ArtifactsNotifi
         // `rootPath` is the workspace root for a workspace project and the package root
         // for a standalone integration/library — which can still gain a sibling package,
         // e.g. when another integration/library is added via AI chat.
-        const projectInfo = await StateMachine.langClient().getProjectInfo({ projectPath: rootPath });
+        const projectInfo = await fetchProjectInfoSingleFlight(rootPath);
         if (!projectInfo) {
             console.warn("[updateProjectArtifacts] Project info not found for the project:", rootPath);
             return;

--- a/packages/ballerina-extension/src/views/notebook/languageProvider.ts
+++ b/packages/ballerina-extension/src/views/notebook/languageProvider.ts
@@ -18,7 +18,7 @@
 
 import {
     CancellationToken, CompletionContext, CompletionItem, CompletionItemProvider, CompletionList,
-    Disposable, DocumentSelector, languages, Position, TextDocument,
+    Disposable, DocumentSelector, languages, Position, TextDocument, Uri,
 } from "vscode";
 import { CompletionItemKind as MonacoCompletionItemKind } from "monaco-languageclient";
 import { SyntaxTree, NotebookFileSource } from "@wso2/ballerina-core";
@@ -53,12 +53,13 @@ export class NotebookCompletionItemProvider implements CompletionItemProvider {
             return [];
         }
         let { content, filePath } = response as NotebookFileSource;
-        performDidOpen(langClient, filePath, content);
-        let endPositionOfMain = await this.getEndPositionOfMain(langClient, filePath);
+        const fileUri = Uri.file(filePath).toString();
+        performDidOpen(langClient, fileUri, content);
+        let endPositionOfMain = await this.getEndPositionOfMain(langClient, fileUri);
         let textToWrite = content ? `${content.substring(0, content.length - 1)}${document.getText()}\n}` : document.getText();
         langClient.didChange({
             textDocument: {
-                uri: filePath,
+                uri: fileUri,
                 version: 2,
             },
             contentChanges: [
@@ -69,7 +70,7 @@ export class NotebookCompletionItemProvider implements CompletionItemProvider {
         });
         let completions = await langClient.getCompletion({
             textDocument: {
-                uri: filePath
+                uri: fileUri
             },
             position: {
                 character: endPositionOfMain.character + position.character,
@@ -89,10 +90,10 @@ export class NotebookCompletionItemProvider implements CompletionItemProvider {
         });
     }
 
-    private async getEndPositionOfMain(langClient: ExtendedLangClient, filePath: string) {
+    private async getEndPositionOfMain(langClient: ExtendedLangClient, fileUri: string) {
         let response = await langClient.getSyntaxTree({
             documentIdentifier: {
-                uri: filePath
+                uri: fileUri
             }
         });
         let syntaxTree = response as any;
@@ -125,10 +126,10 @@ export function registerLanguageProviders(ballerinaExtInstance: BallerinaExtensi
     return Disposable.from(...disposables);
 }
 
-function performDidOpen(langClient: ExtendedLangClient, filePath: string, content: string) {
+function performDidOpen(langClient: ExtendedLangClient, fileUri: string, content: string) {
     langClient.didOpen({
         textDocument: {
-            uri: filePath,
+            uri: fileUri,
             languageId: LANGUAGE.BALLERINA,
             version: 1,
             text: content


### PR DESCRIPTION
## Purpose
$title
- Adding a new integration fired multiple `designModelService/projectInfo` requests. Replaced with URI-based untracked-package detection and a single-flight `refreshProjectStructure()` shared across all refresh triggers.
- Fixed `Missing scheme` LS errors on `text/didChange` caused by passing raw filesystem paths instead of `file://` URIs in `modification.ts` and the notebook completion provider.

Addresses: https://github.com/wso2/product-integrator/issues/1888
