### PR TITLE
Add CodeRabbit Configurations

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,45 +1,20 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 #
-# CodeRabbit configuration - https://docs.coderabbit.ai/getting-started/yaml-configuration
+# CodeRabbit config - https://docs.coderabbit.ai/getting-started/yaml-configuration
+# Only the root .coderabbit.yaml is read. A copy inside a package does nothing.
 #
-# Only a .coderabbit.yaml at the repo root is read; a copy inside a package has
-# no effect.
+# Precedence, high to low: workspace and org global overrides, THIS FILE, central
+# YAML, repo UI, org UI, workspace UI, schema defaults. Global overrides beat this
+# file, so if any are set, nothing here applies.
 #
-# Precedence, highest to lowest: workspace global overrides, org global
-# overrides, THIS FILE, central YAML, repository UI settings, org UI settings,
-# workspace UI settings, schema defaults.
+# `inheritance` is on, so anything left unset keeps resolving from the dashboard
+# instead of snapping back to a schema default. CodeRabbit ran on dashboard config
+# here for a while and that was worth keeping. So only set a value when there is a
+# reason: CI already covers it, a tracked issue says so, or the rules below depend
+# on it. Arrays merge child-first, so an org-level path_instructions entry lands
+# after ours rather than replacing it.
 #
-# `inheritance` is enabled below. It defaults to false, and leaving it off would
-# mean only the highest-priority source applies -- this file would become the
-# entire configuration and every dashboard setting for this repo would stop
-# taking effect, including the ones already in use before this file existed.
-# CodeRabbit was configured through the dashboard for a while, so discarding
-# that was not the intent. With inheritance on:
-#
-#   - Values set here win, since repository YAML outranks all the UI levels.
-#   - Values NOT set here fall through to central YAML, then the repo, org, and
-#     workspace UI settings, then schema defaults -- so existing dashboard
-#     configuration keeps working for everything this file is silent about.
-#   - Because of that, this file deliberately stays narrow. A setting is stated
-#     only where there is a concrete reason for it: a verified overlap with CI, a
-#     decision recorded in a tracked issue, or something the review design here
-#     depends on. Everything else is left out so it keeps resolving from the
-#     dashboard rather than being silently reset to a schema default.
-#   - Arrays merge as "child items first, then unique parent items appended", so
-#     an org-level path_instructions entry would be appended after ours rather
-#     than replaced.
-#   - Org- or workspace-level *global overrides* outrank this file either way. If
-#     any are set, settings here are silently ignored. Run
-#     `@coderabbitai configuration` on a PR to see the effective config with its
-#     per-setting source, and confirm these values are attributed to the
-#     repository YAML.
-#
-# Baseline is `chill`. The blocklist in the first path_instructions block is the
-# only thing meant to be raised loudly. request_changes_workflow is off, so the
-# bot never gates the merge button.
-
-# Fill values this file leaves undefined from the dashboard rather than from
-# schema defaults. See the precedence note above.
+# To see what actually applies, comment `@coderabbitai configuration` on a PR.
 inheritance: true
 
 tone_instructions: >-
@@ -48,11 +23,9 @@ tone_instructions: >-
   VS Code listeners. Everything else is a suggestion.
 
 reviews:
-  # These two match the schema defaults, but they are stated because the whole
-  # design depends on them: a chill baseline with a short hard-flag list, and a
-  # bot that comments rather than gating the merge button. If the dashboard ever
-  # moves to `assertive` or enables the request-changes workflow, omitting these
-  # would silently change how every path instruction below is applied.
+  # Both match the schema default, but every instruction below assumes a chill
+  # baseline that comments rather than blocks. Pinned so an org-level switch to
+  # `assertive` cannot quietly change how all of it is applied.
   profile: chill
   request_changes_workflow: false
 
@@ -66,13 +39,12 @@ reviews:
       - 'staging/.*'
 
   path_filters:
-    # --- Build output. Gitignored, listed anyway so a stray commit is filtered.
+    # Build output. Gitignored already; listed so a stray commit is still skipped.
     - '!**/node_modules/**'
     - '!**/dist/**'
-    # 'build' and 'lib' are scoped to the package root on purpose. A bare
-    # '**/build/**' also swallows .github/actions/build/action.yml, and a bare
-    # '**/lib/**' swallows packages/ballerina-extension/test/lib/index.ts --
-    # both hand-written.
+    # Scoped to the package root: a bare '**/build/**' also catches
+    # .github/actions/build/action.yml, and '**/lib/**' catches
+    # packages/ballerina-extension/test/lib/index.ts.
     - '!packages/*/build/**'
     - '!packages/*/build-app/**'
     - '!packages/*/lib/**'
@@ -86,20 +58,18 @@ reviews:
     # Build-time copy of packages/ballerina-grammar/syntaxes/.
     - '!packages/ballerina-extension/grammar/ballerina-grammar/**'
 
-    # --- Not this repo's code. Separate git repo; git tracks it as a single
-    # gitlink entry with no trailing path, so both forms are needed.
+    # Separate repo. Git tracks it as one gitlink with no trailing path, so both
+    # forms are needed.
     - '!submodules'
     - '!submodules/**'
 
-    # --- Machine-generated content that IS tracked.
-    # ~10k expected-output blobs for the language server. Reviewing them is noise.
+    # Generated content that is tracked anyway.
+    # ~10k expected-output blobs for the language server.
     - '!packages/ballerina-language-server/**/src/test/resources/**'
-    # main/resources is NOT excluded wholesale. It holds large generated data
-    # blobs (moduleInfo.json 452K, node_templates.json 316K, search_list.json,
-    # the trigger definitions) alongside hand-written files that matter --
-    # META-INF/services SPI registrations in particular. Miss one of those and
-    # the language server silently fails to load the extension. Exclude the
-    # data, keep the rest reviewable.
+    # Only the JSON under main/resources, not the whole tree. It mixes big
+    # generated blobs (moduleInfo.json is 452K) with hand-written files that
+    # matter -- miss a META-INF/services entry and the LS silently fails to load
+    # an extension.
     - '!packages/ballerina-language-server/**/src/main/resources/**/*.json'
     - '!packages/ballerina-extension/test/data/**'
     - '!packages/ballerina-extension/ui-test/data/**'
@@ -109,22 +79,21 @@ reviews:
     - '!packages/syntax-tree/src/syntax-tree-interfaces.ts'
     - '!packages/syntax-tree/src/check-kind-util.ts'
     - '!packages/syntax-tree/src/base-visitor.ts'
