### PR TITLE
Sync hotfix-5.12.4 extension fixes

### DIFF
--- a/packages/ballerina-core/src/state-machine-types.ts
+++ b/packages/ballerina-core/src/state-machine-types.ts
@@ -204,6 +204,7 @@ export interface ApprovalOverlayState {
 export interface VisualizerMetadata {
     haveLS?: boolean;
     isBISupported?: boolean;
+    isICPSupported?: boolean; // ICP is only available alongside the WSO2 Integrator extension
     recordFilePath?: string;
     enableSequenceDiagram?: boolean; // Enable sequence diagram view
     target?: LinePosition;

--- a/packages/ballerina-extension/package.json
+++ b/packages/ballerina-extension/package.json
@@ -813,13 +813,13 @@
                 "command": "ballerina.icp.start",
                 "title": "Start ICP",
                 "category": "Ballerina",
-                "enablement": "isSupportedProject && !ballerina.icpRunning && !devant.editor"
+                "enablement": "isSupportedProject && ballerina.icpSupported && !ballerina.icpRunning && !devant.editor"
             },
             {
                 "command": "ballerina.icp.stop",
                 "title": "Stop ICP",
                 "category": "Ballerina",
-                "enablement": "isSupportedProject && ballerina.icpRunning && !devant.editor"
+                "enablement": "isSupportedProject && ballerina.icpSupported && ballerina.icpRunning && !devant.editor"
             },
             {
                 "command": "ballerina.showTraceWindow",

--- a/packages/ballerina-extension/src/RPCLayer.ts
+++ b/packages/ballerina-extension/src/RPCLayer.ts
@@ -44,6 +44,7 @@ import { registerTestManagerRpcHandlers } from './rpc-managers/test-manager/rpc-
 import { registerIcpServiceRpcHandlers } from './rpc-managers/icp-service/rpc-handler';
 import { registerWorkflowManagementServiceRpcHandlers } from './rpc-managers/workflow-management-service/rpc-handler';
 import { extension } from './BalExtensionContext';
+import { isICPSupported } from './utils/config';
 import { registerAgentChatRpcHandlers } from './rpc-managers/agent-chat/rpc-handler';
 import { ChatPanel } from './views/agent-chat/webview';
 import { activeAgentChanged, tracingStatusChanged, TraceStatus } from '@wso2/ballerina-core';
@@ -182,6 +183,7 @@ async function getContext(): Promise<VisualizerLocation> {
             rootDiagramId: context.rootDiagramId,
             metadata: {
                 isBISupported: context.isBISupported,
+                isICPSupported: isICPSupported(),
                 haveLS: StateMachine.langClient() && true,
                 recordFilePath: context.projectPath ? path.join(context.projectPath, "types.bal") : undefined,
                 enableSequenceDiagram: extension.ballerinaExtInstance.enableSequenceDiagramView(),

--- a/packages/ballerina-extension/src/extension.ts
+++ b/packages/ballerina-extension/src/extension.ts
@@ -37,7 +37,7 @@ import { activate as activateBIFeatures } from './features/bi';
 import { activate as activateERDiagram } from './views/persist-layer-diagram';
 import { activateAiPanel } from './views/ai-panel';
 import { activateMigrationPanel } from './views/migration-panel';
-import { debug, handleResolveMissingDependencies, isInDevant, log } from './utils';
+import { debug, handleResolveMissingDependencies, isICPSupported, isInDevant, log } from './utils';
 import { activateUriHandlers } from './utils/uri-handlers';
 import { StateMachine } from './stateMachine';
 import { activateSubscriptions } from './views/visualizer/activate';
@@ -250,8 +250,8 @@ export async function activateBallerina(): Promise<BallerinaExtension> {
         // Activate Tracing Feature
         activateTracing(ballerinaExtInstance);
 
-        // Activate ICP (Integration Control Plane) — skip in Devant
-        if (!isInDevant()) {
+        // Activate ICP (Integration Control Plane) — skip in Devant and without the Integrator extension
+        if (!isInDevant() && isICPSupported()) {
             activateICP(ballerinaExtInstance);
         }
 

--- a/packages/ballerina-extension/src/features/bi/activator.ts
+++ b/packages/ballerina-extension/src/features/bi/activator.ts
@@ -37,7 +37,7 @@ import { StateMachine } from "../../stateMachine";
 import { BiDiagramRpcManager } from "../../rpc-managers/bi-diagram/rpc-manager";
 import { readFileSync, readdirSync, statSync } from "fs";
 import path from "path";
-import { isInDevant } from "../../utils";
+import { isICPSupported, isInDevant } from "../../utils";
 import { isPositionEqual, isPositionWithinDeletedComponent } from "../../utils/history/util";
 import { startDebugging } from "../editor-support/activator";
 import {
@@ -75,8 +75,8 @@ export function activate(context: BallerinaExtension) {
         const isWebviewOpen = VisualizerWebview.currentPanel !== undefined;
         const hasActiveTextEditor = !!window.activeTextEditor;
 
-        // Check if ICP is enabled for this project (skip entirely in Devant)
-        if (!isInDevant() && projectPath && stateMachineContext.langClient) {
+        // Check if ICP is enabled for this project (skip in Devant and without the Integrator extension)
+        if (!isInDevant() && isICPSupported() && projectPath && stateMachineContext.langClient) {
             try {
                 const icpStatus = await stateMachineContext.langClient.isIcpEnabled({ projectPath });
                 if (icpStatus && 'enabled' in icpStatus && icpStatus.enabled) {

--- a/packages/ballerina-extension/src/features/icp/activator.ts
+++ b/packages/ballerina-extension/src/features/icp/activator.ts
@@ -265,6 +265,10 @@ function createICPTask(icpPath: string): vscode.Task {
 }
 
 export function activateICP(ballerinaExtInstance: BallerinaExtension) {
+    // Only set when ICP is available — the ICP commands are gated on this key in package.json,
+    // and an unset key evaluates as false for the standalone Ballerina extension.
+    vscode.commands.executeCommand('setContext', 'ballerina.icpSupported', true);
+
     statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
     setICPState(false);
     statusBarItem.show();

--- a/packages/ballerina-extension/src/rpc-managers/icp-service/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/icp-service/rpc-manager.ts
@@ -33,6 +33,7 @@ import { parse, stringify } from "@iarna/toml";
 import { WorkflowManagementServiceRpcManager } from "../workflow-management-service/rpc-manager";
 import { getProjectHandle, getStoredICPSecret } from "../../features/icp/setup";
 import { ensureICPServerRunning, isICPServerRunning, getICPUrl } from "../../features/icp";
+import { isICPSupported } from "../../utils/config";
 
 const ICP_IMPORTS = [
     'import wso2/icp.runtime.bridge as _;',
@@ -274,6 +275,9 @@ function removeICPConfigToml(projectPath: string): void {
 export class ICPServiceRpcManager implements ICPServiceAPI {
 
     async addICP(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
+        if (!isICPSupported()) {
+            return { enabled: false };
+        }
         return new Promise(async (resolve) => {
             const context = StateMachine.context();
             try {
@@ -310,6 +314,9 @@ export class ICPServiceRpcManager implements ICPServiceAPI {
     }
 
     async disableICP(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
+        if (!isICPSupported()) {
+            return { enabled: false };
+        }
         return new Promise(async (resolve) => {
             const context = StateMachine.context();
             try {
@@ -331,10 +338,13 @@ export class ICPServiceRpcManager implements ICPServiceAPI {
 
 
     async isICPServerRunning(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
-        return { enabled: isICPServerRunning() };
+        return { enabled: isICPSupported() && isICPServerRunning() };
     }
 
     async viewInICP(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
+        if (!isICPSupported()) {
+            return { enabled: false };
+        }
         try {
             const icpUrl = getICPUrl();
 
@@ -368,6 +378,9 @@ export class ICPServiceRpcManager implements ICPServiceAPI {
     }
 
     async isIcpEnabled(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
+        if (!isICPSupported()) {
+            return { enabled: false };
+        }
         return new Promise(async (resolve) => {
             const context = StateMachine.context();
             try {

--- a/packages/ballerina-extension/src/utils/config.ts
+++ b/packages/ballerina-extension/src/utils/config.ts
@@ -233,6 +233,15 @@ export function isInWI(): boolean {
     return !!extensions.getExtension(WI_EXTENSION_ID);
 }
 
+/**
+ * ICP (Integration Control Plane) ships inside the WSO2 Integrator installation, so it is only
+ * offered when the Integrator extension is present. Users running the Ballerina extension on its
+ * own get no ICP commands, status bar item, or ICP sections in the overview webviews.
+ */
+export function isICPSupported(): boolean {
+    return isInWI();
+}
+
 export function isInDevant(): boolean {
     return !!process.env.CLOUD_STS_TOKEN;
 }

--- a/packages/ballerina-side-panel/src/components/editors/FormArrayEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/FormArrayEditor.tsx
@@ -174,8 +174,11 @@ export const FormArrayEditor = (props: FormFieldEditorProps & {
             });
             elementDiagnosticsRef.current = initialDioagnostics;
         }
-        let newValue = buildStringArray(props.value);
-        const initialValues = stringToRawArrayElements(newValue);
+        // An array holds the elements already, so the values are read from it directly. Building a string out of it
+        // and splitting it back apart loses an element that contains a comma, such as a string template.
+        const initialValues: string[] = Array.isArray(props.value)
+            ? props.value.map((val: any) => (typeof val === "string" ? val : String(val?.value ?? "")))
+            : stringToRawArrayElements(buildStringArray(props.value));
         if (!Array.isArray(props.value)) {
             initialValues.forEach((val: any, index: number) => {
                 const key = crypto.randomUUID();
@@ -183,7 +186,13 @@ export const FormArrayEditor = (props: FormFieldEditorProps & {
             })
         }
         if (keyArray.length !== initialValues.length) {
-            throw new Error("Key array length and initial values length do not match");
+            // The keys are only used to identify the elements of the editor. Hence, they are adjusted to the values
+            // instead of failing the render of the form.
+            console.warn(`FormArrayEditor: ${keyArray.length} keys for ${initialValues.length} values`);
+            while (keyArray.length < initialValues.length) {
+                keyArray.push(crypto.randomUUID());
+            }
+            keyArray.length = initialValues.length;
         }
         const initialFields = initialValues.map((val, index) => {
             const key = keyArray[index];

--- a/packages/ballerina-side-panel/src/components/editors/rawValueUtils.ts
+++ b/packages/ballerina-side-panel/src/components/editors/rawValueUtils.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { FormField } from "../Form/types";
+
+/**
+ * Splits the raw text of an array into its elements.
+ *
+ * Only a comma that lies outside of every quoted string, backtick template and nested `[]`, `{}` or `()` is an
+ * element separator. The module holds no import of its own, so that it can be exercised in isolation.
+ */
+export function stringToRawArrayElements(input: string): string[] {
+    // remove outer [ ]
+    const s = input.trim().slice(1, -1);
+
+    if (s === "") {
+        return [];
+    }
+
+    const result: string[] = [];
+    let current = "";
+    let depth = 0;
+    let inString = false;
+    // Backtick templates such as `string \`...\``, `xml \`...\`` and `re \`...\``. A comma within a template is never
+    // an element separator.
+    let inTemplate = false;
+    // The nesting of the `${...}` interpolations of a template. The expression of an interpolation may hold a quoted
+    // string, which in turn may hold a backtick, so the template only ends outside of an interpolation.
+    let interpolationDepth = 0;
+
+    for (let i = 0; i < s.length; i++) {
+        const char = s[i];
+        const prev = s[i - 1];
+
+        // within a quoted string, only its closing quote is significant
+        if (inString) {
+            if (char === '"' && prev !== "\\") {
+                inString = false;
+            }
+            current += char;
+            continue;
+        }
+
+        // within the interpolation of a template, the expression ends the interpolation alone
+        if (interpolationDepth > 0) {
+            if (char === '"') {
+                inString = true;
+            } else if (char === "{") {
+                interpolationDepth++;
+            } else if (char === "}") {
+                interpolationDepth--;
+            }
+            current += char;
+            continue;
+        }
+
+        // within the text of a template, only an interpolation and the closing backtick are significant
+        if (inTemplate) {
+            if (char === "{" && prev === "$") {
+                interpolationDepth++;
+            } else if (char === "`") {
+                inTemplate = false;
+            }
+            current += char;
+            continue;
+        }
+
+        // handle template boundaries
+        if (char === "`") {
+            inTemplate = true;
+            current += char;
+            continue;
+        }
+
+        // handle string boundaries
+        if (char === '"' && prev !== "\\") {
+            inString = true;
+            current += char;
+            continue;
+        }
+
+        if (char === "[" || char === "{" || char === "(") depth++;
+        if (char === "]" || char === "}" || char === ")") depth--;
+
+        if (char === "," && depth === 0) {
+            result.push(current);
+            current = "";
+            continue;
+        }
+
+        current += char;
+    }
+
+    // Always push the final element (even if empty) to preserve trailing empty values
+    result.push(current);
+
+    return result;
+}
+
+/**
+ * Builds the raw text of an array out of the elements of the editor.
+ */
+export function buildStringArray(elements: FormField[]): string {
+    if (typeof elements === "string") return elements;
+    const parts = elements.map(el => {
+        return ((el.value as string) ?? "").trim();
+    });
+    return `[${parts.join(", ")}]`;
+}

--- a/packages/ballerina-side-panel/src/components/editors/utils.ts
+++ b/packages/ballerina-side-panel/src/components/editors/utils.ts
@@ -23,6 +23,9 @@ import { InputMode } from "../..";
 import { EditorMode } from "./ExpandedEditor";
 import { EXPANDABLE_MODES } from "./ExpandedEditor/modes/types";
 
+// Re-exported so that the existing imports of these helpers keep working.
+export { stringToRawArrayElements, buildStringArray } from "./rawValueUtils";
+
 export function isDropdownField(field: FormField) {
     return field.type === "MULTIPLE_SELECT" || field.type === "SINGLE_SELECT" || field.type?.toUpperCase() === "ENUM";
 }
@@ -215,50 +218,6 @@ export const getMapSubFormFieldFromTypes = (formId: string, types: InputType[]):
     ]
 }
 
-export function stringToRawArrayElements(input: string): string[] {
-    // remove outer [ ]
-    const s = input.trim().slice(1, -1);
-
-    if (s === "") {
-        return [];
-    }
-
-    const result: string[] = [];
-    let current = "";
-    let depth = 0;
-    let inString = false;
-
-    for (let i = 0; i < s.length; i++) {
-        const char = s[i];
-        const prev = s[i - 1];
-
-        // handle string boundaries
-        if (char === '"' && prev !== "\\") {
-            inString = !inString;
-            current += char;
-            continue;
-        }
-
-        if (!inString) {
-            if (char === "[" || char === "{") depth++;
-            if (char === "]" || char === "}") depth--;
-
-            if (char === "," && depth === 0) {
-                result.push(current);
-                current = "";
-                continue;
-            }
-        }
-
-        current += char;
-    }
-
-    // Always push the final element (even if empty) to preserve trailing empty values
-    result.push(current);
-
-    return result;
-}
-
 export function stringToRawObjectEntries(
     input: string
 ): { key: string; value: string }[] {
@@ -337,14 +296,6 @@ function pushPair(
             }
         }
     }
-}
-
-export function buildStringArray(elements: FormField[]): string {
-    if (typeof elements === "string") return elements;
-    const parts = elements.map(el => {
-        return ((el.value as string) ?? "").trim();
-    });
-    return `[${parts.join(", ")}]`;
 }
 
 export function buildStringMap(elements: FormField[][] | string): string {

--- a/packages/ballerina-side-panel/src/test/rawValueUtils.test.ts
+++ b/packages/ballerina-side-panel/src/test/rawValueUtils.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Pure-logic test for the split of the raw text of an array into its elements. The module holds no
+// import of its own, so it needs no mock of the side-panel barrel.
+
+import { stringToRawArrayElements, buildStringArray } from "../components/editors/rawValueUtils";
+
+describe("stringToRawArrayElements", () => {
+    it("splits on the separators of the array", () => {
+        expect(stringToRawArrayElements("[a, b, c]")).toEqual(["a", " b", " c"]);
+        expect(stringToRawArrayElements('["a", [1, 2], {k: 1}]')).toHaveLength(3);
+    });
+
+    it("returns no element for an empty array", () => {
+        expect(stringToRawArrayElements("[]")).toEqual([]);
+    });
+
+    it("preserves a trailing empty element", () => {
+        expect(stringToRawArrayElements("[a, ]")).toEqual(["a", " "]);
+    });
+
+    it("keeps a comma of a quoted string within its element", () => {
+        expect(stringToRawArrayElements('["a, b"]')).toEqual(['"a, b"']);
+    });
+
+    it("keeps a comma of a call within its element", () => {
+        expect(stringToRawArrayElements("[foo(a, b)]")).toEqual(["foo(a, b)"]);
+    });
+
+    it("keeps a comma of a template within its element", () => {
+        const element =
+            "string `Customer details: ID ${customerIdElement.data()}, Name ${firstNameElement.data()}`";
+        expect(stringToRawArrayElements(`[${element}]`)).toEqual([element]);
+    });
+
+    it("keeps a comma of an interpolation within its element", () => {
+        const element = "string `a ${f(1, 2)} b`";
+        expect(stringToRawArrayElements(`[${element}]`)).toEqual([element]);
+    });
+
+    it("ends a template that holds a backtick within an interpolation", () => {
+        // string `Backtick:${"`"}` holds a literal backtick, which does not end the template
+        const element = 'string `Backtick:${"`"}`';
+        expect(stringToRawArrayElements(`[${element}, next]`)).toEqual([element, " next"]);
+    });
+
+    it("splits after a template", () => {
+        expect(stringToRawArrayElements('[string `p, q`, "r"]')).toEqual(["string `p, q`", ' "r"']);
+    });
+});
+
+describe("buildStringArray", () => {
+    it("lets an element of an array survive a round trip", () => {
+        const element = "string `Customer details: ID ${a.data()}, Name ${b.data()}`";
+        expect(stringToRawArrayElements(buildStringArray([{ value: element }] as any))).toEqual([element]);
+    });
+});

--- a/packages/ballerina-visualizer/src/MainPanel.tsx
+++ b/packages/ballerina-visualizer/src/MainPanel.tsx
@@ -338,6 +338,7 @@ const MainPanel = () => {
                                 <PackageOverview
                                     projectPath={value.projectPath}
                                     isInDevant={value.isInDevant}
+                                    isICPSupported={value.metadata?.isICPSupported}
                                 />
                             );
                             break;
@@ -345,7 +346,12 @@ const MainPanel = () => {
                         case MACHINE_VIEW.WorkspaceOverview: {
                             const { WorkspaceOverview } = await import("./views/BI/WorkspaceOverview");
                             if (isStaleNavigation()) return;
-                            setViewComponent(<WorkspaceOverview isInDevant={value.isInDevant} />);
+                            setViewComponent(
+                                <WorkspaceOverview
+                                    isInDevant={value.isInDevant}
+                                    isICPSupported={value.metadata?.isICPSupported}
+                                />
+                            );
                             break;
                         }
                         case MACHINE_VIEW.ServiceDesigner: {

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -812,10 +812,11 @@ function DevantDashboard({ projectStructure, handleDeploy, goToDevant }: { proje
 interface PackageOverviewProps {
     projectPath: string;
     isInDevant: boolean;
+    isICPSupported?: boolean;
 }
 
 export function PackageOverview(props: PackageOverviewProps) {
-    const { projectPath, isInDevant } = props;
+    const { projectPath, isInDevant, isICPSupported } = props;
     const { rpcClient } = useRpcContext();
     const [readmeContent, setReadmeContent] = React.useState<string>("");
     const { platformExtState } = usePlatformExtContext();
@@ -850,12 +851,14 @@ export function PackageOverview(props: PackageOverviewProps) {
                 setReadmeContent(res.content);
             });
 
-        rpcClient
-            .getICPRpcClient()
-            .isIcpEnabled({ projectPath: '' })
-            .then((res) => {
-                setEnableICP(res.enabled);
-            });
+        if (isICPSupported) {
+            rpcClient
+                .getICPRpcClient()
+                .isIcpEnabled({ projectPath: '' })
+                .then((res) => {
+                    setEnableICP(res.enabled);
+                });
+        }
 
         rpcClient
             .getWorkflowManagementRpcClient()
@@ -863,14 +866,7 @@ export function PackageOverview(props: PackageOverviewProps) {
             .then((res) => {
                 setWorkflowMgmtEnabled(res.enabled);
             });
-
-        rpcClient
-            .getBIDiagramRpcClient()
-            .getReadmeContent({ projectPath })
-            .then((res) => {
-                setReadmeContent(res.content);
-            });
-    }, [rpcClient, projectPath]);
+    }, [rpcClient, projectPath, isICPSupported]);
 
     useEffect(() => {
         fetchContext();
@@ -1237,11 +1233,15 @@ export function PackageOverview(props: PackageOverviewProps) {
                                         hasDeployableIntegration={deployableIntegrationTypes.length > 0}
                                         projectPath={projectPath}
                                     />
-                                    <Divider sx={{ margin: "16px 0" }} />
-                                    <IntegrationControlPlane enabled={enabled} handleICP={handleICP} />
-                                    <div style={{ marginTop: 8 }}>
-                                        <LocalICPDeployment />
-                                    </div>
+                                    {isICPSupported && (
+                                        <>
+                                            <Divider sx={{ margin: "16px 0" }} />
+                                            <IntegrationControlPlane enabled={enabled} handleICP={handleICP} />
+                                            <div style={{ marginTop: 8 }}>
+                                                <LocalICPDeployment />
+                                            </div>
+                                        </>
+                                    )}
                                     {(projectStructure?.directoryMap?.[DIRECTORY_MAP.WORKFLOW]?.length ?? 0) > 0 && (
                                         <>
                                             <Divider sx={{ margin: "16px 0" }} />

--- a/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -726,9 +726,10 @@ function IntegrationControlPlane({
 
 interface WorkspaceOverviewProps {
     isInDevant: boolean;
+    isICPSupported?: boolean;
 }
 
-export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
+export function WorkspaceOverview({ isInDevant, isICPSupported }: WorkspaceOverviewProps) {
     const { rpcClient } = useRpcContext();
     const [readmeContent, setReadmeContent] = React.useState<string>("");
     const [projectCollection, setProjectCollection] = React.useState<ProjectStructureResponse>();
@@ -753,7 +754,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
     };
 
     const syncProjectICPStatus = async (projectPaths: string[]) => {
-        if (projectPaths.length === 0) {
+        if (!isICPSupported || projectPaths.length === 0) {
             setIcpStatusByProjectPath({});
             return;
         }
@@ -784,13 +785,6 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                 rpcClient
                     .getBIDiagramRpcClient()
                     .handleReadmeContent({ projectPath: res.workspacePath, read: true })
-                    .then((res) => {
-                        setReadmeContent(res.content);
-                    });
-        
-                rpcClient
-                    .getBIDiagramRpcClient()
-                    .getReadmeContent({ projectPath: res.workspacePath })
                     .then((res) => {
                         setReadmeContent(res.content);
                     });
@@ -1124,7 +1118,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                                 <PackageListView
                                     projectCollection={projectCollection}
                                     icpStatusByProjectPath={icpStatusByProjectPath}
-                                    showICPBadge={icpState !== "none"}
+                                    showICPBadge={isICPSupported && icpState !== "none"}
                                 />
                             )}
                         </ContentPanel>
@@ -1177,16 +1171,20 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                                     deployableProjectPaths={deployableProjectPaths}
                                     libraryProjectPaths={libraryProjectPaths}
                                 />
-                                <Divider sx={{ margin: "16px 0" }} />
-                                <IntegrationControlPlane
-                                    icpState={icpState}
-                                    enabledCount={icpEnabledCount}
-                                    totalCount={icpProjectPaths.length}
-                                    onEnableAll={handleEnableAllICP}
-                                    onDisableAll={handleDisableAllICP}
-                                    onEnableRemaining={handleEnableRemainingICP}
-                                    icpActionLoading={icpActionLoading}
-                                />
+                                {isICPSupported && (
+                                    <>
+                                        <Divider sx={{ margin: "16px 0" }} />
+                                        <IntegrationControlPlane
+                                            icpState={icpState}
+                                            enabledCount={icpEnabledCount}
+                                            totalCount={icpProjectPaths.length}
+                                            onEnableAll={handleEnableAllICP}
+                                            onDisableAll={handleDisableAllICP}
+                                            onEnableRemaining={handleEnableRemainingICP}
+                                            icpActionLoading={icpActionLoading}
+                                        />
+                                    </>
+                                )}
                             </>
                         )}
                         {isInDevant && (


### PR DESCRIPTION
## Purpose

Sync of two fixes already merged into the old extensions repo, so that this repo carries them as well:

- wso2/vscode-extensions#2438 — Remove ICP for ballerina-ext users (wso2/product-integrator#1927)
- wso2/vscode-extensions#2447 — Fix side panel crash for a list element with a comma (wso2/product-integrator#1979)

One commit per upstream PR.

## Goals

Carry both fixes over with the same behaviour as upstream, adapted where this repo's layout or test tooling differs.

## Approach

### Commit 1 — Remove ICP for ballerina-ext users

ICP ships as part of the WSO2 Integrator installation, but the Ballerina extension activated it unconditionally, so standalone users were shown ICP commands, the ICP status bar item and ICP sections in the overview webviews.

`isICPSupported()` in `packages/ballerina-extension/src/utils/config.ts` is the single source of truth (delegating to `isInWI()`), applied at four layers:

1. **Activation** — `extension.ts` skips `activateICP()`, and `features/bi/activator.ts` skips the per-project `isIcpEnabled` probe, avoiding an LS round trip on every visualizer open.
2. **Commands** — `activateICP()` sets the `ballerina.icpSupported` context key, which the `enablement` clauses of `ballerina.icp.start` / `ballerina.icp.stop` now require. The key is only ever set inside `activateICP()`, so it evaluates as false for standalone users and no teardown path is needed.
3. **RPC** — `ICPServiceRpcManager` guards `addICP`, `disableICP`, `viewInICP`, `isIcpEnabled` and `isICPServerRunning`. Defence in depth: `addICP` writes ICP imports and `Config.toml` entries, so a restored or stale webview must not be able to mutate a project with an unsupported feature.
4. **Webviews** — `isICPSupported` is threaded through `VisualizerMetadata` → `MainPanel` → `PackageOverview` / `WorkspaceOverview`, which hide the ICP panel and its divider and skip the ICP status fetch. `WorkspaceOverview` also suppresses the per-package ICP badge and short-circuits `syncProjectICPStatus`.

The flag is optional (`isICPSupported?: boolean`) and read via `value.metadata?.isICPSupported`, so a context payload without it falls through to hiding ICP.

Behaviour under the Integrator is unchanged.

### Commit 2 — Fix side panel crash for a list element with a comma

The form of a node such as the following could not be opened:

```ballerina
io:println(string `Customer details: ID ${customerIdElement.data()}, Name ${firstNameElement.data()}`);
```

The rest parameter is a `REPEATABLE_LIST`, which `FormArrayEditor` rendered by building a string out of the value array and splitting it back apart. `stringToRawArrayElements()` tracked only a double quoted string and the `[` / `{` nesting; a backtick template was tracked by neither, and the braces of the `${...}` interpolation preceding the comma close before it is reached. The comma was therefore read as an element separator and the single argument was split into two. The editor then held one key per element of the value array and two values, and the length check threw inside an effect, so the side panel crashed instead of showing the form. `io:println(foo(a, b))` failed the same way, since parentheses were not counted either.

The node template returned by the language server is correct, so this is a fix on the editor alone.

- `FormArrayEditor` reads the values directly from the value array, so the keys and the values can no longer disagree. The string path is unchanged, since the mode switcher hands over a raw string.
- `stringToRawArrayElements()` tracks a backtick template and treats the whole span as opaque — a comma within a template is never a separator, not even within an interpolation such as `${f(1, 2)}` — and counts parentheses along with `[` and `{`. Moved to a new `rawValueUtils.ts` that holds no import of its own, and re-exported from `utils.ts` so existing imports keep working. This path is still used by the mode switcher and by `FlowNodeForm`, where a wrong split silently attaches the diagnostics of one element to another.
- The length check no longer throws. The keys only identify the elements of the editor, so they are adjusted to the values and a warning is logged.

## Deviations from the upstream PRs

Both are consequences of this repo's layout, not behaviour changes:

- **`PackageOverview` effect** — upstream also dropped a redundant second `getReadmeContent` call in the same effect. This repo has an `isWorkflowManagementEnabled` call between it and the ICP call; that call is kept, and only the redundant readme fetch is dropped.
- **Side panel tests** — upstream added `test/rawValueUtils.test.mjs`, a `node:test` suite run against the compiled `lib/`, plus a `test` script change in `package.json`. This repo runs the side panel tests through jest from `src/test`, so the cases are ported to `src/test/rawValueUtils.test.ts` and the upstream `package.json` change is dropped (jest discovers the file).

## UI Component Development

- [x] Matches with the native VSCode look and feel — no new components; the ICP change only removes existing sections from the two overview views.
- No new reusable components, so nothing to add to the ui-toolkit.

## Release note

- ICP is no longer offered in the standalone Ballerina extension. It remains available as before when the WSO2 Integrator extension is installed.
- Fixed a side panel crash when opening the form of a node whose list argument contains a comma, such as a string template or a nested call.

## Documentation

N/A — no documented behaviour changes for Integrator users, and the second change is a crash fix.

## Automation tests

- Unit tests — 10 cases ported to `packages/ballerina-side-panel/src/test/rawValueUtils.test.ts`, covering the failing template element, a comma within parentheses, within double quotes and within an interpolation, a template holding a backtick inside an interpolation, plus the inputs that must still split (plain separator, mixed nesting, a template followed by a separator, an empty array, a trailing empty element).
- The ICP change is a set of activation and render guards with no new logic to assert against; the existing ICP behaviour under the Integrator is unchanged.

Verified locally:

- `rush build --to @wso2/ballerina-visualizer` — success (includes `ballerina-core` and `ballerina-side-panel`)
- `npx tsc -p ./ --noEmit` in `packages/ballerina-extension` — clean
- `npx jest` in `packages/ballerina-side-panel` — 24 suites, 138 tests passed, including the pre-existing `editorUtils` and `ArrayEditor` suites that cover these helpers

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs

- wso2/vscode-extensions#2438 (merged)
- wso2/vscode-extensions#2447 (merged)

## Test environment

macOS, Node.js 22.17.0. Behaviour verified upstream in the extension per the original PRs; this sync was verified through the build, typecheck and unit test runs listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Disabled ICP activation, commands, RPC operations, and UI controls for standalone Ballerina extension users.
- Preserved ICP behavior when the WSO2 Integrator extension is installed.
- Fixed repeatable-list parsing for values that contain commas or nested structures.
- Prevented side panel crashes caused by mismatched array keys and values.
- Added raw-value parsing utilities and Jest tests for the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->