### PR TITLE
Add new icon for azure-files

### DIFF
--- a/packages/ballerina-core/src/icons/brand-icon-registry.ts
+++ b/packages/ballerina-core/src/icons/brand-icon-registry.ts
@@ -52,6 +52,7 @@ export const BRAND_ICON_REGISTRY: Record<string, BrandIcon> = {
     ftp: { glyph: "bi-ftp" },
     smb: { glyph: "bi-smb" },
     file: { glyph: "bi-file" },
+    "azure.storage.files": { glyph: "bi-file" },
     mssql: { glyph: "bi-mssql", color: "#b61d1c" },
     postgresql: { glyph: "bi-postgresql", color: "#336791" },
     mysql: { glyph: "bi-mysql", color: "#00758F" },

--- a/packages/ballerina-language-server/model-generator-commons/src/main/resources/bundled_trigger_artifact.json
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/resources/bundled_trigger_artifact.json
@@ -39,7 +39,7 @@
   "azure.storage.files": {
     "displayName": "Azure Files Integration",
     "icon": {
-      "glyph": "bi-file",
+      "glyph": "bi-azure-files",
       "kind": "file"
     },
     "labelFields": [

--- a/packages/ballerina-language-server/model-generator-commons/src/main/resources/bundled_trigger_artifact.json
+++ b/packages/ballerina-language-server/model-generator-commons/src/main/resources/bundled_trigger_artifact.json
@@ -35,5 +35,15 @@
       "color": "#00C895",
       "kind": "event"
     }
+  },
+  "azure.storage.files": {
+    "displayName": "Azure Files Integration",
+    "icon": {
+      "glyph": "bi-file",
+      "kind": "file"
+    },
+    "labelFields": [
+      "path"
+    ]
   }
 }


### PR DESCRIPTION
## Purpose
- Changed the glyph for Azure Files integration from "bi-file" to "bi-azure-files" to better represent the service in the UI.