-    # Downloaded from wso2/code-quality-tools, tracked despite the build/ path.
+    # Vendored from wso2/code-quality-tools, tracked despite the build/ path.
     - '!packages/ballerina-language-server/build-config/checkstyle/build/**'
 
-    # --- Lockfiles, rush state, and media.
+    # Lockfiles, rush state, media.
     - '!**/pnpm-lock.yaml'
     - '!**/package-lock.json'
     - '!common/config/rush/repo-state.json'
     - '!docs/**/images/**'
     - '!resources/images/**'
 
-    # Deliberately NOT filtered despite its size: packages/ballerina-extension/
-    # package.json. Its `contributes` block is where command and setting
-    # regressions land.
+    # packages/ballerina-extension/package.json stays reviewable despite its size.
+    # Its `contributes` block is where command and setting regressions land.
 
   path_instructions:
-    # ---------------------------------------------------------------- blocklist
+    # Blocklist
     - path: '**/*.{ts,tsx,java}'
       instructions: |
         These four are the only findings to raise as blocking. State them plainly
@@ -151,7 +120,7 @@ reviews:
            packages/ballerina-extension/src/views/ already get this wrong; do not
            treat surrounding code as the standard.
 
-    # ------------------------------------------------------------ repo mechanics
+    # Repo mechanics
     - path: '**/*.{ts,tsx,json}'
       instructions: |
         Conventions specific to this Rush monorepo. Each is written down in
@@ -179,7 +148,7 @@ reviews:
           common/config/rush/pnpm-config.json under globalOverrides, not to
           .trivyignore. .trivyignore must stay one plain ID per line.
 
-    # -------------------------------------------------------------- RPC boundary
+    # RPC boundary
     - path: 'packages/{ballerina-core,ballerina-rpc-client,ballerina-extension}/**/*.ts'
       instructions: |
         The extension-to-webview contract is a three-layer split that has to move
@@ -208,7 +177,7 @@ reviews:
           side becomes an unhandled promise rejection inside the webview with no
           user-visible error.
 
