### PR TITLE
Show the ambient Copilot surfaces only where they help

### DIFF
--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
@@ -84,7 +84,10 @@ async function configureUploadResourceIO(locatorOwner: ReturnType<typeof switchT
 
 async function addReturnNodeFromDiagram(locatorOwner: ReturnType<typeof switchToIFrame> extends Promise<infer T> ? NonNullable<T> : never) {
     logStep('Add Return node from diagram');
-    for (let attempt = 0; attempt < 10; attempt++) {
+    // 20 attempts (~60s worst case): late in a long suite run the diagram can take
+    // noticeably longer to become interactive under accumulated system load, even
+    // though the click/dispatch strategy itself is not the flaky part.
+    for (let attempt = 0; attempt < 20; attempt++) {
         const addButton = locatorOwner.locator('[data-testid="empty-node-add-button-1"]').first();
         if (await addButton.waitFor({ state: 'visible', timeout: 1000 }).then(() => true, () => false)) {
             await addButton.hover({ force: true }).catch(() => {});
@@ -118,7 +121,7 @@ async function addReturnNodeFromDiagram(locatorOwner: ReturnType<typeof switchTo
             && await locatorOwner.getByText('Return', { exact: true }).isVisible().catch(() => false)) {
             break;
         }
-        if (attempt === 9) {
+        if (attempt === 19) {
             throw new Error(`Node panel did not open after clicking diagram add button "${clickedId}"`);
         }
     }

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
@@ -189,7 +189,14 @@ export default function createTests() {
             logStep('Run integration');
             await FileUtils.openProjectFileInEditor('main.bal');
 
-            await page.executePaletteCommand('BI.project.run');
+            // The command palette matches against the label ("Run Integration"), not the
+            // raw command ID — "BI.project.run" contains no letters the label has, so it
+            // never matches and Run never fires. Same pattern automation-run.spec.ts uses.
+            await page.page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P');
+            await page.page.waitForTimeout(500);
+            await page.page.keyboard.type('Run Integration');
+            await page.page.waitForTimeout(500);
+            await page.page.keyboard.press('Enter');
 
             logStep('Verify upload endpoint response');
             const result = await waitForEndpoint('http://localhost:9090/upload?name=probe.txt', 120000);

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/project-explorer/project-explorer.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/project-explorer/project-explorer.spec.ts
@@ -195,7 +195,10 @@ export default function createTests() {
             await addBtn.click();
 
             const artifactWebView = await getWebview(BI_INTEGRATOR_LABEL, page);
-            await expect(artifactWebView.getByRole('heading', { name: 'Artifacts', exact: true })).toBeVisible({ timeout: 15000 });
+            // Doubled from 15s: this runs late in the suite (right after a tree delete,
+            // deep into a long serial run), where the artifact picker can take longer to
+            // render than earlier in a fresh session.
+            await expect(artifactWebView.getByRole('heading', { name: 'Artifacts', exact: true })).toBeVisible({ timeout: 30000 });
 
             logStep('Selecting "Automation" and creating it');
             const automationCard = artifactWebView.locator('[data-testid="automation"], #automation').first();

--- a/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
@@ -127,9 +127,6 @@ class AgentStatusManager {
             return;
         }
         this.status = { ...this.status, aiPanelOpen: open, timestamp: Date.now() };
-        if (open) {
-            this.acknowledgeTerminalState();
-        }
         this.render();
         this.broadcast();
     }
@@ -139,7 +136,9 @@ class AgentStatusManager {
             return;
         }
         this.aiPanelVisible = visible;
-        const acknowledged = visible && this.acknowledgeTerminalState();
+        // Either direction means the panel has been on screen: becoming visible
+        // shows the outcome, and going hidden means it was visible until now.
+        const acknowledged = this.acknowledgeTerminalState();
         this.render();
         if (acknowledged) {
             this.broadcast();

--- a/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
@@ -46,6 +46,8 @@ class AgentStatusManager {
     private status: AgentRunStatus = { state: 'idle', aiPanelOpen: false, timestamp: Date.now() };
     private runActive = false;
     private resetTimer: NodeJS.Timeout | undefined;
+    /** Panel on screen right now, as opposed to `status.aiPanelOpen`, which is merely alive. */
+    private aiPanelVisible = false;
 
     init(context: vscode.ExtensionContext): void {
         if (this.statusBarItem) {
@@ -56,7 +58,6 @@ class AgentStatusManager {
         this.statusBarItem.command = SHARED_COMMANDS.OPEN_AI_PANEL;
         context.subscriptions.push(this.statusBarItem, new vscode.Disposable(() => this.clearResetTimer()));
         this.render();
-        this.statusBarItem.show();
     }
 
     runStarted(generationId: string): void {
@@ -126,15 +127,37 @@ class AgentStatusManager {
             return;
         }
         this.status = { ...this.status, aiPanelOpen: open, timestamp: Date.now() };
-        // Opening the panel acknowledges a finished/failed run — reset to idle
-        // so the 'Done — click to open' nudge doesn't reappear when the panel
-        // is closed again within the terminal-state window.
-        if (open && !this.runActive && (this.status.state === 'completed' || this.status.state === 'error')) {
-            this.clearResetTimer();
-            this.status = { ...this.status, state: 'idle', label: undefined };
+        if (open) {
+            this.acknowledgeTerminalState();
         }
         this.render();
         this.broadcast();
+    }
+
+    setAiPanelVisible(visible: boolean): void {
+        if (this.aiPanelVisible === visible) {
+            return;
+        }
+        this.aiPanelVisible = visible;
+        const acknowledged = visible && this.acknowledgeTerminalState();
+        this.render();
+        if (acknowledged) {
+            this.broadcast();
+        }
+    }
+
+    /**
+     * Seeing the panel acknowledges a finished/failed run — reset to idle so the
+     * 'Done — click to open' nudge doesn't reappear once the panel is closed or
+     * hidden again within the terminal-state window.
+     */
+    private acknowledgeTerminalState(): boolean {
+        if (this.runActive || (this.status.state !== 'completed' && this.status.state !== 'error')) {
+            return false;
+        }
+        this.clearResetTimer();
+        this.status = { ...this.status, state: 'idle', label: undefined };
+        return true;
     }
 
     getStatus(): AgentRunStatus {
@@ -164,6 +187,13 @@ class AgentStatusManager {
         if (!this.statusBarItem) {
             return;
         }
+        // Only worth a slot in the status bar when there is live status to report
+        // and no panel on screen already reporting it. A panel that is open but
+        // hidden behind another tab still needs the status bar.
+        if (this.status.state === 'idle' || this.aiPanelVisible) {
+            this.statusBarItem.hide();
+            return;
+        }
         const label = truncate(this.status.label, STATUS_BAR_LABEL_MAX);
         switch (this.status.state) {
             case 'running':
@@ -182,7 +212,6 @@ class AgentStatusManager {
                 this.statusBarItem.text = `$(error) Copilot error`;
                 this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
                 break;
-            case 'idle':
             default:
                 this.statusBarItem.text = `$(bi-ai-chat) WSO2 Integrator Copilot`;
                 this.statusBarItem.backgroundColor = undefined;
@@ -192,6 +221,7 @@ class AgentStatusManager {
         tooltip.appendMarkdown(`**WSO2 Integrator Copilot**${this.status.label ? ` — ${this.status.label}` : ''}\n\n`);
         tooltip.appendMarkdown('Click to open the Copilot chat.');
         this.statusBarItem.tooltip = tooltip;
+        this.statusBarItem.show();
     }
 
     private broadcast(): void {

--- a/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
+++ b/packages/ballerina-extension/src/features/ai/state/AgentStatusManager.ts
@@ -211,10 +211,6 @@ class AgentStatusManager {
                 this.statusBarItem.text = `$(error) Copilot error`;
                 this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
                 break;
-            default:
-                this.statusBarItem.text = `$(bi-ai-chat) WSO2 Integrator Copilot`;
-                this.statusBarItem.backgroundColor = undefined;
-                break;
         }
         const tooltip = new vscode.MarkdownString();
         tooltip.appendMarkdown(`**WSO2 Integrator Copilot**${this.status.label ? ` — ${this.status.label}` : ''}\n\n`);

--- a/packages/ballerina-extension/src/views/ai-panel/webview.ts
+++ b/packages/ballerina-extension/src/views/ai-panel/webview.ts
@@ -36,9 +36,15 @@ export class AiPanelWebview {
     constructor() {
         this._panel = AiPanelWebview.createWebview();
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+        this._panel.onDidChangeViewState(
+            () => agentStatusManager.setAiPanelVisible(this._panel?.visible ?? false),
+            null,
+            this._disposables
+        );
         this._panel.webview.html = this.getWebviewContent(this._panel.webview);
         RPCLayer.create(this._panel);
         agentStatusManager.setAiPanelOpen(true);
+        agentStatusManager.setAiPanelVisible(this._panel.visible);
     }
 
     private static createWebview(): vscode.WebviewPanel {
@@ -139,6 +145,7 @@ export class AiPanelWebview {
 
         AiPanelWebview.currentPanel = undefined;
         agentStatusManager.setAiPanelOpen(false);
+        agentStatusManager.setAiPanelVisible(false);
         AIStateMachine.sendEvent(AIMachineEventType.DISPOSE);
         this._panel?.dispose();
 

--- a/packages/ballerina-visualizer/src/MainPanel.tsx
+++ b/packages/ballerina-visualizer/src/MainPanel.tsx
@@ -392,7 +392,8 @@ const MainPanel = () => {
                         case MACHINE_VIEW.BIDiagram:
                             const { default: DiagramWrapper } = await import("./views/BI/DiagramWrapper");
                             if (isStaleNavigation()) return;
-                            rpcClient.getLangClientRpcClient().getSTByRange({
+                            // Awaited so the code after the switch sees the view as settled.
+                            await rpcClient.getLangClientRpcClient().getSTByRange({
                                 documentIdentifier: {
                                     uri: URI.file(value.documentUri).toString(),
                                 },

--- a/packages/ballerina-visualizer/src/MainPanel.tsx
+++ b/packages/ballerina-visualizer/src/MainPanel.tsx
@@ -38,6 +38,7 @@ import { debounce } from "lodash";
 import styled from "@emotion/styled";
 import { LoadingRing } from "./components/Loader";
 import { WebviewErrorState } from "./components/WebviewErrorState";
+import { useSuppressAgentStatusOrb, viewHidesAgentStatusOrb } from "./components/AgentStatusOrb/shared";
 import { handleRedo, handleUndo } from "./utils/utils";
 import { STKindChecker } from "@wso2/syntax-tree";
 import { URI, Utils } from "vscode-uri";
@@ -195,6 +196,7 @@ const MainPanel = () => {
     const errorBoundaryRef = createRef<any>();
     const [viewComponent, setViewComponent] = useState<React.ReactNode>();
     const [viewError, setViewError] = useState<string>();
+    const [activeView, setActiveView] = useState<MACHINE_VIEW>();
     const [navActive, setNavActive] = useState<boolean>(true);
     // A navigation is in flight: the previous view stays on screen while the next one's
     // chunk loads, which on a first visit is seconds.
@@ -208,6 +210,7 @@ const MainPanel = () => {
     const remountKeyRef = useRef<number>(0);
     const previousNavTargetRef = useRef<string | undefined>(undefined);
 
+    useSuppressAgentStatusOrb(viewHidesAgentStatusOrb(activeView) || !!viewError);
 
     const gitIssueUrl = "https://github.com/wso2/product-integrator/issues";
 
@@ -879,6 +882,9 @@ const MainPanel = () => {
                             setViewComponent(<LoadingRing />);
                     }
                 }
+                // Only once the new view is on screen — lifting it earlier flashes
+                // the orb over the view being navigated away from.
+                setActiveView(value?.view ?? undefined);
                 // The chunk is in memory and the browser is about to go idle — cheapest
                 // moment to warm the next view.
                 prefetchAfterView(value?.view);

--- a/packages/ballerina-visualizer/src/Visualizer.tsx
+++ b/packages/ballerina-visualizer/src/Visualizer.tsx
@@ -146,7 +146,7 @@ export function Visualizer({ mode }: { mode: string }) {
                 {(() => {
                     switch (mode) {
                         case MODES.VISUALIZER:
-                            return <><VisualizerComponent state={state} /><AgentStatusOrb /></>
+                            return <VisualizerComponent state={state} />
                         case MODES.RUNTIME_SERVICES:
                             return <MainPanel />
                         case MODES.AI:
@@ -305,7 +305,7 @@ const VisualizerComponent = React.memo(({ state }: { state: MachineStateValue })
 
     switch (true) {
         case showMainPanel:
-            return <MainPanel />;
+            return <><MainPanel /><AgentStatusOrb /></>;
         case typeof state === 'object' && 'viewActive' in state && state.viewActive === "resolveMissingDependencies":
             return <PullingDependenciesView />;
         default:

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
@@ -31,7 +31,7 @@ import {
     IconOverlay,
     activeStateLabel,
     AmbientFrame,
-    registerHeroPresence,
+    useSuppressAgentStatusOrb,
     subscribeAgentRunStatus,
 } from "./shared";
 
@@ -133,7 +133,7 @@ export function CopilotHeroBox() {
     const handleWebglFailed = useCallback(() => setWebglFailed(true), []);
     const inputRef = useRef<HTMLInputElement | null>(null);
 
-    useEffect(() => registerHeroPresence(), []);
+    useSuppressAgentStatusOrb();
 
     useEffect(() => {
         if (!rpcClient) {

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/CopilotHeroBox.tsx
@@ -36,14 +36,13 @@ import {
 } from "./shared";
 
 /**
- * Inline "ask the Copilot" hero for the package overview landing page: a
- * prompt box that is the primary way into the Copilot. Submitting opens the
- * AI panel with the prompt auto-submitted into the agent. While a run is
- * active the box morphs into the orb + live status label (the same status
- * feed as the floating AgentStatusOrb), and clicking it opens the panel.
+ * Inline "ask the Copilot" prompt box in the package overview's design panel,
+ * the primary way into the Copilot from that page. Submitting opens the AI
+ * panel with the prompt auto-submitted into the agent. While a run is active
+ * the box morphs into the orb + live status label (the same status feed as the
+ * floating AgentStatusOrb), and clicking it opens the panel.
  *
- * While mounted it registers hero presence so the floating orb hides —
- * one copilot surface per view.
+ * While mounted it suppresses the floating orb — one copilot surface per view.
  */
 
 const HERO_ORB_SIZE = 44;
@@ -124,7 +123,7 @@ const SendButton = styled.button`
     }
 `;
 
-export function CopilotHeroBox() {
+export function CopilotHeroBox({ placeholder }: { placeholder: string }) {
     const { rpcClient } = useRpcContext();
     const [status, setStatus] = useState<AgentRunStatus | null>(null);
     const [text, setText] = useState("");
@@ -219,7 +218,7 @@ export function CopilotHeroBox() {
                                     submit();
                                 }
                             }}
-                            placeholder="What can I help you build or change?"
+                            placeholder={placeholder}
                             aria-label="Message WSO2 Integrator Copilot"
                         />
                         <SendButton

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/index.tsx
@@ -38,7 +38,7 @@ import {
     IconOverlay,
     activeStateLabel,
     subscribeAgentRunStatus,
-    subscribeHeroPresence,
+    subscribeOrbSuppressed,
     subscribeMiniChatOpen,
 } from "./shared";
 import { createMiniChatPrompt, MiniChatPrompt } from "./promptHandoff";
@@ -313,8 +313,8 @@ export function AgentStatusOrb() {
     const snapTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     const [inviteText, setInviteText] = useState("");
     const [inviteDismissed, setInviteDismissed] = useState(false);
-    /** A landing-page hero box is on screen — it is the copilot surface there. */
-    const [heroPresent, setHeroPresent] = useState(false);
+    /** The current view opts out of the floating orb. */
+    const [orbSuppressed, setOrbSuppressed] = useState(false);
     /** Mini chat overlay toggled by clicking the orb. */
     const [miniOpen, setMiniOpen] = useState(false);
     /** Contextual prompt handed to the mini chat once on open. */
@@ -350,16 +350,16 @@ export function AgentStatusOrb() {
         });
     }, [rpcClient]);
 
-    useEffect(() => subscribeHeroPresence(setHeroPresent), []);
+    useEffect(() => subscribeOrbSuppressed(setOrbSuppressed), []);
 
     useEffect(() => () => clearTimeout(snapTimerRef.current), []);
 
     // The orb hides without unmounting, so mini-chat state outlives it. Left alone,
     // `miniOpen` stays true and the mini resurfaces unprompted as soon as the orb
-    // returns — the full panel closing, or navigating off a hero-bearing view.
+    // returns — the full panel closing, or navigating off a view that opts out.
     // A prompt queued by `subscribeMiniChatOpen` is discarded for the same reason:
     // MiniChat cannot mount while hidden, so it is never taken, only left to go stale.
-    const orbHidden = !status || status.aiPanelOpen || heroPresent;
+    const orbHidden = !status || status.aiPanelOpen || orbSuppressed;
     useEffect(() => {
         if (orbHidden) {
             setMiniOpen(false);

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { keyframes } from "@emotion/react";
 import { AgentRunState, AgentRunStatus, ChatNotify, MACHINE_VIEW } from "@wso2/ballerina-core";
@@ -372,9 +372,13 @@ function notifyOrbSuppressed() {
     orbSuppressListeners.forEach((listener) => listener(orbSuppressCount > 0));
 }
 
-/** Hides the floating orb while the caller is mounted and `suppressed` holds. */
+/**
+ * Hides the floating orb while the caller is mounted and `suppressed` holds.
+ * Layout effect, not passive: suppression has to land in the same frame as the
+ * render that caused it, or the orb paints once over a view that opts out.
+ */
 export function useSuppressAgentStatusOrb(suppressed = true): void {
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (!suppressed) {
             return;
         }

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -19,7 +19,7 @@
 import { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { keyframes } from "@emotion/react";
-import { AgentRunState, AgentRunStatus, ChatNotify } from "@wso2/ballerina-core";
+import { AgentRunState, AgentRunStatus, ChatNotify, MACHINE_VIEW } from "@wso2/ballerina-core";
 import { BallerinaRpcClient, useRpcContext } from "@wso2/ballerina-rpc-client";
 import type { MiniChatPrompt } from "./promptHandoff";
 
@@ -372,16 +372,43 @@ function notifyOrbSuppressed() {
     orbSuppressListeners.forEach((listener) => listener(orbSuppressCount > 0));
 }
 
-/** Hides the floating orb while the caller is mounted. */
-export function useSuppressAgentStatusOrb(): void {
+/** Hides the floating orb while the caller is mounted and `suppressed` holds. */
+export function useSuppressAgentStatusOrb(suppressed = true): void {
     useEffect(() => {
+        if (!suppressed) {
+            return;
+        }
         orbSuppressCount++;
         notifyOrbSuppressed();
         return () => {
             orbSuppressCount--;
             notifyOrbSuppressed();
         };
-    }, []);
+    }, [suppressed]);
+}
+
+/**
+ * The hubs and design canvases the ambient orb belongs on. Forms, wizards, list
+ * and settings pages, setup/welcome pages, Copilot's own views and anything still
+ * loading go without it, so a view added later has to opt in here rather than
+ * inherit the overlay.
+ */
+const VIEWS_WITH_ORB: ReadonlySet<MACHINE_VIEW> = new Set([
+    MACHINE_VIEW.PackageOverview,
+    MACHINE_VIEW.BIComponentView,
+    MACHINE_VIEW.BIDiagram,
+    MACHINE_VIEW.ServiceDesigner,
+    MACHINE_VIEW.BIServiceClassDesigner,
+    MACHINE_VIEW.AIAgentDesigner,
+    MACHINE_VIEW.ERDiagram,
+    MACHINE_VIEW.TypeDiagram,
+    MACHINE_VIEW.GraphQLDiagram,
+    MACHINE_VIEW.DataMapper,
+    MACHINE_VIEW.InlineDataMapper,
+]);
+
+export function viewHidesAgentStatusOrb(view: MACHINE_VIEW | null | undefined): boolean {
+    return !view || !VIEWS_WITH_ORB.has(view);
 }
 
 export function subscribeOrbSuppressed(listener: (suppressed: boolean) => void): () => void {

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -359,33 +359,35 @@ export function subscribeCopilotChatNotify(
 }
 
 // ---------------------------------------------------------------------------
-// Hero-box presence.
+// Floating-orb suppression.
 //
-// While a landing-page hero box is on screen it IS the copilot surface for
-// that view, so the floating orb hides itself to avoid showing two orbs.
+// A view opts out of the floating orb either because its own hero box is the
+// copilot surface there, or because it deliberately offers no ambient copilot.
 // ---------------------------------------------------------------------------
 
-let heroCount = 0;
-const heroListeners = new Set<(present: boolean) => void>();
+let orbSuppressCount = 0;
+const orbSuppressListeners = new Set<(suppressed: boolean) => void>();
 
-function notifyHeroPresence() {
-    heroListeners.forEach((listener) => listener(heroCount > 0));
+function notifyOrbSuppressed() {
+    orbSuppressListeners.forEach((listener) => listener(orbSuppressCount > 0));
 }
 
-/** Called by a hero box on mount; returns the matching unmount cleanup. */
-export function registerHeroPresence(): () => void {
-    heroCount++;
-    notifyHeroPresence();
-    return () => {
-        heroCount--;
-        notifyHeroPresence();
-    };
+/** Hides the floating orb while the caller is mounted. */
+export function useSuppressAgentStatusOrb(): void {
+    useEffect(() => {
+        orbSuppressCount++;
+        notifyOrbSuppressed();
+        return () => {
+            orbSuppressCount--;
+            notifyOrbSuppressed();
+        };
+    }, []);
 }
 
-export function subscribeHeroPresence(listener: (present: boolean) => void): () => void {
-    heroListeners.add(listener);
-    listener(heroCount > 0);
+export function subscribeOrbSuppressed(listener: (suppressed: boolean) => void): () => void {
+    orbSuppressListeners.add(listener);
+    listener(orbSuppressCount > 0);
     return () => {
-        heroListeners.delete(listener);
+        orbSuppressListeners.delete(listener);
     };
 }

--- a/packages/ballerina-visualizer/src/views/AIPanel/components/FollowupSuggestions/index.tsx
+++ b/packages/ballerina-visualizer/src/views/AIPanel/components/FollowupSuggestions/index.tsx
@@ -25,8 +25,8 @@ const Container = styled.div`
     flex-wrap: wrap;
     align-items: center;
     gap: 6px;
-    /* Deliberately asymmetric: the chips belong to the input below, not the message above. */
-    margin: 20px 0 -22px;
+    /* Keep the bottom at zero: a negative margin puts the chips past the transcript's scroll end. */
+    margin: 20px 0 0;
 `;
 
 const AiHint = styled.span`

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -126,10 +126,14 @@ const MainContent = styled.div<{ fullWidth?: boolean }>`
     max-height: calc(100vh - 90px);
 `;
 
-// Sits at the foot of the design panel, which carries no padding of its own.
+// Pinned to the foot of the design panel (which carries no padding of its own),
+// so it stays reachable once the artifact list is long enough to scroll.
 const HeroRow = styled.div`
     flex: none;
+    position: sticky;
+    bottom: 0;
     padding: 16px;
+    background: var(--vscode-editor-background);
 `;
 
 const DiagramPanel = styled.div<{ noPadding?: boolean, noBorder?: boolean }>`

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -1239,7 +1239,9 @@ export function PackageOverview(props: PackageOverviewProps) {
                             )}
                             {showHero && (
                                 <HeroRow>
-                                    <CopilotHeroBox />
+                                    <CopilotHeroBox
+                                        placeholder={isEmptyIntegration() ? "What would you like to build?" : "What would you like to change?"}
+                                    />
                                 </HeroRow>
                             )}
                         </DiagramPanel>

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -116,18 +116,20 @@ const HeaderControls = styled.div`
     align-items: center;
 `;
 
-const MainContent = styled.div<{ fullWidth?: boolean; withHero?: boolean }>`
+const MainContent = styled.div<{ fullWidth?: boolean }>`
     padding: 16px;
     display: grid;
     grid-template-columns: ${(props: { fullWidth?: boolean }) => props.fullWidth ? '1fr' : '3fr 1fr'};
     min-height: 0; // Prevents grid blowout
     overflow: auto;
-    // Adjust based on header and any margins; the hero prompt row adds ~87px.
-    max-height: ${(props: { withHero?: boolean }) => props.withHero ? 'calc(100vh - 177px)' : 'calc(100vh - 90px)'};
+    // Adjust based on header and any margins.
+    max-height: calc(100vh - 90px);
 `;
 
+// Sits at the foot of the design panel, which carries no padding of its own.
 const HeroRow = styled.div`
-    margin: 16px 16px 0 16px;
+    flex: none;
+    padding: 16px;
 `;
 
 const DiagramPanel = styled.div<{ noPadding?: boolean, noBorder?: boolean }>`
@@ -1165,12 +1167,7 @@ export function PackageOverview(props: PackageOverviewProps) {
                         </HeaderControls>
                     </HeaderRow>
                 )}
-                {showHero && (
-                    <HeroRow>
-                        <CopilotHeroBox />
-                    </HeroRow>
-                )}
-                <MainContent fullWidth={isLibrary} withHero={showHero}>
+                <MainContent fullWidth={isLibrary}>
                     <LeftContent>
                         <DiagramPanel noPadding={true} noBorder={isLibrary}>
                             {showAlert && (
@@ -1216,7 +1213,7 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                 sx={{ marginBottom: "24px", color: "var(--vscode-descriptionForeground)" }}
                                             >
                                                 Add an artifact to get started, or describe what you want to build in
-                                                the Copilot box above
+                                                the Copilot box below
                                             </Typography>
                                             <ButtonContainer>
                                                 {/* An empty integration means the creation wizard was
@@ -1239,6 +1236,11 @@ export function PackageOverview(props: PackageOverviewProps) {
                                         </React.Suspense>
                                     )}
                                 </DiagramContent>
+                            )}
+                            {showHero && (
+                                <HeroRow>
+                                    <CopilotHeroBox />
+                                </HeroRow>
                             )}
                         </DiagramPanel>
                         {!isLibrary && (

--- a/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/shared/CreateFlowShell.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/shared/CreateFlowShell.tsx
@@ -19,6 +19,7 @@
 import { ReactNode } from "react";
 import styled from "@emotion/styled";
 import { Icon } from "@wso2/ui-toolkit";
+import { useSuppressAgentStatusOrb } from "../../../../../../components/AgentStatusOrb/shared";
 import {
     HeaderRow,
     BackButton,
@@ -94,6 +95,10 @@ export interface CreateFlowShellProps {
  * the library form feels like one continuous flow rather than separate forms.
  */
 export function CreateFlowShell({ title, subtitle, onBack, bodyFill, fill, children }: CreateFlowShellProps) {
+    // The embedded panels render inside an overview, whose view still counts as
+    // orb-worthy — so the shell has to opt out for them.
+    useSuppressAgentStatusOrb();
+
     return (
         <ShellBackdrop fill={fill}>
             <ShellContainer>

--- a/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -35,6 +35,7 @@ import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { Markdown } from "../../../components/Markdown";
 import { AlertBoxWithClose } from "../../AIPanel/AlertBoxWithClose";
 import { PackageListView } from "./PackageListView";
+import { useSuppressAgentStatusOrb } from "../../../components/AgentStatusOrb/shared";
 import { getWorkspaceProjectScopes } from "../PackageOverview/utils";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
 
@@ -732,6 +733,8 @@ export function WorkspaceOverview({ isInDevant, isICPSupported }: WorkspaceOverv
 
     const [showAlert, setShowAlert] = React.useState(false);
     const [icpActionLoading, setIcpActionLoading] = React.useState<IcpAction | null>(null);
+
+    useSuppressAgentStatusOrb();
 
     const { data: devantMetadata, refetch: refetchDevantMetadata } = useQuery({
         queryKey: ["project-devant-metadata"],

--- a/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -35,7 +35,6 @@ import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { Markdown } from "../../../components/Markdown";
 import { AlertBoxWithClose } from "../../AIPanel/AlertBoxWithClose";
 import { PackageListView } from "./PackageListView";
-import { useSuppressAgentStatusOrb } from "../../../components/AgentStatusOrb/shared";
 import { getWorkspaceProjectScopes } from "../PackageOverview/utils";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
 
@@ -733,8 +732,6 @@ export function WorkspaceOverview({ isInDevant, isICPSupported }: WorkspaceOverv
 
     const [showAlert, setShowAlert] = React.useState(false);
     const [icpActionLoading, setIcpActionLoading] = React.useState<IcpAction | null>(null);
-
-    useSuppressAgentStatusOrb();
 
     const { data: devantMetadata, refetch: refetchDevantMetadata } = useQuery({
         queryKey: ["project-devant-metadata"],

--- a/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -35,8 +35,6 @@ import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { Markdown } from "../../../components/Markdown";
 import { AlertBoxWithClose } from "../../AIPanel/AlertBoxWithClose";
 import { PackageListView } from "./PackageListView";
-import { CopilotHeroBox } from "../../../components/AgentStatusOrb/CopilotHeroBox";
-import { useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
 import { getWorkspaceProjectScopes } from "../PackageOverview/utils";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
 
@@ -83,11 +81,6 @@ const HeaderRow = styled.div`
     border-bottom: 1px solid var(--vscode-dropdown-border);
     flex-shrink: 0;
     margin: 16px 16px 0 16px;
-`;
-
-const HeroRow = styled.div`
-    margin: 16px 16px 0 16px;
-    flex-shrink: 0;
 `;
 
 const MainContent = styled.div<{ hasDeployment?: boolean }>`
@@ -739,7 +732,6 @@ export function WorkspaceOverview({ isInDevant, isICPSupported }: WorkspaceOverv
 
     const [showAlert, setShowAlert] = React.useState(false);
     const [icpActionLoading, setIcpActionLoading] = React.useState<IcpAction | null>(null);
-    const aiPanelOpen = useAiPanelOpen();
 
     const { data: devantMetadata, refetch: refetchDevantMetadata } = useQuery({
         queryKey: ["project-devant-metadata"],
@@ -1056,12 +1048,6 @@ export function WorkspaceOverview({ isInDevant, isICPSupported }: WorkspaceOverv
                     <ProjectSubtitle>Project</ProjectSubtitle>
                 </TitleContainer>
             </HeaderRow>
-
-            {!aiPanelOpen && (
-                <HeroRow>
-                    <CopilotHeroBox />
-                </HeroRow>
-            )}
 
             <MainContent hasDeployment={hasStandardIntegrations}>
                 <LeftContent>


### PR DESCRIPTION
Follow-up to #769. Each ambient Copilot surface now appears only where it helps.

- Remove the prompt bar from the project (workspace) overview — it stays on the package/integration overview
- Move that prompt bar into the design panel, below the component diagram, so it sits with the artifacts it acts on rather than above the page
- Vary its placeholder by state — "What would you like to build?" on an empty integration, "What would you like to change?" once artifacts exist — matching the wording the chat panel already uses
- Show the floating orb only on the hubs and design canvases — overview, artifacts, the flow/service/service-class/agent designers, the ER/type/GraphQL diagrams and both data mappers. Forms, wizards, list and settings pages, setup/welcome pages and Copilot's own views go without it, and a view added later has to opt in
- Stop the orb rendering over loading and error states: it moves inside the `viewReady` branch (so the language-server loading and dependency-pulling views no longer carry it), and it stays hidden while no view is resolved, on an unknown view, and on the view-load error state
- Generalise the hero-presence store into orb suppression (`useSuppressAgentStatusOrb()` / `subscribeOrbSuppressed()`), so a view opts out whether or not it carries a prompt bar
- Hide the Copilot status bar item unless it has something to report: it now shows only for a live run, a pending input or an error, and only while the panel is not on screen. The AI panel gains an `onDidChangeViewState` listener so a panel hidden behind another tab still gets the status bar
- Stop the follow-up chips being clipped: a negative bottom margin put the last ~14px of the chip row past the transcript's scroll end, so auto-scroll could never reveal the full row
- Fix a pre-existing e2e bug in the HTTP upload test: it invoked "Run Integration" by command ID through the palette, which never matches the palette's label text, so the service never started

The view declares the orb opt-out because the orb cannot learn the current view from `onStateChanged` — one listener per notification, owned by the panel roots — and mount/unmount already follows navigation. Panel visibility is tracked separately from `aiPanelOpen`, which keeps its "panel is alive" meaning for the orb and the mini-chat handoff.

<img width="1912" height="1192" alt="Screenshot 2026-08-04 at 11 40 57 PM" src="https://github.com/user-attachments/assets/289c5db9-87c6-40bd-a1cd-7759200510eb" />

<img width="1912" height="1192" alt="Screenshot 2026-08-04 at 11 40 49 PM" src="https://github.com/user-attachments/assets/825a4a5c-d7f9-4b6a-b50b-a79fe0185afd" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Removed the Copilot prompt bar from workspace overviews.
- Moved the prompt bar into the package and integration design panel.
- Updated prompt text for empty and populated integrations.
- Limited the floating agent status orb to supported design views.
- Suppressed the orb on unsupported, loading, error, unresolved, and Copilot views.
- Added shared orb-suppression state and removed hero-presence APIs.
- Updated AI panel visibility tracking and status bar behavior.
- Suppressed the orb in embedded Create flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


