### PR TITLE
Add WhatsApp Business, Telegram, and Google Chat as schema-driven triggers

### DIFF
--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/bundled_trigger_models.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/bundled_trigger_models.json
@@ -22,5 +22,8 @@
   "oracledb": "trigger-models/oracledb.json",
   "solace": "trigger-models/solace.json",
   "solace.jms": "trigger-models/solace.jms.json",
-  "sap.jco": "trigger-models/sap.jco.json"
+  "sap.jco": "trigger-models/sap.jco.json",
+  "whatsapp.business": "trigger-models/whatsapp.business.json",
+  "telegram": "trigger-models/telegram.json",
+  "googleapis.chat": "trigger-models/googleapis.chat.json"
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/googleapis.chat.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/googleapis.chat.json
@@ -1,0 +1,1525 @@
+{
+  "schemaVersion": "1.0",
+  "id": "googleapis.chat",
+  "displayName": "Google Chat",
+  "description": "Create a service to handle Google Chat app interaction events (messages, card clicks, app commands, and more)",
+  "orgName": "ballerinax",
+  "packageName": "googleapis.chat",
+  "moduleName": "googleapis.chat",
+  "version": "0.1.0",
+  "type": "chat",
+  "icon": "icon.png",
+  "kind": "event",
+  "initProperties": {
+    "listener": {
+      "metadata": {
+        "label": "Configure Google Chat Listener",
+        "description": "Select an existing Google Chat listener or create a new one"
+      },
+      "types": [
+        {
+          "fieldType": "CHOICE",
+          "selected": true
+        }
+      ],
+      "value": "createNew",
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false,
+      "codedata": {
+        "type": "LISTENER_CONFIG"
+      },
+      "choices": [
+        {
+          "metadata": {
+            "label": "Create new",
+            "description": "Create a new Google Chat listener"
+          },
+          "types": [
+            {
+              "fieldType": "FORM",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "properties": {
+            "listenerConfig": {
+              "metadata": {
+                "label": "Listener Configurations",
+                "description": "Configure the Google Chat webhook listener"
+              },
+              "types": [
+                {
+                  "fieldType": "GROUP_SECTION",
+                  "selected": true
+                }
+              ],
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "properties": {
+                "listenerVarName": {
+                  "metadata": {
+                    "label": "Listener Name",
+                    "description": "Provide a name for the listener being created."
+                  },
+                  "types": [
+                    {
+                      "fieldType": "IDENTIFIER",
+                      "selected": true,
+                      "ballerinaType": "googleapis.chat:Listener"
+                    }
+                  ],
+                  "value": "chatListener",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "type": "LISTENER_VAR_NAME"
+                  },
+                  "validations": [
+                    {
+                      "rule": "common.validate.identifier"
+                    },
+                    {
+                      "rule": "ls.validate.unique.listener.name",
+                      "message": "A listener with this name already exists in the project"
+                    }
+                  ]
+                },
+                "listenOn": {
+                  "metadata": {
+                    "label": "Port",
+                    "description": "A port number to bind a new HTTP listener to, or an existing `http:Listener` to reuse. Defaults to 8000."
+                  },
+                  "value": "8000",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": true,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_REQUIRED",
+                    "originalName": "listenOn",
+                    "position": 1
+                  },
+                  "types": [
+                    {
+                      "fieldType": "NUMBER",
+                      "ballerinaType": "int|http:Listener",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int|http:Listener",
+                      "selected": false
+                    }
+                  ],
+                  "placeholder": "8000"
+                },
+                "auth": {
+                  "metadata": {
+                    "label": "Auth Config",
+                    "description": "Authentication for the Chat API client used to respond to events: a service account (JSON key file or inline credentials), OAuth2, or a pre-obtained bearer token."
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_INCLUDED_FIELD",
+                    "originalName": "auth",
+                    "path": "auth"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "RECORD_MAP_EXPRESSION",
+                      "ballerinaType": "chat:ServiceAccountAuthConfig|chat:OAuth2Config|http:BearerTokenConfig",
+                      "typeMembers": [
+                        {
+                          "type": "ServiceAccountFileConfig",
+                          "packageInfo": "ballerinax:googleapis.chat:0.1.0",
+                          "packageName": "chat",
+                          "kind": "RECORD_TYPE",
+                          "selected": true
+                        },
+                        {
+                          "type": "ServiceAccountCredentials",
+                          "packageInfo": "ballerinax:googleapis.chat:0.1.0",
+                          "packageName": "chat",
+                          "kind": "RECORD_TYPE",
+                          "selected": false
+                        },
+                        {
+                          "type": "OAuth2Config",
+                          "packageInfo": "ballerinax:googleapis.chat:0.1.0",
+                          "packageName": "chat",
+                          "kind": "RECORD_TYPE",
+                          "selected": false
+                        },
+                        {
+                          "type": "BearerTokenConfig",
+                          "packageInfo": "ballerina:http:2.15.7",
+                          "packageName": "http",
+                          "kind": "RECORD_TYPE",
+                          "selected": false
+                        }
+                      ],
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "chat:ServiceAccountAuthConfig|chat:OAuth2Config|http:BearerTokenConfig",
+                      "selected": false
+                    }
+                  ]
+                },
+                "httpListenerConfig": {
+                  "metadata": {
+                    "label": "HTTP Listener Config",
+                    "description": "Optional inbound HTTP listener settings (SSL/TLS, timeouts, request limits, ...)"
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": true,
+                  "advanced": true,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                    "originalName": "httpListenerConfig",
+                    "path": "httpListenerConfig"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "RECORD_MAP_EXPRESSION",
+                      "ballerinaType": "http:ListenerConfiguration",
+                      "typeMembers": [
+                        {
+                          "type": "ListenerConfiguration",
+                          "packageInfo": "ballerina:http:2.15.7",
+                          "packageName": "http",
+                          "kind": "RECORD_TYPE",
+                          "selected": true
+                        }
+                      ],
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "http:ListenerConfiguration",
+                      "selected": false
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "Use existing",
+            "description": "Select an existing Google Chat listener"
+          },
+          "types": [
+            {
+              "fieldType": "FORM",
+              "selected": true
+            }
+          ],
+          "enabled": false,
+          "editable": false,
+          "optional": false,
+          "advanced": false,
+          "properties": {
+            "existingListener": {
+              "metadata": {
+                "label": "Listener(s)",
+                "description": "Select one or more existing Google Chat listeners to attach to"
+              },
+              "types": [
+                {
+                  "fieldType": "MULTI_SELECT_LISTENER",
+                  "selected": true,
+                  "ballerinaType": "googleapis.chat:Listener"
+                }
+              ],
+              "items": [],
+              "value": [],
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "codedata": {
+                "type": "KEY_EXISTING_LISTENER"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "serviceTypes": [
+    {
+      "metadata": {
+        "label": "Chat Service",
+        "description": "Handles Google Chat app interaction events. Handler methods are recognised by convention, not declared on the type; declare only the ones you need."
+      },
+      "name": "ChatService",
+      "description": "Triggers when a Google Chat interaction event is received.\n\nImplement this service object to handle Chat app events. Each remote function\ncorresponds to a specific event type. You only need to implement the handlers\nrelevant to your Chat app.\n\nEach handler receives the event and an event-specific Caller for responding.\nThe Caller's respond() method sends a synchronous HTTP response back to\nGoogle Chat. Additional async Chat API operations (sendMessage, updateMessage,\netc.) are available on callers that support them.\n\n```ballerina\nremote function onMessage(chat:MessageEvent event, chat:MessageCaller caller) returns error? {\n    check caller->respond({ text: \"Got your message!\" });\n}\nremote function onAppHome(chat:ChatEvent event, chat:AppHomeCaller caller) returns error? {\n    check caller->respond({ sections: [{ widgets: [{ textParagraph: { text: \"Welcome!\" } }] }] });\n}\n```\n\n**Available event handlers:**\n- `onMessage(MessageEvent|ChatEvent, MessageCaller)` - A user sends a message\n- `onAddedToSpace(ChatEvent, MessageCaller)` - The app is added to a space\n- `onRemovedFromSpace(ChatEvent)` - The app is removed from a space (no caller)\n- `onCardClicked(ChatEvent, CardClickedCaller)` - A user clicks a button/card element\n- `onWidgetUpdated(ChatEvent, WidgetUpdatedCaller)` - A user updates a widget\n- `onAppCommand(ChatEvent, MessageCaller)` - A user invokes a command\n- `onAppHome(ChatEvent, AppHomeCaller)` - A user navigates to the app home\n- `onSubmitForm(ChatEvent, SubmitFormCaller)` - A user submits a form from app home",
+      "enabled": true,
+      "editable": false,
+      "codedata": {
+        "type": "SERVICE_TYPE_DESCRIPTOR",
+        "moduleName": "chat",
+        "originalName": "ChatService"
+      },
+      "properties": {
+        "serviceConfig": {
+          "metadata": {
+            "label": "Service Config",
+            "description": "@chat:ServiceConfig \u2014 bearer-token verification settings for this Chat app: verify by HTTP endpoint URL (recommended) or by GCP project number."
+          },
+          "types": [
+            {
+              "fieldType": "CHOICE",
+              "selected": true,
+              "ballerinaType": "chat:ServiceConfiguration"
+            }
+          ],
+          "value": "endpointUrl",
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "codedata": {
+            "type": "SERVICE_ANNOTATION",
+            "originalName": "ServiceConfig",
+            "moduleName": "chat",
+            "path": ""
+          },
+          "choices": [
+            {
+              "metadata": {
+                "label": "HTTP Endpoint URL",
+                "description": "Verify the bearer token's audience against this listener's public HTTPS endpoint URL (recommended)."
+              },
+              "types": [
+                {
+                  "fieldType": "FORM",
+                  "selected": true
+                }
+              ],
+              "value": "endpointUrl",
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "codedata": {
+                "type": "MAPPING_CONSTRUCTOR"
+              },
+              "properties": {
+                "endpointUrl": {
+                  "metadata": {
+                    "label": "Endpoint URL",
+                    "description": "The public HTTPS URL of this listener, exactly as entered in the Chat app's HTTP endpoint URL field."
+                  },
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "selected": true,
+                      "ballerinaType": "string"
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "selected": false,
+                      "ballerinaType": "string"
+                    }
+                  ],
+                  "value": "",
+                  "placeholder": "https://my-app.example.com",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "type": "MAPPING_FIELD",
+                    "field": "endpointUrl",
+                    "valueKind": "STRING_LITERAL"
+                  }
+                }
+              }
+            },
+            {
+              "metadata": {
+                "label": "Project Number",
+                "description": "Verify the bearer token's audience against this GCP project number."
+              },
+              "types": [
+                {
+                  "fieldType": "FORM",
+                  "selected": true
+                }
+              ],
+              "value": "projectNumber",
+              "enabled": false,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "codedata": {
+                "type": "MAPPING_CONSTRUCTOR"
+              },
+              "properties": {
+                "projectNumber": {
+                  "metadata": {
+                    "label": "Project Number",
+                    "description": "The GCP project number used to build the Chat app."
+                  },
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "selected": true,
+                      "ballerinaType": "string"
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "selected": false,
+                      "ballerinaType": "string"
+                    }
+                  ],
+                  "value": "",
+                  "placeholder": "1234567890",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "type": "MAPPING_FIELD",
+                    "field": "projectNumber",
+                    "valueKind": "STRING_LITERAL"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "functions": [],
+      "schemaFunctions": [
+        {
+          "metadata": {
+            "label": "On Message",
+            "description": "Invoked when a user sends a message to the Chat app."
+          },
+          "name": "onMessage",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onMessage",
+            "moduleName": "chat"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Event",
+                "description": "Invoked when a user sends a message to the Chat app."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "chat:MessageEvent",
+                "value": "chat:MessageEvent",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  },
+                  {
+                    "fieldType": "TYPE",
+                    "selected": false
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "event",
+                  "description": "Invoked when a user sends a message to the Chat app."
+                },
+                "placeholder": "event",
+                "value": "event",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            },
+            {
+              "metadata": {
+                "label": "Caller",
+                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+              },
+              "kind": "OPTIONAL",
+              "type": {
+                "metadata": {
+                  "label": "Include Caller",
+                  "description": "Tick to include the caller parameter in the handler signature."
+                },
+                "placeholder": "chat:MessageCaller",
+                "value": true,
+                "types": [
+                  {
+                    "fieldType": "FLAG",
+                    "selected": true,
+                    "ballerinaType": "chat:MessageCaller"
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "caller",
+                  "description": "Used to respond to the event."
+                },
+                "placeholder": "caller",
+                "value": "caller",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": true,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Added To Space",
+            "description": "Invoked when the Chat app is added to a space."
+          },
+          "name": "onAddedToSpace",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onAddedToSpace",
+            "moduleName": "chat"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Event",
+                "description": "Invoked when the Chat app is added to a space."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "chat:ChatEvent",
+                "value": "chat:ChatEvent",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "event",
+                  "description": "Invoked when the Chat app is added to a space."
+                },
+                "placeholder": "event",
+                "value": "event",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            },
+            {
+              "metadata": {
+                "label": "Caller",
+                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+              },
+              "kind": "OPTIONAL",
+              "type": {
+                "metadata": {
+                  "label": "Include Caller",
+                  "description": "Tick to include the caller parameter in the handler signature."
+                },
+                "placeholder": "chat:MessageCaller",
+                "value": true,
+                "types": [
+                  {
+                    "fieldType": "FLAG",
+                    "selected": true,
+                    "ballerinaType": "chat:MessageCaller"
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "caller",
+                  "description": "Used to respond to the event."
+                },
+                "placeholder": "caller",
+                "value": "caller",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": true,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Removed From Space",
+            "description": "Invoked when the Chat app is removed from a space."
+          },
+          "name": "onRemovedFromSpace",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onRemovedFromSpace",
+            "moduleName": "chat"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Event",
+                "description": "Invoked when the Chat app is removed from a space."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "chat:ChatEvent",
+                "value": "chat:ChatEvent",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "event",
+                  "description": "Invoked when the Chat app is removed from a space."
+                },
+                "placeholder": "event",
+                "value": "event",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Card Clicked",
+            "description": "Invoked when a user clicks a button or card element."
+          },
+          "name": "onCardClicked",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onCardClicked",
+            "moduleName": "chat"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Event",
+                "description": "Invoked when a user clicks a button or card element."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "chat:ChatEvent",
+                "value": "chat:ChatEvent",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "event",
+                  "description": "Invoked when a user clicks a button or card element."
+                },
+                "placeholder": "event",
+                "value": "event",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            },
+            {
+              "metadata": {
+                "label": "Caller",
+                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+              },
+              "kind": "OPTIONAL",
+              "type": {
+                "metadata": {
+                  "label": "Include Caller",
+                  "description": "Tick to include the caller parameter in the handler signature."
+                },
+                "placeholder": "chat:CardClickedCaller",
+                "value": true,
+                "types": [
+                  {
+                    "fieldType": "FLAG",
+                    "selected": true,
+                    "ballerinaType": "chat:CardClickedCaller"
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "caller",
+                  "description": "Used to respond to the event."
+                },
+                "placeholder": "caller",
+                "value": "caller",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": true,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Widget Updated",
+            "description": "Invoked when a user updates a widget."
+          },
+          "name": "onWidgetUpdated",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onWidgetUpdated",
+            "moduleName": "chat"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Event",
+                "description": "Invoked when a user updates a widget."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "chat:ChatEvent",
+                "value": "chat:ChatEvent",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "event",
+                  "description": "Invoked when a user updates a widget."
+                },
+                "placeholder": "event",
+                "value": "event",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            },
+            {
+              "metadata": {
+                "label": "Caller",
+                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+              },
+              "kind": "OPTIONAL",
+              "type": {
+                "metadata": {
+                  "label": "Include Caller",
+                  "description": "Tick to include the caller parameter in the handler signature."
+                },
+                "placeholder": "chat:WidgetUpdatedCaller",
+                "value": true,
+                "types": [
+                  {
+                    "fieldType": "FLAG",
+                    "selected": true,
+                    "ballerinaType": "chat:WidgetUpdatedCaller"
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "caller",
+                  "description": "Used to respond to the event."
+                },
+                "placeholder": "caller",
+                "value": "caller",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": true,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On App Command",
+            "description": "Invoked when a user invokes a Chat app command."
+          },
+          "name": "onAppCommand",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onAppCommand",
+            "moduleName": "chat"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Event",
+                "description": "Invoked when a user invokes a Chat app command."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "chat:ChatEvent",
+                "value": "chat:ChatEvent",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "event",
+                  "description": "Invoked when a user invokes a Chat app command."
+                },
+                "placeholder": "event",
+                "value": "event",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            },
+            {
+              "metadata": {
+                "label": "Caller",
+                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+              },
+              "kind": "OPTIONAL",
+              "type": {
+                "metadata": {
+                  "label": "Include Caller",
+                  "description": "Tick to include the caller parameter in the handler signature."
+                },
+                "placeholder": "chat:MessageCaller",
+                "value": true,
+                "types": [
+                  {
+                    "fieldType": "FLAG",
+                    "selected": true,
+                    "ballerinaType": "chat:MessageCaller"
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "caller",
+                  "description": "Used to respond to the event."
+                },
+                "placeholder": "caller",
+                "value": "caller",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": true,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On App Home",
+            "description": "Invoked when a user navigates to the Chat app's home view."
+          },
+          "name": "onAppHome",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onAppHome",
+            "moduleName": "chat"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Event",
+                "description": "Invoked when a user navigates to the Chat app's home view."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "chat:ChatEvent",
+                "value": "chat:ChatEvent",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "event",
+                  "description": "Invoked when a user navigates to the Chat app's home view."
+                },
+                "placeholder": "event",
+                "value": "event",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            },
+            {
+              "metadata": {
+                "label": "Caller",
+                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+              },
+              "kind": "OPTIONAL",
+              "type": {
+                "metadata": {
+                  "label": "Include Caller",
+                  "description": "Tick to include the caller parameter in the handler signature."
+                },
+                "placeholder": "chat:AppHomeCaller",
+                "value": true,
+                "types": [
+                  {
+                    "fieldType": "FLAG",
+                    "selected": true,
+                    "ballerinaType": "chat:AppHomeCaller"
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "caller",
+                  "description": "Used to respond to the event."
+                },
+                "placeholder": "caller",
+                "value": "caller",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": true,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Submit Form",
+            "description": "Invoked when a user submits a form from the Chat app's home view."
+          },
+          "name": "onSubmitForm",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onSubmitForm",
+            "moduleName": "chat"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Event",
+                "description": "Invoked when a user submits a form from the Chat app's home view."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "chat:ChatEvent",
+                "value": "chat:ChatEvent",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "event",
+                  "description": "Invoked when a user submits a form from the Chat app's home view."
+                },
+                "placeholder": "event",
+                "value": "event",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            },
+            {
+              "metadata": {
+                "label": "Caller",
+                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+              },
+              "kind": "OPTIONAL",
+              "type": {
+                "metadata": {
+                  "label": "Include Caller",
+                  "description": "Tick to include the caller parameter in the handler signature."
+                },
+                "placeholder": "chat:SubmitFormCaller",
+                "value": true,
+                "types": [
+                  {
+                    "fieldType": "FLAG",
+                    "selected": true,
+                    "ballerinaType": "chat:SubmitFormCaller"
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "caller",
+                  "description": "Used to respond to the event."
+                },
+                "placeholder": "caller",
+                "value": "caller",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": true,
+              "optional": true,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "importStatements": [
+    "ballerina/http"
+  ],
+  "listenerKind": "MULTIPLE_SELECT_LISTENER"
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/telegram.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/telegram.json
@@ -1,0 +1,1141 @@
+{
+  "schemaVersion": "1.0",
+  "id": "telegram",
+  "displayName": "Telegram",
+  "description": "Create a service to handle Telegram Bot API webhook updates (messages, callback queries, inline queries, and more)",
+  "orgName": "ballerinax",
+  "packageName": "telegram",
+  "moduleName": "telegram",
+  "version": "0.9.1",
+  "type": "telegram",
+  "icon": "icon.png",
+  "kind": "event",
+  "initProperties": {
+    "listener": {
+      "metadata": {
+        "label": "Configure Telegram Listener",
+        "description": "Select an existing Telegram listener or create a new one"
+      },
+      "types": [
+        {
+          "fieldType": "CHOICE",
+          "selected": true
+        }
+      ],
+      "value": "createNew",
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false,
+      "codedata": {
+        "type": "LISTENER_CONFIG"
+      },
+      "choices": [
+        {
+          "metadata": {
+            "label": "Create new",
+            "description": "Create a new Telegram listener"
+          },
+          "types": [
+            {
+              "fieldType": "FORM",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "properties": {
+            "listenerConfig": {
+              "metadata": {
+                "label": "Listener Configurations",
+                "description": "Configure the Telegram webhook listener"
+              },
+              "types": [
+                {
+                  "fieldType": "GROUP_SECTION",
+                  "selected": true
+                }
+              ],
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "properties": {
+                "listenerVarName": {
+                  "metadata": {
+                    "label": "Listener Name",
+                    "description": "Provide a name for the listener being created."
+                  },
+                  "types": [
+                    {
+                      "fieldType": "IDENTIFIER",
+                      "selected": true,
+                      "ballerinaType": "telegram:Listener"
+                    }
+                  ],
+                  "value": "telegramListener",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "type": "LISTENER_VAR_NAME"
+                  },
+                  "validations": [
+                    {
+                      "rule": "common.validate.identifier"
+                    },
+                    {
+                      "rule": "ls.validate.unique.listener.name",
+                      "message": "A listener with this name already exists in the project"
+                    }
+                  ]
+                },
+                "listenTo": {
+                  "metadata": {
+                    "label": "Port",
+                    "description": "A port number to bind a new HTTP listener to, or an existing `http:Listener` to reuse"
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_REQUIRED",
+                    "originalName": "listenTo",
+                    "position": 1
+                  },
+                  "types": [
+                    {
+                      "fieldType": "NUMBER",
+                      "ballerinaType": "int|http:Listener",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int|http:Listener",
+                      "selected": false
+                    }
+                  ],
+                  "placeholder": "8090"
+                },
+                "secretToken": {
+                  "metadata": {
+                    "label": "Secret Token",
+                    "description": "Use this secret token directly. Every inbound update is authenticated by comparing it\nagainst the `X-Telegram-Bot-Api-Secret-Token` header."
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": true,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                    "originalName": "secretToken",
+                    "path": "secretToken"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "ballerinaType": "string",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "string",
+                      "selected": false
+                    }
+                  ],
+                  "placeholder": "<SECRET_TOKEN>"
+                },
+                "token": {
+                  "metadata": {
+                    "label": "Bot Token",
+                    "description": "Derive the secret token from this bot token via `deriveSecretToken` \u2014 the same derivation\n`Client->setWebhook` falls back to when its own `secret_token` option is omitted, so neither\nside needs a separately invented/threaded secret. Also required (alongside `publicUrl`) for\nthe listener to register its own webhook automatically when it starts."
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": true,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                    "originalName": "token",
+                    "path": "token"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "ballerinaType": "string",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "string",
+                      "selected": false
+                    }
+                  ],
+                  "placeholder": "<BOT_TOKEN>"
+                },
+                "publicUrl": {
+                  "metadata": {
+                    "label": "Public URL",
+                    "description": "This listener's public HTTPS URL. When set together with `token`, starting the listener\nautomatically registers it as the webhook via `Client->setWebhook`, so no separate\n`setWebhook` call is needed."
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": true,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                    "originalName": "publicUrl",
+                    "path": "publicUrl"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "ballerinaType": "string",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "string",
+                      "selected": false
+                    }
+                  ],
+                  "placeholder": "https://<PUBLIC_HOST>/"
+                },
+                "serviceUrl": {
+                  "metadata": {
+                    "label": "Service URL",
+                    "description": "The Telegram Bot API base URL used for the automatic `setWebhook` call when `publicUrl` is\nset. Only useful to override in tests or when routing through a proxy."
+                  },
+                  "value": "\"https://api.telegram.org\"",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": true,
+                  "advanced": true,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                    "originalName": "serviceUrl",
+                    "path": "serviceUrl"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "ballerinaType": "string",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "string",
+                      "selected": false
+                    }
+                  ],
+                  "placeholder": "https://api.telegram.org"
+                }
+              }
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "Use existing",
+            "description": "Select an existing Telegram listener"
+          },
+          "types": [
+            {
+              "fieldType": "FORM",
+              "selected": true
+            }
+          ],
+          "enabled": false,
+          "editable": false,
+          "optional": false,
+          "advanced": false,
+          "properties": {
+            "existingListener": {
+              "metadata": {
+                "label": "Listener(s)",
+                "description": "Select one or more existing Telegram listeners to attach to"
+              },
+              "types": [
+                {
+                  "fieldType": "MULTI_SELECT_LISTENER",
+                  "selected": true,
+                  "ballerinaType": "telegram:Listener"
+                }
+              ],
+              "items": [],
+              "value": [],
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "codedata": {
+                "type": "KEY_EXISTING_LISTENER"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "serviceTypes": [
+    {
+      "metadata": {
+        "label": "Telegram Service",
+        "description": "Handles Telegram Bot API webhook updates. Handler methods are recognised by convention, not declared on the type; declare only the ones you need."
+      },
+      "name": "TelegramService",
+      "description": "The service object a consumer implements to handle Telegram webhook updates. Attach an\nimplementation to a `Listener` to receive updates.\n\n`TelegramService` declares no remote methods of its own \u2014 implement only the handlers you need;\nan unimplemented handler is simply not invoked. Declaring a remote function under any other\nname, with the wrong parameter type, or without the `remote` qualifier is a compile error (see\nthis connector's compiler plugin). There are nine supported handlers, one per supported update\ntype:\n\n- `remote function onMessage(Message message) returns error?;` \u2014 a new incoming message.\n- `remote function onEditedMessage(Message editedMessage) returns error?;` \u2014 a message the\nbot knows about was edited.\n- `remote function onChannelPost(Message channelPost) returns error?;` \u2014 a new channel post.\n- `remote function onEditedChannelPost(Message editedChannelPost) returns error?;` \u2014 a\nchannel post the bot knows about was edited.\n- `remote function onCallbackQuery(CallbackQuery callbackQuery) returns error?;` \u2014 an inline\nkeyboard button press.\n- `remote function onInlineQuery(InlineQuery inlineQuery) returns error?;` \u2014 a new inline query.\n- `remote function onPoll(Poll poll) returns error?;` \u2014 a poll's state changed.\n- `remote function onPreCheckoutQuery(PreCheckoutQuery preCheckoutQuery) returns error?;` \u2014 a new\npre-checkout query.\n- `remote function onShippingQuery(ShippingQuery shippingQuery) returns error?;` \u2014 a new shipping\nquery.\n\nAn update outside this set (e.g. `poll_answer`, `my_chat_member`, `chat_member`,\n`chat_join_request`, business-account events) is logged and dropped rather than delivered to a\nhandler.",
+      "enabled": true,
+      "editable": false,
+      "codedata": {
+        "type": "SERVICE_TYPE_DESCRIPTOR",
+        "moduleName": "telegram",
+        "originalName": "TelegramService"
+      },
+      "properties": {},
+      "functions": [],
+      "schemaFunctions": [
+        {
+          "metadata": {
+            "label": "On Message",
+            "description": "Invoked when a new incoming message is received."
+          },
+          "name": "onMessage",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onMessage",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Message",
+                "description": "Invoked when a new incoming message is received."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:Message",
+                "value": "telegram:Message",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "message",
+                  "description": "Invoked when a new incoming message is received."
+                },
+                "placeholder": "message",
+                "value": "message",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Edited Message",
+            "description": "Invoked when a message the bot knows about was edited."
+          },
+          "name": "onEditedMessage",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onEditedMessage",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Edited Message",
+                "description": "Invoked when a message the bot knows about was edited."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:Message",
+                "value": "telegram:Message",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "editedMessage",
+                  "description": "Invoked when a message the bot knows about was edited."
+                },
+                "placeholder": "editedMessage",
+                "value": "editedMessage",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Channel Post",
+            "description": "Invoked when a new channel post is received."
+          },
+          "name": "onChannelPost",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onChannelPost",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Channel Post",
+                "description": "Invoked when a new channel post is received."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:Message",
+                "value": "telegram:Message",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "channelPost",
+                  "description": "Invoked when a new channel post is received."
+                },
+                "placeholder": "channelPost",
+                "value": "channelPost",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Edited Channel Post",
+            "description": "Invoked when a channel post the bot knows about was edited."
+          },
+          "name": "onEditedChannelPost",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onEditedChannelPost",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Edited Channel Post",
+                "description": "Invoked when a channel post the bot knows about was edited."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:Message",
+                "value": "telegram:Message",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "editedChannelPost",
+                  "description": "Invoked when a channel post the bot knows about was edited."
+                },
+                "placeholder": "editedChannelPost",
+                "value": "editedChannelPost",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Callback Query",
+            "description": "Invoked when an inline keyboard button is pressed."
+          },
+          "name": "onCallbackQuery",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onCallbackQuery",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Callback Query",
+                "description": "Invoked when an inline keyboard button is pressed."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:CallbackQuery",
+                "value": "telegram:CallbackQuery",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "callbackQuery",
+                  "description": "Invoked when an inline keyboard button is pressed."
+                },
+                "placeholder": "callbackQuery",
+                "value": "callbackQuery",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Inline Query",
+            "description": "Invoked when a new inline query is received."
+          },
+          "name": "onInlineQuery",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onInlineQuery",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Inline Query",
+                "description": "Invoked when a new inline query is received."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:InlineQuery",
+                "value": "telegram:InlineQuery",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "inlineQuery",
+                  "description": "Invoked when a new inline query is received."
+                },
+                "placeholder": "inlineQuery",
+                "value": "inlineQuery",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Poll",
+            "description": "Invoked when a poll's state changes."
+          },
+          "name": "onPoll",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onPoll",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Poll",
+                "description": "Invoked when a poll's state changes."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:Poll",
+                "value": "telegram:Poll",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "poll",
+                  "description": "Invoked when a poll's state changes."
+                },
+                "placeholder": "poll",
+                "value": "poll",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Pre Checkout Query",
+            "description": "Invoked when a new pre-checkout query is received."
+          },
+          "name": "onPreCheckoutQuery",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onPreCheckoutQuery",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Pre-Checkout Query",
+                "description": "Invoked when a new pre-checkout query is received."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:PreCheckoutQuery",
+                "value": "telegram:PreCheckoutQuery",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "preCheckoutQuery",
+                  "description": "Invoked when a new pre-checkout query is received."
+                },
+                "placeholder": "preCheckoutQuery",
+                "value": "preCheckoutQuery",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Shipping Query",
+            "description": "Invoked when a new shipping query is received."
+          },
+          "name": "onShippingQuery",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onShippingQuery",
+            "moduleName": "telegram"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Shipping Query",
+                "description": "Invoked when a new shipping query is received."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "telegram:ShippingQuery",
+                "value": "telegram:ShippingQuery",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "shippingQuery",
+                  "description": "Invoked when a new shipping query is received."
+                },
+                "placeholder": "shippingQuery",
+                "value": "shippingQuery",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "importStatements": [
+    "ballerina/http"
+  ],
+  "listenerKind": "MULTIPLE_SELECT_LISTENER"
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/whatsapp.business.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/whatsapp.business.json
@@ -1,0 +1,1265 @@
+{
+  "schemaVersion": "1.0",
+  "id": "whatsapp.business",
+  "displayName": "WhatsApp Business",
+  "description": "Create a service to handle WhatsApp Business Cloud webhook events (messages, template and account updates, and more)",
+  "orgName": "ballerinax",
+  "packageName": "whatsapp.business",
+  "moduleName": "whatsapp.business",
+  "version": "2.0.1",
+  "type": "business",
+  "icon": "icon.png",
+  "kind": "event",
+  "initProperties": {
+    "listener": {
+      "metadata": {
+        "label": "Configure WhatsApp Business Listener",
+        "description": "Select an existing WhatsApp Business listener or create a new one"
+      },
+      "types": [
+        {
+          "fieldType": "CHOICE",
+          "selected": true
+        }
+      ],
+      "value": "createNew",
+      "enabled": true,
+      "editable": true,
+      "optional": false,
+      "advanced": false,
+      "codedata": {
+        "type": "LISTENER_CONFIG"
+      },
+      "choices": [
+        {
+          "metadata": {
+            "label": "Create new",
+            "description": "Create a new WhatsApp Business listener"
+          },
+          "types": [
+            {
+              "fieldType": "FORM",
+              "selected": true
+            }
+          ],
+          "enabled": true,
+          "editable": true,
+          "optional": false,
+          "advanced": false,
+          "properties": {
+            "listenerConfig": {
+              "metadata": {
+                "label": "Listener Configurations",
+                "description": "Configure the WhatsApp Business webhook listener"
+              },
+              "types": [
+                {
+                  "fieldType": "GROUP_SECTION",
+                  "selected": true
+                }
+              ],
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "properties": {
+                "listenerVarName": {
+                  "metadata": {
+                    "label": "Listener Name",
+                    "description": "Provide a name for the listener being created."
+                  },
+                  "types": [
+                    {
+                      "fieldType": "IDENTIFIER",
+                      "selected": true,
+                      "ballerinaType": "business:Listener"
+                    }
+                  ],
+                  "value": "businessListener",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "type": "LISTENER_VAR_NAME"
+                  },
+                  "validations": [
+                    {
+                      "rule": "common.validate.identifier"
+                    },
+                    {
+                      "rule": "ls.validate.unique.listener.name",
+                      "message": "A listener with this name already exists in the project"
+                    }
+                  ]
+                },
+                "listenTo": {
+                  "metadata": {
+                    "label": "Port",
+                    "description": "A port number to bind a new HTTP listener to, or an existing `http:Listener` to reuse"
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_REQUIRED",
+                    "originalName": "listenTo",
+                    "position": 1
+                  },
+                  "types": [
+                    {
+                      "fieldType": "NUMBER",
+                      "ballerinaType": "int|http:Listener",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "int|http:Listener",
+                      "selected": false
+                    }
+                  ],
+                  "placeholder": "8090"
+                },
+                "verifyToken": {
+                  "metadata": {
+                    "label": "Verify Token",
+                    "description": "The verification token configured in the Meta App dashboard. Matched against\n`hub.verify_token` during the webhook subscription handshake before the `hub.challenge` is\nechoed back."
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_INCLUDED_FIELD",
+                    "originalName": "verifyToken",
+                    "path": "verifyToken"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "ballerinaType": "string",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "string",
+                      "selected": false
+                    }
+                  ]
+                },
+                "appSecret": {
+                  "metadata": {
+                    "label": "App Secret",
+                    "description": "The Meta app secret. Every inbound notification is authenticated by validating the\n`X-Hub-Signature-256` header against the raw request body (HMAC-SHA256)."
+                  },
+                  "value": "",
+                  "enabled": true,
+                  "editable": true,
+                  "optional": false,
+                  "advanced": false,
+                  "codedata": {
+                    "argType": "LISTENER_PARAM_INCLUDED_FIELD",
+                    "originalName": "appSecret",
+                    "path": "appSecret"
+                  },
+                  "types": [
+                    {
+                      "fieldType": "TEXT",
+                      "ballerinaType": "string",
+                      "selected": true
+                    },
+                    {
+                      "fieldType": "EXPRESSION",
+                      "ballerinaType": "string",
+                      "selected": false
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "Use existing",
+            "description": "Select an existing WhatsApp Business listener"
+          },
+          "types": [
+            {
+              "fieldType": "FORM",
+              "selected": true
+            }
+          ],
+          "enabled": false,
+          "editable": false,
+          "optional": false,
+          "advanced": false,
+          "properties": {
+            "existingListener": {
+              "metadata": {
+                "label": "Listener(s)",
+                "description": "Select one or more existing WhatsApp Business listeners to attach to"
+              },
+              "types": [
+                {
+                  "fieldType": "MULTI_SELECT_LISTENER",
+                  "selected": true,
+                  "ballerinaType": "business:Listener"
+                }
+              ],
+              "items": [],
+              "value": [],
+              "enabled": true,
+              "editable": true,
+              "optional": false,
+              "advanced": false,
+              "codedata": {
+                "type": "KEY_EXISTING_LISTENER"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "serviceTypes": [
+    {
+      "metadata": {
+        "label": "WhatsApp Service",
+        "description": "Handles WhatsApp Business Cloud webhook events. Handler methods are recognised by convention, not declared on the type; declare only the ones you need."
+      },
+      "name": "WhatsAppService",
+      "description": "The service type a consumer implements to handle WhatsApp Business Cloud webhook events. Attach\nan implementation to a `Listener` to receive notifications.\n\nThere are ten possible handlers, one per webhook field the WhatsApp Business Cloud webhook\nsubscription can select. Unlike most Ballerina service types, none of them are required \u2014\ndeclare only the ones you care about; a field whose handler you did not declare (or a field\noutside this closed set, e.g. `account_alerts`, `group_lifecycle_update`) is logged and dropped\nrather than delivered anywhere.\n\nAn eleventh, optional handler, `onError`, does not correspond to a webhook field. It is invoked\nwhenever one of the ten handlers above returns an `error` while being dispatched \u2014 the\nnotification has already been acknowledged to Meta by that point, so this is the only way to\nreact to a handler failure other than logging (which always happens regardless of whether\n`onError` is declared).\n\nA compiler plugin validates every remote function you do declare on a `WhatsAppService`: its\nname must be one of the eleven below, its parameter must match the documented event type, and it\nmust return `error?`. Anything else is a compile-time error.\n\n- `remote function onMessages(MessagesNotification notification) returns error?` \u2014 Invoked once\nper `messages` webhook notification: either a batch of inbound messages or a batch of status\nupdates. Meta always sends these as two mutually exclusive shapes under this one field, never\nboth together; narrow with `notification is Messages` / `notification is MessageStatuses`.\n- `remote function onAccountReviewUpdate(AccountReviewUpdate update) returns error?` \u2014\nInvoked when a WhatsApp Business Account's review decision changes.\n- `remote function onAccountUpdate(AccountUpdate update) returns error?` \u2014 Invoked on\naccount-lifecycle and compliance changes (verification, violations, partner changes,\npricing-tier updates, restrictions, disconnection).\n- `remote function onBusinessCapabilityUpdate(BusinessCapabilityUpdate update) returns error?`\n\u2014 Invoked when a WABA's messaging or phone-number capability limits change.\n- `remote function onMessageTemplateQualityUpdate(MessageTemplateQualityUpdate update) returns error?`\n\u2014 Invoked when a message template's quality score changes.\n- `remote function onMessageTemplateStatusUpdate(MessageTemplateStatusUpdate update) returns error?`\n\u2014 Invoked when a message template's status changes (approved, rejected, disabled, ...).\n- `remote function onPhoneNumberNameUpdate(PhoneNumberNameUpdate update) returns error?` \u2014\nInvoked when a business phone number's display-name review outcome is available.\n- `remote function onPhoneNumberQualityUpdate(PhoneNumberQualityUpdate update) returns error?`\n\u2014 Invoked when a business phone number's messaging throughput/quality tier changes.\n- `remote function onSecurity(Security security) returns error?` \u2014 Invoked on\ntwo-step-verification PIN changes and reset requests for a business phone number.\n- `remote function onTemplateCategoryUpdate(TemplateCategoryUpdate update) returns error?` \u2014\nInvoked when a message template's category changes, or is about to change.\n- `remote function onError(HandlerError handlerError) returns error?` \u2014 Invoked when any of the\nhandlers above returns an error while being dispatched for an incoming notification.",
+      "enabled": true,
+      "editable": false,
+      "codedata": {
+        "type": "SERVICE_TYPE_DESCRIPTOR",
+        "moduleName": "business",
+        "originalName": "WhatsAppService"
+      },
+      "properties": {},
+      "functions": [],
+      "schemaFunctions": [
+        {
+          "metadata": {
+            "label": "On Messages",
+            "description": "Invoked once per `messages` webhook notification carrying either a batch of inbound messages or a batch of delivery/read status updates. Narrow with `notification is business:Messages` / `notification is business:MessageStatuses`."
+          },
+          "name": "onMessages",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onMessages",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Notification",
+                "description": "Invoked once per `messages` webhook notification carrying either a batch of inbound messages or a batch of delivery/read status updates. Narrow with `notification is business:Messages` / `notification is business:MessageStatuses`."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:MessagesNotification",
+                "value": "business:MessagesNotification",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "notification",
+                  "description": "Invoked once per `messages` webhook notification carrying either a batch of inbound messages or a batch of delivery/read status updates. Narrow with `notification is business:Messages` / `notification is business:MessageStatuses`."
+                },
+                "placeholder": "notification",
+                "value": "notification",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Account Review Update",
+            "description": "Invoked when a WhatsApp Business Account's review decision changes."
+          },
+          "name": "onAccountReviewUpdate",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onAccountReviewUpdate",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Review Update",
+                "description": "Invoked when a WhatsApp Business Account's review decision changes."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:AccountReviewUpdate",
+                "value": "business:AccountReviewUpdate",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "update",
+                  "description": "Invoked when a WhatsApp Business Account's review decision changes."
+                },
+                "placeholder": "update",
+                "value": "update",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Account Update",
+            "description": "Invoked on account-lifecycle and compliance changes: verification, violations, partner changes, pricing-tier updates, restrictions, or disconnection."
+          },
+          "name": "onAccountUpdate",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onAccountUpdate",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Account Update",
+                "description": "Invoked on account-lifecycle and compliance changes: verification, violations, partner changes, pricing-tier updates, restrictions, or disconnection."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:AccountUpdate",
+                "value": "business:AccountUpdate",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "update",
+                  "description": "Invoked on account-lifecycle and compliance changes: verification, violations, partner changes, pricing-tier updates, restrictions, or disconnection."
+                },
+                "placeholder": "update",
+                "value": "update",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Business Capability Update",
+            "description": "Invoked when a WhatsApp Business Account's messaging or phone-number capability limits change."
+          },
+          "name": "onBusinessCapabilityUpdate",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onBusinessCapabilityUpdate",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Capability Update",
+                "description": "Invoked when a WhatsApp Business Account's messaging or phone-number capability limits change."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:BusinessCapabilityUpdate",
+                "value": "business:BusinessCapabilityUpdate",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "update",
+                  "description": "Invoked when a WhatsApp Business Account's messaging or phone-number capability limits change."
+                },
+                "placeholder": "update",
+                "value": "update",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Message Template Quality Update",
+            "description": "Invoked when a message template's quality score changes."
+          },
+          "name": "onMessageTemplateQualityUpdate",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onMessageTemplateQualityUpdate",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Quality Update",
+                "description": "Invoked when a message template's quality score changes."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:MessageTemplateQualityUpdate",
+                "value": "business:MessageTemplateQualityUpdate",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "update",
+                  "description": "Invoked when a message template's quality score changes."
+                },
+                "placeholder": "update",
+                "value": "update",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Message Template Status Update",
+            "description": "Invoked when a message template's status changes (approved, rejected, disabled, archived, unarchived, ...)."
+          },
+          "name": "onMessageTemplateStatusUpdate",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onMessageTemplateStatusUpdate",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Status Update",
+                "description": "Invoked when a message template's status changes (approved, rejected, disabled, archived, unarchived, ...)."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:MessageTemplateStatusUpdate",
+                "value": "business:MessageTemplateStatusUpdate",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "update",
+                  "description": "Invoked when a message template's status changes (approved, rejected, disabled, archived, unarchived, ...)."
+                },
+                "placeholder": "update",
+                "value": "update",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Phone Number Name Update",
+            "description": "Invoked when a business phone number's display-name review outcome is available."
+          },
+          "name": "onPhoneNumberNameUpdate",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onPhoneNumberNameUpdate",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Name Update",
+                "description": "Invoked when a business phone number's display-name review outcome is available."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:PhoneNumberNameUpdate",
+                "value": "business:PhoneNumberNameUpdate",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "update",
+                  "description": "Invoked when a business phone number's display-name review outcome is available."
+                },
+                "placeholder": "update",
+                "value": "update",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Phone Number Quality Update",
+            "description": "Invoked when a business phone number's messaging throughput/quality tier changes."
+          },
+          "name": "onPhoneNumberQualityUpdate",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onPhoneNumberQualityUpdate",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Quality Update",
+                "description": "Invoked when a business phone number's messaging throughput/quality tier changes."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:PhoneNumberQualityUpdate",
+                "value": "business:PhoneNumberQualityUpdate",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "update",
+                  "description": "Invoked when a business phone number's messaging throughput/quality tier changes."
+                },
+                "placeholder": "update",
+                "value": "update",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Security",
+            "description": "Invoked on two-step-verification PIN changes and reset requests for a business phone number."
+          },
+          "name": "onSecurity",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onSecurity",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Security Event",
+                "description": "Invoked on two-step-verification PIN changes and reset requests for a business phone number."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:Security",
+                "value": "business:Security",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "security",
+                  "description": "Invoked on two-step-verification PIN changes and reset requests for a business phone number."
+                },
+                "placeholder": "security",
+                "value": "security",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Template Category Update",
+            "description": "Invoked when a message template's category changes, or is about to change (24-hour advance notice)."
+          },
+          "name": "onTemplateCategoryUpdate",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onTemplateCategoryUpdate",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Category Update",
+                "description": "Invoked when a message template's category changes, or is about to change (24-hour advance notice)."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:TemplateCategoryUpdate",
+                "value": "business:TemplateCategoryUpdate",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "update",
+                  "description": "Invoked when a message template's category changes, or is about to change (24-hour advance notice)."
+                },
+                "placeholder": "update",
+                "value": "update",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        },
+        {
+          "metadata": {
+            "label": "On Error",
+            "description": "Invoked when any of the other handlers returns an error while being dispatched for an incoming notification."
+          },
+          "name": "onError",
+          "nameEditable": false,
+          "kind": "REMOTE",
+          "accessor": "",
+          "qualifiers": [
+            "remote"
+          ],
+          "enabled": false,
+          "editable": true,
+          "optional": true,
+          "canAddParameters": false,
+          "repeatable": "FALSE",
+          "codedata": {
+            "type": "FUNCTION",
+            "originalName": "onError",
+            "moduleName": "business"
+          },
+          "parameters": [
+            {
+              "metadata": {
+                "label": "Handler Error",
+                "description": "Invoked when any of the other handlers returns an error while being dispatched for an incoming notification."
+              },
+              "kind": "REQUIRED",
+              "type": {
+                "metadata": {
+                  "label": "Parameter Type",
+                  "description": "The type of the parameter"
+                },
+                "placeholder": "business:HandlerError",
+                "value": "business:HandlerError",
+                "types": [
+                  {
+                    "fieldType": "TYPE",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": false,
+                "optional": true,
+                "advanced": false
+              },
+              "name": {
+                "metadata": {
+                  "label": "handlerError",
+                  "description": "Invoked when any of the other handlers returns an error while being dispatched for an incoming notification."
+                },
+                "placeholder": "handlerError",
+                "value": "handlerError",
+                "types": [
+                  {
+                    "fieldType": "IDENTIFIER",
+                    "selected": true
+                  }
+                ],
+                "enabled": true,
+                "editable": true,
+                "optional": false,
+                "advanced": false
+              },
+              "enabled": true,
+              "editable": false,
+              "optional": false,
+              "advanced": false,
+              "hidden": false,
+              "codedata": {
+                "type": "FUNCTION_PARAM"
+              }
+            }
+          ],
+          "returnType": {
+            "metadata": {
+              "label": "Return Type",
+              "description": "The return type of the function; `error?` to signal a processing error."
+            },
+            "type": "error?",
+            "typeEditable": false,
+            "enabled": true,
+            "editable": false,
+            "optional": true,
+            "hasError": true,
+            "importStatements": "",
+            "codedata": {
+              "type": "FUNCTION_RETURN"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "importStatements": [
+    "ballerina/http"
+  ],
+  "listenerKind": "MULTIPLE_SELECT_LISTENER"
+}

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
@@ -284,5 +284,51 @@
     "version": "1.0.0",
     "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_azure.storage.files_1.0.0.png",
     "kind": "file"
+  },
+  "22": {
+    "name": "whatsapp.business",
+    "orgName": "ballerinax",
+    "packageName": "whatsapp.business",
+    "keywords": [
+      "whatsapp",
+      "messaging",
+      "webhook",
+      "event"
+    ],
+    "triggerName": "WhatsApp Business",
+    "version": "2.0.1",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_whatsapp.business_2.0.1.png",
+    "kind": "event"
+  },
+  "23": {
+    "name": "telegram",
+    "orgName": "ballerinax",
+    "packageName": "telegram",
+    "keywords": [
+      "telegram",
+      "messaging",
+      "webhook",
+      "event"
+    ],
+    "triggerName": "Telegram",
+    "version": "0.9.1",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_telegram_0.9.1.png",
+    "kind": "event"
+  },
+  "24": {
+    "name": "googleapis.chat",
+    "orgName": "ballerinax",
+    "packageName": "googleapis.chat",
+    "keywords": [
+      "google",
+      "chat",
+      "messaging",
+      "webhook",
+      "event"
+    ],
+    "triggerName": "Google Chat",
+    "version": "0.1.0",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_googleapis.chat_0.1.0.png",
+    "kind": "event"
   }
 }


### PR DESCRIPTION
## Purpose
It resolves: https://github.com/wso2/product-integrator/issues/2010
- Onboards three connectors as bundled schema-driven triggers:
  - `ballerinax/whatsapp.business` — 11 independent optional webhook handlers (messages, account/template updates, security events, `onError`)
  - `ballerinax/telegram` — 9 independent optional webhook update handlers
  - `ballerinax/googleapis.chat` — 8 interaction-event handlers, each pairing a `ChatEvent` with a handler-specific `Caller` type; multi-mode auth (service account / OAuth2 / bearer token); `@chat:ServiceConfig` annotation modeled as an endpoint-URL vs. project-number choice
- Adds `trigger-models/{whatsapp.business,telegram,googleapis.chat}.json` and registers each in `bundled_trigger_models.json` and `trigger_properties.json`

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.