-    # ------------------------------------------------------------ React webviews
+    # React webviews
     - path: 'packages/*/src/**/*.tsx'
       instructions: |
         - useEffect dependency arrays and stale closures. `react-hooks/
@@ -235,7 +204,7 @@ reviews:
         CI runs no ESLint or Prettier on this repo, and six packages are still on
         legacy tslint, so these are not caught anywhere else.
 
-    # ----------------------------------------------------------- Java LS backend
+    # Java LS backend
     - path: 'packages/ballerina-language-server/**/*.java'
       instructions: |
         Do NOT comment on formatting, naming, import order, line length, javadoc
@@ -258,7 +227,7 @@ reviews:
         - Cancellation tokens accepted and then ignored on long operations.
         - New behavior with no TestNG coverage.
 
-    # ------------------------------------------------------------------- tests
+    # Test files
     - path: '**/{*.test.ts,*.test.tsx,*.spec.ts,*.spec.tsx,e2e-test/**,jest.*.js}'
       instructions: |
         - JEST CONFIG FILENAMES (hard rule). Only a file named exactly
@@ -282,7 +251,8 @@ reviews:
         - Review test quality where tests exist: hardcoded sleeps instead of
           waits, missing assertions, mocking so broad the test asserts nothing.
 
-    # ------------------------------------------------- test coverage expectations
+    # Test coverage. Separate from the block above because "a test is missing"
+    # has to fire on the source file, not on a test file that may not exist.
     - path: 'packages/**/*.{ts,tsx,java}'
       instructions: |
         Test expectations, split by how hard the rule is.
@@ -297,7 +267,7 @@ reviews:
         config-only PRs legitimately have no test change, and nagging on those
         trains people to ignore you.
 
-    # ------------------------------------------------------------- E2E label rule
+    # E2E label prompt
     - path: '**'
       instructions: |
         E2E SUITE GATING. The Playwright suite does not run on most PRs. Per
@@ -318,36 +288,29 @@ reviews:
         not require -- promotion into the suite is a deliberate step and
         test.list.ts controls ordering.
 
-  # Every tool defaults to enabled: true, and with inheritance on an omitted tool
-  # resolves from the dashboard. So only tools we can point at a concrete reason
-  # for are listed; everything else defers to whatever the team already set.
-  # Each entry below turns a tool OFF because something in CI already covers it,
-  # or because of a decision recorded in a tracked issue.
+  # Tools default to on, and with inheritance an omitted tool keeps whatever the
+  # dashboard says. So these are only the ones worth turning off.
   tools:
-    # 2156 .java files, and the Gradle build runs checkstyle (wso2
-    # code-quality-tools v1.4) plus spotbugs on every PR inside Build_Stage.
-    # Enabling this would report the same findings twice.
+    # 2156 .java files, and Gradle runs checkstyle + spotbugs on every PR in
+    # Build_Stage. Enabling this reports the same findings twice.
     pmd:
       enabled: false
 
-    # Trivy already runs in reusable-build.yml and schedule.yml, governed by
-    # .trivyignore. osvScanner covers the same dependency-CVE ground.
+    # Trivy already runs in reusable-build.yml and schedule.yml. osvScanner
+    # covers the same dependency-CVE ground.
     trivy:
       enabled: false
     osvScanner:
       enabled: false
 
-    # By decision, not because of CI. Six packages are still on legacy tslint
-    # (ballerina-extension, ballerina-low-code-diagram, syntax-tree,
-    # graphql-design-diagram, statement-editor, data-mapper), the rest are split
-    # across .eslintrc and flat config, data-mapper and overview-view have
-    # conflicting configs, and four packages have a lint script that cannot
-    # succeed. The rules worth enforcing are in path_instructions above instead.
+    # Off by decision, not because CI covers it -- nothing lints TypeScript here.
+    # The configs are too uneven to act on: six packages still use tslint, the
+    # rest split across .eslintrc and flat config, data-mapper and overview-view
+    # have conflicting configs, and four packages have a lint script that cannot
+    # run. The rules worth keeping are in path_instructions above.
     #
-    # TODO: set this to true once the ESLint migration lands. Tracked in
-    # wso2-enterprise/integration-engineering#2167, which covers migrating the
-    # six tslint packages, converging on one flat config, and adding a lint job
-    # to pull-request.yml. CodeRabbit has no tslint integration, so those six
-    # packages cannot be covered by this tool until they move.
+    # TODO: set to true once the ESLint migration lands --
+    # wso2-enterprise/integration-engineering#2167. CodeRabbit has no tslint
+    # integration, so those six packages stay uncovered until they move.
     eslint:
       enabled: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,9 +18,11 @@ reviews:
   # `assertive` cannot quietly change how all of it is applied.
   profile: chill
   request_changes_workflow: false
-  # Same reason: a dashboard `fail_commit_status` would let the bot gate merges
-  # through the check instead of the review.
-  commit_status: false
+  # Same reason. This one fails the active review-status surface -- the check
+  # run, or the legacy commit-status mirror when `review_progress` is off --
+  # whenever a review errors, so a CodeRabbit-side failure would block the
+  # merge. It already defaults to false; pinned so inheritance cannot flip it.
+  fail_commit_status: false
 
   # The Playwright E2E suite runs only when a PR carries this label, or when the
   # base branch ends in `.x` (see .github/workflows/pull-request.yml). Nothing in

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -129,7 +129,9 @@ reviews:
            17-line form from the top of packages/ballerina-core/src/index.ts.
            For .java, match the 15-line form used by sibling files in the same
            package -- the Java headers use different wording from the
-           TypeScript one, so do not carry it across. New files use year 2026.
+           TypeScript one, so do not carry it across. A new file should use the
+           current year; do not copy the year from the file you took the
+           header from.
 
         3. BREAKING A PUBLISHED SURFACE. Flag changes to the exported extension
            API, to RPC message contracts, or to public Java interfaces when the
@@ -176,6 +178,11 @@ reviews:
         A fixable CVE goes to common/config/rush/pnpm-config.json under
         globalOverrides, not to .trivyignore. .trivyignore must stay one plain
         ID per line.
+
+        A new .trivyignore entry needs a linked tracking issue in the comment
+        above it, next to the reason no usable fix exists. Ask for one when it
+        is missing -- without it nothing prompts a recheck once upstream
+        publishes a fix.
 
     # RPC boundary
     - path: 'packages/{ballerina-core,ballerina-rpc-client,ballerina-extension}/**/*.ts'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -35,11 +35,13 @@ reviews:
   labeling_instructions:
     - label: 'Checks/Run Ballerina UI Tests'
       instructions: >-
-        Suggest this label when the PR changes user-facing editor behavior:
-        React components under packages/*/src, webview panels, side panels,
-        diagram rendering, form or expression editors, or anything under
-        packages/ballerina-extension/src/views. Do not suggest it for changes
-        limited to the language server, build config, tests, or documentation.
+        A run is four parallel Playwright jobs capped at 60 minutes each, so
+        the default answer is no. Suggest this label only when the change
+        could break an end-to-end flow the suite actually covers; read
+        packages/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
+        to see what that is. Do not suggest it for styling, copy, or
+        layout-only changes, or for language server, build config, test, or
+        documentation changes.
 
   # labeling_instructions only reaches the author through the walkthrough, so this
   # has to stay on for the suggestion to appear at all.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,20 +1,10 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-#
 # CodeRabbit config - https://docs.coderabbit.ai/getting-started/yaml-configuration
-# Only the root .coderabbit.yaml is read. A copy inside a package does nothing.
-#
-# Precedence, high to low: workspace and org global overrides, THIS FILE, central
-# YAML, repo UI, org UI, workspace UI, schema defaults. Global overrides beat this
-# file, so if any are set, nothing here applies.
 #
 # `inheritance` is on, so anything left unset keeps resolving from the dashboard
-# instead of snapping back to a schema default. CodeRabbit ran on dashboard config
-# here for a while and that was worth keeping. So only set a value when there is a
+# instead of snapping back to a schema default. So only set a value when there is a
 # reason: CI already covers it, a tracked issue says so, or the rules below depend
 # on it. Arrays merge child-first, so an org-level path_instructions entry lands
 # after ours rather than replacing it.
-#
-# To see what actually applies, comment `@coderabbitai configuration` on a PR.
 inheritance: true
 
 tone_instructions: >-
@@ -28,6 +18,29 @@ reviews:
   # `assertive` cannot quietly change how all of it is applied.
   profile: chill
   request_changes_workflow: false
+
+  # The Playwright E2E suite runs only when a PR carries this label, or when the
+  # base branch ends in `.x` (see .github/workflows/pull-request.yml). Nothing in
+  # the PR template mentions that, so UI changes routinely merge without it.
+  #
+  # Listing a label here restricts CodeRabbit to suggesting only from this list,
+  # which is the intent -- this is the one label that changes what CI runs.
+  labeling_instructions:
+    - label: 'Checks/Run Ballerina UI Tests'
+      instructions: >-
+        Suggest this label when the PR changes user-facing editor behavior:
+        React components under packages/*/src, webview panels, side panels,
+        diagram rendering, form or expression editors, or anything under
+        packages/ballerina-extension/src/views. Do not suggest it for changes
+        limited to the language server, build config, tests, or documentation.
+
+  # labeling_instructions only reaches the author through the walkthrough, so this
+  # has to stay on for the suggestion to appear at all.
+  suggested_labels: true
+  # Left off deliberately. Applying this label starts a full Playwright run, so a
+  # misjudged PR would burn CI with no one having agreed to it. Suggest, and let
+  # the author decide.
+  auto_apply_labels: false
 
   auto_review:
     base_branches:
@@ -201,6 +214,14 @@ reviews:
           Flag an unguarded onDidChangeTextDocument that leads to an RPC
           notification.
 
+        - E2E COVERAGE. When the change introduces a new UI feature or a major
+          flow that the suites under
+          packages/ballerina-extension/e2e-test/e2e-playwright-tests/ do not
+          already cover, encourage adding an E2E test and point at the authoring
+          workflow in .claude/skills/ballerina-e2e-writer/SKILL.md. Encourage, do
+          not require -- promotion into the suite is a deliberate step and
+          test.list.ts controls ordering.
+
         CI runs no ESLint or Prettier on this repo, and six packages are still on
         legacy tslint, so these are not caught anywhere else.
 
@@ -266,27 +287,6 @@ reviews:
         touched. Phrase it as a question. Refactors, dependency bumps, and
         config-only PRs legitimately have no test change, and nagging on those
         trains people to ignore you.
-
-    # E2E label prompt
-    - path: '**'
-      instructions: |
-        E2E SUITE GATING. The Playwright suite does not run on most PRs. Per
-        .github/workflows/pull-request.yml it runs only when the PR carries the
-        label `Checks/Run Ballerina UI Tests`, or when the base branch ends in
-        `.x`. Nothing in the PR template mentions this, so it is easy to miss.
-
-        When a PR contains significant UI changes -- webview components, side
-        panels, diagram rendering, form or editor behavior -- ask the author to
-        add the `Checks/Run Ballerina UI Tests` label before merge. Related
-        labels: `Checks/Run LS Tests` (also auto-added when
-        packages/ballerina-language-server/ changes) and `Runner/AWS`.
-
-        When the PR introduces a new UI feature or a major UI flow that the suites
-        under packages/ballerina-extension/e2e-test/e2e-playwright-tests/ do not
-        already cover, encourage adding an E2E test and point at the authoring
-        workflow in .claude/skills/ballerina-e2e-writer/SKILL.md. Encourage, do
-        not require -- promotion into the suite is a deliberate step and
-        test.list.ts controls ordering.
 
   # Tools default to on, and with inheritance an omitted tool keeps whatever the
   # dashboard says. So these are only the ones worth turning off.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,8 +3,8 @@
 # `inheritance` is on, so anything left unset keeps resolving from the dashboard
 # instead of snapping back to a schema default. So only set a value when there is a
 # reason: CI already covers it, a tracked issue says so, or the rules below depend
-# on it. Arrays merge child-first, so an org-level path_instructions entry lands
-# after ours rather than replacing it.
+# on it. Arrays merge child-first: an org-level path_instructions entry lands
+# after ours, or is dropped entirely if it carries the same `path`.
 inheritance: true
 
 tone_instructions: >-
@@ -18,13 +18,18 @@ reviews:
   # `assertive` cannot quietly change how all of it is applied.
   profile: chill
   request_changes_workflow: false
+  # Same reason: a dashboard `fail_commit_status` would let the bot gate merges
+  # through the check instead of the review.
+  commit_status: false
 
   # The Playwright E2E suite runs only when a PR carries this label, or when the
   # base branch ends in `.x` (see .github/workflows/pull-request.yml). Nothing in
   # the PR template mentions that, so UI changes routinely merge without it.
   #
   # Listing a label here restricts CodeRabbit to suggesting only from this list,
-  # which is the intent -- this is the one label that changes what CI runs.
+  # which is the intent. `Checks/Run LS Tests` also changes what CI runs but is
+  # left out on purpose: the `ls` path filter turns it on automatically, so a
+  # suggestion adds nothing. This label has no such fallback.
   labeling_instructions:
     - label: 'Checks/Run Ballerina UI Tests'
       instructions: >-
@@ -116,8 +121,11 @@ reviews:
            credential in source or in a test fixture.
 
         2. LICENSE HEADER. Every new source file needs the WSO2 Apache-2.0
-           header. Copy the exact 17-line form from the top of
-           packages/ballerina-core/src/index.ts. New files use year 2026.
+           header, and the form differs by language. For .ts and .tsx, copy the
+           17-line form from the top of packages/ballerina-core/src/index.ts.
+           For .java, match the 15-line form used by sibling files in the same
+           package -- the Java headers use different wording from the
+           TypeScript one, so do not carry it across. New files use year 2026.
 
         3. BREAKING A PUBLISHED SURFACE. Flag changes to the exported extension
            API, to RPC message contracts, or to public Java interfaces when the
@@ -157,9 +165,13 @@ reviews:
           belong in their own commit against their own repo (AGENTS.md,
           "Submodule changes are not monorepo changes").
 
-        - CVE HANDLING. A fixable CVE goes to
-          common/config/rush/pnpm-config.json under globalOverrides, not to
-          .trivyignore. .trivyignore must stay one plain ID per line.
+    # CVE suppressions. Its own entry because .trivyignore has no extension, so
+    # no `**/*.{ext}` glob above reaches it.
+    - path: '{.trivyignore,common/config/rush/pnpm-config.json}'
+      instructions: |
+        A fixable CVE goes to common/config/rush/pnpm-config.json under
+        globalOverrides, not to .trivyignore. .trivyignore must stay one plain
+        ID per line.
 
     # RPC boundary
     - path: 'packages/{ballerina-core,ballerina-rpc-client,ballerina-extension}/**/*.ts'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,353 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit configuration - https://docs.coderabbit.ai/getting-started/yaml-configuration
