### PR TITLE
Add Start with Copilot to the integration creation wizard

### DIFF
--- a/packages/ballerina-core/src/rpc-types/webview-bridge/index.ts
+++ b/packages/ballerina-core/src/rpc-types/webview-bridge/index.ts
@@ -252,6 +252,8 @@ export interface CreateIntegrationRequest {
     project: IntegrationProjectParams;
     /** Configured first artifact; absent for an empty integration. */
     artifact?: PendingIntegrationArtifactPayload;
+    /** Lands on the new integration instead of the project — only that page has the Copilot prompt bar. */
+    startWithCopilot?: boolean;
 }
 
 /**

--- a/packages/ballerina-extension/src/features/bi/integration-wizard.ts
+++ b/packages/ballerina-extension/src/features/bi/integration-wizard.ts
@@ -118,7 +118,7 @@ export async function createIntegration(params: CreateIntegrationRequest): Promi
     const { packageRoot, openRoot } = await createBIComponent(projectRequest);
     await cleanupStaging();
 
-    const landingContext = resolveCreateLandingContext(packageRoot, openRoot, projectRequest);
+    const landingContext = resolveCreateLandingContext(packageRoot, openRoot, projectRequest, params.startWithCopilot);
 
     // Live path only when the extension has ALREADY activated `openRoot` — a just-converted
     // workspace at the same path is open in VS Code but still needs the reload.

--- a/packages/ballerina-extension/src/utils/bi.ts
+++ b/packages/ballerina-extension/src/utils/bi.ts
@@ -953,7 +953,9 @@ export interface CreateLandingContext {
 export function resolveCreateLandingContext(
     packageRoot: string,
     openRoot: string,
-    request: Pick<ProjectRequest, 'newProject' | 'convertToWorkspace' | 'workspaceName'>
+    request: Pick<ProjectRequest, 'newProject' | 'convertToWorkspace' | 'workspaceName'>,
+    /** Lands on the package even for a new project — the Copilot prompt bar is only there. */
+    preferPackageLanding = false
 ): CreateLandingContext {
     // The folder to open being the package itself means no project was involved.
     if (isSamePath(packageRoot, openRoot)) {
@@ -965,7 +967,7 @@ export function resolveCreateLandingContext(
         // read the title it was actually created with.
         projectName: request.workspaceName?.trim() || getExistingProjectInfo(openRoot).name || path.basename(openRoot),
         isNewProject,
-        landing: isNewProject ? "project" : "package",
+        landing: isNewProject && !preferPackageLanding ? "project" : "package",
     };
 }
 

--- a/packages/ballerina-visualizer/src/views/BI/CreateIntegrationWizard/components/WizardFooter.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/CreateIntegrationWizard/components/WizardFooter.tsx
@@ -39,17 +39,30 @@ interface WizardFooterProps {
     skipLabel?: string;
     onSkip?: () => void;
     skipDisabled?: boolean;
+    /** Hands the new integration to Copilot. Omit to hide. */
+    copilotLabel?: string;
+    onCopilot?: () => void;
+    copilotDisabled?: boolean;
 }
 
-/** The wizard's per-step action row: … [Create Empty Integration] [Primary].
+/** The wizard's per-step action row: … [Create Empty Integration] [Start with Copilot] [Primary].
  *  The primary action sits last so it lands at the right edge of the form. */
 export function WizardFooter(props: WizardFooterProps) {
-    const { primaryLabel, onPrimary, primaryDisabled, skipLabel, onSkip, skipDisabled } = props;
+    const {
+        primaryLabel, onPrimary, primaryDisabled,
+        skipLabel, onSkip, skipDisabled,
+        copilotLabel, onCopilot, copilotDisabled,
+    } = props;
     return (
         <FooterBar>
             {skipLabel && onSkip && (
                 <Button appearance="secondary" onClick={onSkip} disabled={skipDisabled}>
                     {skipLabel}
+                </Button>
+            )}
+            {copilotLabel && onCopilot && (
+                <Button appearance="secondary" onClick={onCopilot} disabled={copilotDisabled}>
+                    {copilotLabel}
                 </Button>
             )}
             {primaryLabel && onPrimary && (

--- a/packages/ballerina-visualizer/src/views/BI/CreateIntegrationWizard/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/CreateIntegrationWizard/index.tsx
@@ -248,6 +248,7 @@ export function CreateIntegrationWizard({
     const trimmedDirectoryName = basicInfo.directoryName.trim();
     const effectiveDirectoryName = basicInfo.dirTouched ? trimmedDirectoryName : trimmedDirectoryName || packageName;
     const fullPath = joinPath(basicInfo.baseDir, basicInfo.directoryName);
+    const createDisabled = isSubmitting || !!nameError || (!embedded && !!pathError);
 
     useEffect(() => {
         // Sweep any temp staging package left by an abandoned session (the unmount cancel can be lost).
@@ -527,7 +528,10 @@ export function CreateIntegrationWizard({
      *  The real project is created fresh at the final path here (and only here);
      *  the standalone wizard re-validates the path (the embedded flow trusts the
      *  chooser's validation). */
-    const handleCreateIntegration = async (artifact?: PendingIntegrationArtifactPayload) => {
+    const handleCreateIntegration = async (
+        artifact?: PendingIntegrationArtifactPayload,
+        startWithCopilot?: boolean
+    ) => {
         setSubmitError(null);
         if (!embedded && !(await validatePathForSubmit())) {
             return;
@@ -546,6 +550,7 @@ export function CreateIntegrationWizard({
                     convertToWorkspace: projectContext?.convertToWorkspace,
                 },
                 artifact,
+                startWithCopilot,
             });
             // The extension reloads the window — stay in the submitting state until teardown.
         } catch (error) {
@@ -554,6 +559,11 @@ export function CreateIntegrationWizard({
             setSubmitError(`Failed to create the integration: ${message}`);
             setIsSubmitting(false);
         }
+    };
+
+    /** Creates the integration empty and lands on it, ready for the Copilot prompt bar. */
+    const handleStartWithCopilot = (): void => {
+        void handleCreateIntegration(undefined, true);
     };
 
     /** Routes the configured artifact to the mode's submit path: generate into the
@@ -696,7 +706,10 @@ export function CreateIntegrationWizard({
                         // Only offered on the Name step; the Type step requires a selection.
                         skipLabel={!isExistingPackage && step === NAME_STEP ? "Create Empty Integration" : undefined}
                         onSkip={() => handleCreateIntegration()}
-                        skipDisabled={isSubmitting || !!nameError || (!embedded && !!pathError)}
+                        skipDisabled={createDisabled}
+                        copilotLabel={!isExistingPackage && step === NAME_STEP ? "Start with Copilot" : undefined}
+                        onCopilot={handleStartWithCopilot}
+                        copilotDisabled={createDisabled}
                     />
                 )}
             </StepBody>


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/1998

- Add a "Start with Copilot" footer button on the New Integration Name step, alongside the existing "Create Empty Integration" and "Next" actions
- Both create the same empty integration; "Start with Copilot" additionally lands on the new integration's own overview instead of the project overview, since that's the only page with the Copilot prompt bar
- Threaded via a new `startWithCopilot` flag on `CreateIntegrationRequest`, consumed by `resolveCreateLandingContext`'s new `preferPackageLanding` param (only overrides landing for this one path; `createBIProject`'s library-creation caller is unaffected)
- "Create Empty Integration" stays byte-for-byte unchanged


<img width="1276" height="998" alt="image" src="https://github.com/user-attachments/assets/d818494b-3131-4beb-9269-3ed4bfe5ff38" />
