### PR TITLE
Use trigger JSON icons for unsupported brands

### DIFF
--- a/packages/ballerina-core/src/icons/brand-icon-registry.ts
+++ b/packages/ballerina-core/src/icons/brand-icon-registry.ts
@@ -56,21 +56,9 @@ export const BRAND_ICON_REGISTRY: Record<string, BrandIcon> = {
     postgresql: { glyph: "bi-postgresql", color: "#336791" },
     mysql: { glyph: "bi-mysql", color: "#00758F" },
     shopify: { glyph: "bi-shopify", color: "#95BF47" },
-    oracledb: { glyph: "bi-oracledb", color: "#b61d1c" },
-    "sap.jco": { glyph: "bi-sap" },
-    jco: { glyph: "bi-sap" },
     "trigger.shopify": { glyph: "bi-shopify", color: "#95BF47" },
     hubspot: { glyph: "bi-hubspot", color: "#FF7A59" },
     "trigger.hubspot": { glyph: "bi-hubspot", color: "#FF7A59" },
-    "azure.storage.files": { glyph: "bi-file" },
-    files: { glyph: "bi-file" },
-    "googleapis.chat": { glyph: "bi-chat" },
-    chat: { glyph: "bi-chat" },
-    telegram: { glyph: "bi-telegram" },
-    "whatsapp.business": { glyph: "bi-whatsapp" },
-    business: { glyph: "bi-whatsapp" },
-    "aws.sqs": { glyph: "bi-sqs" },
-    sqs: { glyph: "bi-sqs" },
 };
 
 /** Looks up the brand glyph override for a module/type identifier; `undefined` when there is none. */


### PR DESCRIPTION
## What changed
<img width="1548" height="392" alt="image" src="https://github.com/user-attachments/assets/aac1e96f-939c-435f-afec-5378a5dec8e8" />
Removed the unsupported custom font-glyph mappings for the newly added trigger modules.

## Why

The mappings bypassed each trigger JSON model's `icon` field and requested glyphs absent from the shared WSO2 VS Code icon font. This left the affected Event Integration cards blank.

## Impact

The cards now follow the existing `ImageWithFallback` path and render their JSON-provided icons.

## Validation

- `RUSH_BUILD_CACHE_ENABLED=0 rush build --to ballerina`
- Installed the generated VSIX and reloaded VS Code; affected trigger icons rendered correctly.