+#
+# Only a .coderabbit.yaml at the repo root is read; a copy inside a package has
+# no effect.
+#
+# Precedence, highest to lowest: workspace global overrides, org global
+# overrides, THIS FILE, central YAML, repository UI settings, org UI settings,
+# workspace UI settings, schema defaults.
+#
+# `inheritance` is enabled below. It defaults to false, and leaving it off would
+# mean only the highest-priority source applies -- this file would become the
+# entire configuration and every dashboard setting for this repo would stop
+# taking effect, including the ones already in use before this file existed.
+# CodeRabbit was configured through the dashboard for a while, so discarding
+# that was not the intent. With inheritance on:
+#
+#   - Values set here win, since repository YAML outranks all the UI levels.
+#   - Values NOT set here fall through to central YAML, then the repo, org, and
+#     workspace UI settings, then schema defaults -- so existing dashboard
+#     configuration keeps working for everything this file is silent about.
+#   - Because of that, this file deliberately stays narrow. A setting is stated
+#     only where there is a concrete reason for it: a verified overlap with CI, a
+#     decision recorded in a tracked issue, or something the review design here
+#     depends on. Everything else is left out so it keeps resolving from the
+#     dashboard rather than being silently reset to a schema default.
+#   - Arrays merge as "child items first, then unique parent items appended", so
+#     an org-level path_instructions entry would be appended after ours rather
+#     than replaced.
+#   - Org- or workspace-level *global overrides* outrank this file either way. If
+#     any are set, settings here are silently ignored. Run
+#     `@coderabbitai configuration` on a PR to see the effective config with its
+#     per-setting source, and confirm these values are attributed to the
+#     repository YAML.
+#
+# Baseline is `chill`. The blocklist in the first path_instructions block is the
+# only thing meant to be raised loudly. request_changes_workflow is off, so the
+# bot never gates the merge button.
+
+# Fill values this file leaves undefined from the dashboard rather than from
+# schema defaults. See the precedence note above.
+inheritance: true
+
+tone_instructions: >-
+  Be concise. Treat only these as blocking-severity: leaked secrets, a missing
+  WSO2 license header, a broken published API or RPC contract, and undisposed
+  VS Code listeners. Everything else is a suggestion.
+
+reviews:
+  # These two match the schema defaults, but they are stated because the whole
+  # design depends on them: a chill baseline with a short hard-flag list, and a
+  # bot that comments rather than gating the merge button. If the dashboard ever
+  # moves to `assertive` or enables the request-changes workflow, omitting these
+  # would silently change how every path instruction below is applied.
+  profile: chill
+  request_changes_workflow: false
+
+  auto_review:
+    base_branches:
+      - 'main'
+      - '\d+\.\d+\.x'
+      - 'release/.*'
+      - 'feature/.*'
+      - 'hotfix/.*'
+      - 'staging/.*'
+
+  path_filters:
+    # --- Build output. Gitignored, listed anyway so a stray commit is filtered.
+    - '!**/node_modules/**'
+    - '!**/dist/**'
+    # 'build' and 'lib' are scoped to the package root on purpose. A bare
+    # '**/build/**' also swallows .github/actions/build/action.yml, and a bare
+    # '**/lib/**' swallows packages/ballerina-extension/test/lib/index.ts --
+    # both hand-written.
+    - '!packages/*/build/**'
+    - '!packages/*/build-app/**'
+    - '!packages/*/lib/**'
+    - '!**/out/**'
+    - '!**/vsix/**'
+    - '!**/coverage/**'
+    - '!common/temp/**'
+    - '!.rush/**'
+    - '!**/.gradle/**'
+    - '!**/extractedDistribution/**'
+    # Build-time copy of packages/ballerina-grammar/syntaxes/.
+    - '!packages/ballerina-extension/grammar/ballerina-grammar/**'
+
+    # --- Not this repo's code. Separate git repo; git tracks it as a single
+    # gitlink entry with no trailing path, so both forms are needed.
+    - '!submodules'
+    - '!submodules/**'
+
+    # --- Machine-generated content that IS tracked.
+    # ~10k expected-output blobs for the language server. Reviewing them is noise.
+    - '!packages/ballerina-language-server/**/src/test/resources/**'
+    # main/resources is NOT excluded wholesale. It holds large generated data
+    # blobs (moduleInfo.json 452K, node_templates.json 316K, search_list.json,
+    # the trigger definitions) alongside hand-written files that matter --
+    # META-INF/services SPI registrations in particular. Miss one of those and
+    # the language server silently fails to load the extension. Exclude the
+    # data, keep the rest reviewable.
+    - '!packages/ballerina-language-server/**/src/main/resources/**/*.json'
+    - '!packages/ballerina-extension/test/data/**'
+    - '!packages/ballerina-extension/ui-test/data/**'
+    - '!**/*.sqlite'
+    - '!packages/ballerina-grammar/test/resources/snapshots/**'
+    # Emitted by packages/syntax-tree/generator/src/generators.ts.
+    - '!packages/syntax-tree/src/syntax-tree-interfaces.ts'
+    - '!packages/syntax-tree/src/check-kind-util.ts'
+    - '!packages/syntax-tree/src/base-visitor.ts'
+    # Downloaded from wso2/code-quality-tools, tracked despite the build/ path.
+    - '!packages/ballerina-language-server/build-config/checkstyle/build/**'
+
+    # --- Lockfiles, rush state, and media.
+    - '!**/pnpm-lock.yaml'
+    - '!**/package-lock.json'
+    - '!common/config/rush/repo-state.json'
+    - '!docs/**/images/**'
+    - '!resources/images/**'
+
+    # Deliberately NOT filtered despite its size: packages/ballerina-extension/
+    # package.json. Its `contributes` block is where command and setting
+    # regressions land.
+
+  path_instructions:
+    # ---------------------------------------------------------------- blocklist
+    - path: '**/*.{ts,tsx,java}'
+      instructions: |
+        These four are the only findings to raise as blocking. State them plainly
+        and do not soften them. Everything else in this file is a suggestion.
+
+        1. SECRETS. Any token, API key, password, connection string, or
+           credential in source or in a test fixture.
+
+        2. LICENSE HEADER. Every new source file needs the WSO2 Apache-2.0
+           header. Copy the exact 17-line form from the top of
+           packages/ballerina-core/src/index.ts. New files use year 2026.
+
+        3. BREAKING A PUBLISHED SURFACE. Flag changes to the exported extension
+           API, to RPC message contracts, or to public Java interfaces when the
+           PR description does not say how compatibility is handled. Renaming or
+           removing an exported symbol, changing a RequestType payload shape, and
+           changing a method string all count.
+
+        4. UNDISPOSED LISTENERS. A vscode.Disposable, event listener, or webview
+           panel created without being pushed to a _disposables array or to
+           context.subscriptions leaks for the life of the extension host. Check
+           that every subscription in a new or edited class has a disposal path.
+           Note that some existing listeners in
+           packages/ballerina-extension/src/views/ already get this wrong; do not
+           treat surrounding code as the standard.
+
+    # ------------------------------------------------------------ repo mechanics
+    - path: '**/*.{ts,tsx,json}'
+      instructions: |
+        Conventions specific to this Rush monorepo. Each is written down in
+        AGENTS.md or CONTRIBUTING.md, or enforced by a hook.
+
+        - EXACT VERSIONS. No `^` or `~` range in any package.json dependencies,
+          devDependencies, or peerDependencies. `workspace:`, `file:`, `link:`,
+          `git+`, `npm:`, `*`, and `latest` are allowed. This is enforced only by
+          .husky/pre-commit -> common/scripts/validate-package-versions.js, and a
+          `--no-verify` push slips past it, so check it in review.
+
+        - VERSION BUMPS belong only in packages/ballerina-extension/package.json.
+          That field is read by both vsce and Gradle. `-SNAPSHOT` only on main.
+
+        - NO NEW TOOLING. Flag a new task runner, an alternative bundler, or a
+          per-package install script. Use rush and the existing TypeScript build
+          (AGENTS.md, "Use the existing TypeScript / build infrastructure").
+
+        - SUBMODULE SEPARATION. Flag any diff that changes
+          submodules/wso2-vscode-extensions alongside packages/. Submodule edits
+          belong in their own commit against their own repo (AGENTS.md,
+          "Submodule changes are not monorepo changes").
+
+        - CVE HANDLING. A fixable CVE goes to
+          common/config/rush/pnpm-config.json under globalOverrides, not to
+          .trivyignore. .trivyignore must stay one plain ID per line.
+
+    # -------------------------------------------------------------- RPC boundary
+    - path: 'packages/{ballerina-core,ballerina-rpc-client,ballerina-extension}/**/*.ts'
+      instructions: |
+        The extension-to-webview contract is a three-layer split that has to move
+        together. For an area <area>:
+
+          packages/ballerina-core/src/rpc-types/<area>/rpc-type.ts
+              RequestType / NotificationType descriptors, method strings
+          packages/ballerina-rpc-client/src/rpc-clients/<area>/rpc-client.ts
+              webview-side typed client
+          packages/ballerina-extension/src/rpc-managers/<area>/rpc-handler.ts
+              host-side handler, registered from src/RPCLayer.ts
+
+        Flag:
+
+        - A descriptor added, renamed, or with a changed payload type, without
+          the matching client method and host handler in the same PR. This is
+          silent breakage: the type error surfaces in neither package because
+          they build independently.
+        - A handler registered in RPCLayer.ts with no corresponding descriptor,
+          or a descriptor with no registration.
+        - Hand-edits to any file carrying the marker comment
+          "THIS FILE INCLUDES AUTO GENERATED CODE". These are produced by the RPC
+          generator; change the source rpc-types entry and regenerate.
+        - `sendRequest` with no rejection handling. The generated clients
+          `return this._messenger.sendRequest(...)` bare, so a throw on the host
+          side becomes an unhandled promise rejection inside the webview with no
+          user-visible error.
+
+    # ------------------------------------------------------------ React webviews
+    - path: 'packages/*/src/**/*.tsx'
+      instructions: |
+        - useEffect dependency arrays and stale closures. `react-hooks/
+          exhaustive-deps` is an error in the shared toolkit config, but there are
+          roughly 31 eslint-disable comments for it across the tree. A new disable
+          needs a reason in the comment saying why the dep is safe to omit.
+
+        - THEME TOKENS. Colors come from ThemeColors or `var(--vscode-*)`.
+          A hardcoded hex or rgb() value breaks the light, dark, and
+          high-contrast themes. Flag it.
+
+        - REUSE THE TOOLKIT. Prefer an existing @wso2/ui-toolkit component over a
+          new one-off. Say which one when you can name it.
+
+        - ERROR BOUNDARIES. A React.lazy panel belongs inside Suspense and
+          WebviewErrorBoundary; without one, a render throw blanks the webview.
+
+        - HOST-TO-WEBVIEW CHURN. A notification pushed on every document change
+          floods the webview. The established pattern is lodash.debounce(fn, 500)
+          plus a readiness gate on `viewActive === "viewReady"` and panel.active.
+          Flag an unguarded onDidChangeTextDocument that leads to an RPC
+          notification.
+
+        CI runs no ESLint or Prettier on this repo, and six packages are still on
+        legacy tslint, so these are not caught anywhere else.
+
+    # ----------------------------------------------------------- Java LS backend
+    - path: 'packages/ballerina-language-server/**/*.java'
+      instructions: |
+        Do NOT comment on formatting, naming, import order, line length, javadoc
+        presence, or anything else stylistic. The Gradle build already gates
+        those with checkstyle (wso2/code-quality-tools v1.4, jdk-17) and spotbugs
+        (effort MAX, reportLevel LOW, with a validateSpotbugs task that fails on a
+        non-empty report), and it runs on every PR. Repeating them is pure
+        duplicate noise.
+
+        Review logic instead:
+
+        - Null-safety when walking the syntax tree. Optional/nullable results from
+          symbol and type lookups that are dereferenced without a check.
+        - Resources opened without try-with-resources or a finally close.
+        - Concurrency in LS request handling: shared mutable state across
+          requests, non-thread-safe collections, document state read after it may
+          have been invalidated.
+        - Swallowed exceptions. A catch block that logs nothing and returns a
+          default hides real failures from the client.
+        - Cancellation tokens accepted and then ignored on long operations.
+        - New behavior with no TestNG coverage.
+
+    # ------------------------------------------------------------------- tests
+    - path: '**/{*.test.ts,*.test.tsx,*.spec.ts,*.spec.tsx,e2e-test/**,jest.*.js}'
+      instructions: |
+        - JEST CONFIG FILENAMES (hard rule). Only a file named exactly
+          `jest.config.js` is PR-gated in CI. Never accept a rename of
+          jest.ls-integration.config.js, jest.realdata.config.js,
+          jest.headless-view.config.js, or jest.perf.config.js to jest.config.js.
+          Those need Java, a Ballerina distribution, or VS Code, and would break
+          every PR. Flag it loudly if you see it.
+
+        - REGRESSION POLICY. A bug fix ships a fixture named `issue-<n>.json` that
+          feeds an existing invariant assertion, not a new one-off test. Assert a
+          rule over a corpus, not the single reported case.
+
+        - E2E SELECTORS. data-testid only. Emotion generates hashed class names
+          that change per build, so a class-name selector is a future flake.
+
+        - TEST TYPE ERRORS. Test files are excluded from the build's type-check;
+          `node scripts/typecheck-tests.js` covers them. Flag `as any` used to
+          silence a type error in a test rather than fixing the type.
+
+        - Review test quality where tests exist: hardcoded sleeps instead of
+          waits, missing assertions, mocking so broad the test asserts nothing.
+
+    # ------------------------------------------------- test coverage expectations
+    - path: 'packages/**/*.{ts,tsx,java}'
+      instructions: |
+        Test expectations, split by how hard the rule is.
+
+        REQUIRE a test when the PR adds new behavior: a new VS Code command, a new
+        RPC handler, a new state-machine transition, or a new LS endpoint. Say
+        which level it belongs at (L1 unit/contract, L2 component render, L3
+        LS-integration, L4 E2E) per docs/TEST_GUIDE.md.
+
+        ASK, do not demand, when existing logic changed and no test file was
+        touched. Phrase it as a question. Refactors, dependency bumps, and
+        config-only PRs legitimately have no test change, and nagging on those
+        trains people to ignore you.
+
+    # ------------------------------------------------------------- E2E label rule
+    - path: '**'
+      instructions: |
+        E2E SUITE GATING. The Playwright suite does not run on most PRs. Per
+        .github/workflows/pull-request.yml it runs only when the PR carries the
+        label `Checks/Run Ballerina UI Tests`, or when the base branch ends in
+        `.x`. Nothing in the PR template mentions this, so it is easy to miss.
+
+        When a PR contains significant UI changes -- webview components, side
+        panels, diagram rendering, form or editor behavior -- ask the author to
+        add the `Checks/Run Ballerina UI Tests` label before merge. Related
+        labels: `Checks/Run LS Tests` (also auto-added when
+        packages/ballerina-language-server/ changes) and `Runner/AWS`.
+
+        When the PR introduces a new UI feature or a major UI flow that the suites
+        under packages/ballerina-extension/e2e-test/e2e-playwright-tests/ do not
+        already cover, encourage adding an E2E test and point at the authoring
+        workflow in .claude/skills/ballerina-e2e-writer/SKILL.md. Encourage, do
+        not require -- promotion into the suite is a deliberate step and
+        test.list.ts controls ordering.
+
+  # Every tool defaults to enabled: true, and with inheritance on an omitted tool
+  # resolves from the dashboard. So only tools we can point at a concrete reason
+  # for are listed; everything else defers to whatever the team already set.
+  # Each entry below turns a tool OFF because something in CI already covers it,
+  # or because of a decision recorded in a tracked issue.
+  tools:
+    # 2156 .java files, and the Gradle build runs checkstyle (wso2
+    # code-quality-tools v1.4) plus spotbugs on every PR inside Build_Stage.
+    # Enabling this would report the same findings twice.
+    pmd:
+      enabled: false
+
+    # Trivy already runs in reusable-build.yml and schedule.yml, governed by
+    # .trivyignore. osvScanner covers the same dependency-CVE ground.
+    trivy:
+      enabled: false
+    osvScanner:
+      enabled: false
+
+    # By decision, not because of CI. Six packages are still on legacy tslint
+    # (ballerina-extension, ballerina-low-code-diagram, syntax-tree,
+    # graphql-design-diagram, statement-editor, data-mapper), the rest are split
+    # across .eslintrc and flat config, data-mapper and overview-view have
+    # conflicting configs, and four packages have a lint script that cannot
+    # succeed. The rules worth enforcing are in path_instructions above instead.
+    #
+    # TODO: set this to true once the ESLint migration lands. Tracked in
+    # wso2-enterprise/integration-engineering#2167, which covers migrating the
+    # six tslint packages, converging on one flat config, and adding a lint job
+    # to pull-request.yml. CodeRabbit has no tslint integration, so those six
+    # packages cannot be covered by this tool until they move.
+    eslint:
+      enabled: false

