### PR TITLE
Add Azure Files integration to brand icon registry and trigger artifact

### DIFF
--- a/packages/ballerina-core/src/icons/brand-icon-registry.ts
+++ b/packages/ballerina-core/src/icons/brand-icon-registry.ts
@@ -52,6 +52,7 @@ export const BRAND_ICON_REGISTRY: Record<string, BrandIcon> = {
     ftp: { glyph: "bi-ftp" },
     smb: { glyph: "bi-smb" },
     file: { glyph: "bi-file" },
+    "azure.storage.files": { glyph: "bi-file" },
     mssql: { glyph: "bi-mssql", color: "#b61d1c" },
     postgresql: { glyph: "bi-postgresql", color: "#336791" },
     mysql: { glyph: "bi-mysql", color: "#00758F" },

--- a/packages/ballerina-language-server/model-generator-commons/src/main/resources/bundled_trigger_artifact.json
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/resources/bundled_trigger_artifact.json
@@ -35,5 +35,15 @@
       "color": "#00C895",
       "kind": "event"
     }
+  },
+  "azure.storage.files": {
+    "displayName": "Azure Files Integration",
+    "icon": {
+      "glyph": "bi-file",
+      "kind": "file"
+    },
+    "labelFields": [
+      "path"
+    ]
   }
 }


### PR DESCRIPTION
## Purpose
Add Azure Files integration to brand icon registry and trigger artifact, and fix the misalignment in the Add Artifact page. 

- Registered Azure Files with the glyph "bi-file" in the BRAND_ICON_REGISTRY.
- Updated bundled_trigger_artifact.json to include Azure Files integration with display name, icon, and label fields.