### PR TITLE
Hide the overview Copilot prompt bar while the panel is open

### DIFF
--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
@@ -142,9 +142,9 @@ export function CopilotHeroBox() {
         return subscribeAgentRunStatus(rpcClient, setStatus);
     }, [rpcClient]);
 
-    // Unlike the floating orb, the hero box always renders: with no status yet
-    // (or an older host without the RPC) it is still the AI entry point, just
-    // in its idle prompt form.
+    // Unlike the floating orb, a missing status does not hide the box: with no
+    // status yet (or an older host without the RPC) it is still the AI entry
+    // point, just in its idle prompt form.
     const state = status?.state ?? "idle";
     const active = state !== "idle";
     const colors = ORB_COLORS[state];

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -16,10 +16,11 @@
  * under the License.
  */
 
+import { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { keyframes } from "@emotion/react";
 import { AgentRunState, AgentRunStatus, ChatNotify } from "@wso2/ballerina-core";
-import { BallerinaRpcClient } from "@wso2/ballerina-rpc-client";
+import { BallerinaRpcClient, useRpcContext } from "@wso2/ballerina-rpc-client";
 import type { MiniChatPrompt } from "./promptHandoff";
 
 /** WSO2 brand orange — the pulse-icon color from wso2.com/about/brand. */
@@ -281,6 +282,25 @@ export function subscribeAgentRunStatus(
     return () => {
         statusListeners.delete(listener);
     };
+}
+
+/**
+ * True while the Copilot panel is open — inline copilot surfaces stand down so
+ * the panel is the only chat entry point. Seeded from the cached status so a
+ * remount does not flash the surface it is about to hide.
+ */
+export function useAiPanelOpen(): boolean {
+    const { rpcClient } = useRpcContext();
+    const [open, setOpen] = useState(() => currentStatus?.aiPanelOpen ?? false);
+
+    useEffect(() => {
+        if (!rpcClient) {
+            return;
+        }
+        return subscribeAgentRunStatus(rpcClient, (status) => setOpen(status?.aiPanelOpen ?? false));
+    }, [rpcClient]);
+
+    return open;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -45,6 +45,7 @@ import { TitleBar } from "../../../components/TitleBar";
 import { PublishToCentralButton } from "./PublishToCentralButton";
 import { LibraryOverview } from "./LibraryOverview";
 import { CopilotHeroBox } from "../../../components/AgentStatusOrb/CopilotHeroBox";
+import { useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
 
 const SpinnerContainer = styled.div`
     display: flex;
@@ -825,6 +826,8 @@ export function PackageOverview(props: PackageOverviewProps) {
     const [isInProject, setIsInProject] = useState(false);
     const [isLibrary, setIsLibrary] = useState<boolean>(false);
     const [isNPSupported, setIsNPSupported] = useState<boolean>(false);
+    const aiPanelOpen = useAiPanelOpen();
+    const showHero = !isLibrary && !aiPanelOpen;
     const fetchContext = useCallback(() => {
         rpcClient
             .getBIDiagramRpcClient()
@@ -1127,12 +1130,12 @@ export function PackageOverview(props: PackageOverviewProps) {
                         </HeaderControls>
                     </HeaderRow>
                 )}
-                {!isLibrary && (
+                {showHero && (
                     <HeroRow>
                         <CopilotHeroBox />
                     </HeroRow>
                 )}
-                <MainContent fullWidth={isLibrary} withHero={!isLibrary}>
+                <MainContent fullWidth={isLibrary} withHero={showHero}>
                     <LeftContent>
                         <DiagramPanel noPadding={true} noBorder={isLibrary}>
                             {showAlert && (

--- a/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -36,6 +36,7 @@ import ReactMarkdown from "react-markdown";
 import { AlertBoxWithClose } from "../../AIPanel/AlertBoxWithClose";
 import { PackageListView } from "./PackageListView";
 import { CopilotHeroBox } from "../../../components/AgentStatusOrb/CopilotHeroBox";
+import { useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
 import { getWorkspaceProjectScopes } from "../PackageOverview/utils";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
 
@@ -737,6 +738,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
 
     const [showAlert, setShowAlert] = React.useState(false);
     const [icpActionLoading, setIcpActionLoading] = React.useState<IcpAction | null>(null);
+    const aiPanelOpen = useAiPanelOpen();
 
     const { data: devantMetadata, refetch: refetchDevantMetadata } = useQuery({
         queryKey: ["project-devant-metadata"],
@@ -1061,9 +1063,11 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                 </TitleContainer>
             </HeaderRow>
 
-            <HeroRow>
-                <CopilotHeroBox />
-            </HeroRow>
+            {!aiPanelOpen && (
+                <HeroRow>
+                    <CopilotHeroBox />
+                </HeroRow>
+            )}
 
             <MainContent hasDeployment={hasStandardIntegrations}>
                 <LeftContent>


### PR DESCRIPTION
- Hide the `CopilotHeroBox` prompt bar on the package/integration overview and the workspace overview while the Copilot panel is open, so only one chat entry point is on screen
- Add a `useAiPanelOpen()` hook in `AgentStatusOrb/shared.ts` on top of the existing `agentRunStatusChanged` fan-out — no new RPC; seeded from the cached status so a remount does not flash the bar before hiding it
- Drop the hero row's margin and the `MainContent withHero` height allowance along with the bar, so the overview content is not left short by the hero's height


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Hide `CopilotHeroBox` on package, integration, and workspace overviews when the Copilot panel is open.
- Add `useAiPanelOpen()` to track panel state from cached agent status and shared status updates.
- Remove hero spacing and height allowances when the prompt bar is hidden.
- Keep a single chat entry point visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->