--- a/packages/ballerina-language-server/.coderabbit.yaml
+++ b/packages/ballerina-language-server/.coderabbit.yaml
@@ -1,9 +1,0 @@
-language: "en-US"
-reviews:
-  request_changes_workflow: false
-  high_level_summary: true
-  auto_review:
-    enabled: true
-    base_branches:
-      - 'main'
-      - '1\.\d+\.x'


### PR DESCRIPTION
## Purpose

CodeRabbit already reviews PRs on this repo, but it is configured entirely through the CodeRabbit dashboard. That configuration is not versioned, is invisible to contributors, and carries no knowledge of this repo, so the bot reviews a Rush monorepo that is roughly half Java language server and half React webviews using generic advice.

This adds a root `.coderabbit.yaml` so review rules live next to the code and change through PRs.

It also deletes `packages/ballerina-language-server/.coderabbit.yaml`, inherited when the LS was extracted into this repo. CodeRabbit reads only the config at the repository root, so that file has never had any effect, and its `base_branches: ['main', '1\.\d+\.x']` predates the current release lines. Everything it declared is either carried forward or intentionally dropped, per the inheritance note below.

## Goals

- Review guidance is versioned and reviewable instead of held in dashboard state.
- Instructions are scoped per path, so Java, TypeScript, React webviews, and tests each get rules that apply to them.
- A short list of hard rules is flagged loudly; everything else stays advisory. The bot never gates the merge button.
- The bot stops commenting on generated files.
- Existing dashboard configuration keeps working for everything this file does not speak to.

## Approach

No UI change and no product code change: one new config file, one deletion.

### `inheritance: true` — the one setting worth reviewing carefully

Precedence is: workspace global overrides → org global overrides → **this file** → central YAML → repo UI → org UI → workspace UI → schema defaults.

`inheritance` defaults to `false`, and with it off **only the highest-priority source applies**. That would make this file the entire configuration and stop every existing dashboard setting for this repo from taking effect — including settings in use before this file existed. Since CodeRabbit has been dashboard-configured here for a while, discarding that was not the intent.

With inheritance on, values set here win (repository YAML outranks all the UI levels) and values omitted here still resolve from the dashboard. Arrays merge child-first, so an org-level `path_instructions` entry is appended after ours rather than replacing them.

### The file is deliberately narrow

Because an omitted setting means "keep whatever the dashboard says", a value is stated only where there is a reason: a verified overlap with CI, a decision recorded in a tracked issue, or something the review design depends on. That comes to nine explicit settings:

| Setting | Why it is stated |
| --- | --- |
| `inheritance: true` | The decision above. |
| `profile: chill` | Matches the schema default. Pinned because all seven instruction blocks assume a chill baseline; an org-level switch to `assertive` would quietly change how every one of them is applied. |
| `request_changes_workflow: false` | Matches the schema default. Pinned for the same reason — the rules are written for a bot that comments rather than blocks. |
| `pmd: false` | 2,156 `.java` files, and Gradle already runs checkstyle + spotbugs on every PR in `Build_Stage`. Enabling it reports the same findings twice. |
| `trivy: false` | Already runs in `reusable-build.yml` and `schedule.yml`, governed by `.trivyignore`. |
| `osvScanner: false` | Same dependency-CVE ground as Trivy. |
| `eslint: false` | By decision — see below. |
| `suggested_labels: true` | Matches the schema default, but `labeling_instructions` reaches the author only through the walkthrough. If the dashboard has this off, the label suggestion below produces nothing. |
| `auto_apply_labels: false` | Matches the schema default. Pinned the other way for the same reason: if the dashboard has auto-apply on, adding `labeling_instructions` would start applying a label that triggers a full Playwright run. |

Every other tool is left unlisted on purpose. Tools default to enabled, so anything omitted keeps whatever the dashboard already has, which is preferable to asserting a value we cannot point at a reason for.

`eslint` is off despite being the only lint that would run on a PR — CI runs none. The configs are too uneven to act on: six packages still use tslint, the rest are split across `.eslintrc` and flat config, `data-mapper` and `overview-view` have conflicting configs, and four packages have a `lint` script that cannot run. The rules worth keeping are in `path_instructions` instead. Tracked in wso2-enterprise/integration-engineering#2167, referenced from a `TODO` on the key.

### Review rules

**Posture.** `chill` with a four-item hard-flag list, stated in `tone_instructions` and in the first `path_instructions` block: leaked secrets, a missing WSO2 license header, a broken published API or RPC contract, and undisposed VS Code listeners. The `assertive` profile was considered and rejected, since it raises nitpick volume globally, which is the opposite of a short list.

**The E2E label.** The Playwright suite runs only when a PR carries `Checks/Run Ballerina UI Tests`, or when the base branch ends in `.x` (`.github/workflows/pull-request.yml:59`). Nothing in the PR template says so, so UI changes routinely merge without it. `labeling_instructions` makes CodeRabbit suggest that label on PRs touching React components, webview and side panels, diagram rendering, or the form and expression editors — and explicitly *not* on changes limited to the language server, build config, tests, or docs, so it stays worth reading.

The label string was checked byte-for-byte against the workflow condition and the repo's label list; all three match. Note that listing a label here restricts CodeRabbit to suggesting only from this list, which is intended — this is the one label that changes what CI runs. `Runner/AWS` is referenced by the workflow but does not exist as a repo label, so it is deliberately not mentioned.

**Seven `path_instructions` blocks.** Each rule traces to something already written down in `AGENTS.md`, `CONTRIBUTING.md`, `docs/TEST_GUIDE.md`, or enforced by a hook. The ones carrying the most weight:

- The three-layer RPC contract (`ballerina-core/src/rpc-types` → `ballerina-rpc-client/src/rpc-clients` → `ballerina-extension/src/rpc-managers`) must move together. A descriptor changed without its client and handler compiles fine in both packages, because they build independently, and breaks at runtime.
- Java review is told explicitly **not** to comment on formatting, naming, or import order, because Gradle already gates those with checkstyle and spotbugs on every PR. Without that instruction the bot duplicates CI on 2,156 files.
- Never rename `jest.ls-integration.config.js`, `jest.realdata.config.js`, `jest.headless-view.config.js`, or `jest.perf.config.js` to `jest.config.js` — only the exact name is PR-gated, and those four need Java, a Ballerina distribution, or VS Code.
- Webview review covers the things nothing else catches here: hardcoded colors instead of `ThemeColors` / `var(--vscode-*)`, which break the light, dark, and high-contrast themes; `React.lazy` panels outside `WebviewErrorBoundary`; and host-to-webview notification churn that isn't debounced and gated on `viewActive === "viewReady"`. The same block encourages an E2E test when a new UI flow isn't covered by the existing suites.

**30 `path_filters`**, covering build output, the submodule, and generated content that is tracked anyway — chiefly the ~10k expected-output blobs under the LS `src/test/resources/`.

### Pre-merge check

Org- and workspace-level **global overrides** rank above repository YAML regardless of the inheritance setting. If any are set for this org, nothing in this file applies.

CodeRabbit's own review of this PR reports `Configuration used: Organization UI` and `Review profile: CHILL`. Organization UI is precedence level 6, below repository YAML, which is good evidence that no global overrides are in play — if there were, they would be the reported source. Worth one confirming look at the dashboard before merging, since that is inference rather than proof.

After merge, commenting `@coderabbitai configuration` on any PR prints the effective config with a per-setting source, which is how to confirm these values are attributed to the repository YAML.

## UI Component Development

N/A — no UI change. No new components, no `ui-toolkit` usage, no submodule change.

## User stories

N/A — contributor tooling.

## Release note

N/A — no user-facing change.

## Documentation

N/A — the file documents itself in comments, and no product documentation describes the review bot.

## Training

N/A

## Certification

N/A — no product behavior change.

## Marketing

N/A

## Automation tests

- Unit tests

  N/A — there is no test harness for a CodeRabbit config, and adding one is not warranted for a single declarative file. It was validated manually instead:

  - Schema-validated against `https://coderabbit.ai/integrations/schema.v2.json` with `ajv`. Note that `reviews` does not set `additionalProperties: false`, so a misspelled key validates clean and is then silently ignored — confirmed with a negative control, where an injected `pathh_filters` key passed validation. Every key was therefore also cross-checked against the schema's property lists, which caught one real bug: `osv-scanner` should be `osvScanner`.
  - `path_filters` tested with `minimatch` over all 16,493 tracked files: 10,453 excluded, 6,040 reviewable, and zero `.ts`/`.tsx`/`.java` source files excluded by accident. This pass found two wrong exclusions before commit — a bare `**/build/**` also matched `.github/actions/build/action.yml`, and a bare `**/lib/**` matched `packages/ballerina-extension/test/lib/index.ts`, so both are now scoped to the package root. It also caught that excluding the LS `src/main/resources/**` wholesale would have hidden the hand-written `META-INF/services` SPI registrations, where a missing entry makes the language server silently fail to load an extension; that exclusion is now scoped to `*.json`.
  - `base_branches` entries checked as anchored regexes against representative branch names.
  - All seven `path_instructions` globs confirmed to match at least one real file, so none is dead config.
  - The `Checks/Run Ballerina UI Tests` string compared byte-for-byte against the workflow condition and the repo's label list — 29 characters, identical in all three. This also showed `Runner/AWS` is read by the workflow but is not a defined repo label, so the config no longer points authors at it.
  - After the final comment pass, the parsed YAML was diffed against the previous revision to confirm the rewording changed no values.

- Integration tests

  Not run, and not possible before merge: the config only takes effect once it is on the default branch. CodeRabbit's review of this PR still uses the current dashboard configuration.

  After merge, the behavioral check is one PR touching a `.tsx` webview file, a `.java` LS file, and an RPC descriptor, confirming that Java comments are about logic rather than formatting, that the RPC instruction fires on a descriptor changed without its client and handler, that the E2E label prompt appears, and that no comments land on filtered paths.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A — declarative configuration, no code.
- Ran FindSecurityBugs plugin and verified report? N/A — no Java change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes. Leaked secrets are also the first item on the review blocklist this file defines.

## Samples

N/A

## Related PRs

None.

## Migrations (if applicable)

N/A. The deleted LS config was already inert, so removing it changes nothing. `inheritance` is the only setting that affects how existing configuration resolves, and it is covered above.

## Test environment

N/A — no build or runtime change. Validation was done locally on macOS with Node 22 using `ajv-cli`, `js-yaml`, and `minimatch`.

## Learning

CodeRabbit's configuration inheritance is the non-obvious part and is worth reading before editing this file: https://docs.coderabbit.ai/configuration/configuration-inheritance. Two things there are easy to get wrong:

1. Only a root `.coderabbit.yaml` is read. A copy inside a package is silently ignored, which is why the LS file never did anything.
2. A repository YAML does **not** merge with dashboard settings by default. `inheritance` defaults to `false`, and with it off only the highest-priority source applies, so a repo file silently replaces dashboard configuration rather than layering on top of it.

The `@coderabbitai configuration` command (https://docs.coderabbit.ai/guides/commands) prints the effective configuration with a per-setting source, which is the only reliable way to see what actually applies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a root `.coderabbit.yaml` for consistent CodeRabbit reviews across the Rush monorepo.
- Added repository-specific guidance for Java, TypeScript, React webviews, RPC contracts, and tests.
- Configured review behavior, branch handling, labels, inherited dashboard settings, and generated-file exclusions.
- Removed the unused package-level CodeRabbit configuration.
- Validated the configuration against repository paths and workflow requirements.
- No product, UI, or runtime changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->