### PR TITLE
Refine trigger models for Google Chat, Telegram and WhatsApp Business

### DIFF
--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/googleapis.chat.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/googleapis.chat.json
@@ -2,19 +2,20 @@
   "schemaVersion": "1.0",
   "id": "googleapis.chat",
   "displayName": "Google Chat",
-  "description": "Create a service to handle Google Chat app interaction events (messages, card clicks, app commands, and more)",
+  "description": "Receives Google Chat interaction events via direct HTTP delivery from Google Chat.",
   "orgName": "ballerinax",
   "packageName": "googleapis.chat",
   "moduleName": "googleapis.chat",
   "version": "0.1.0",
   "type": "chat",
-  "icon": "icon.png",
+  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_googleapis.chat_0.1.0.png",
   "kind": "event",
+  "listenerKind": "MULTIPLE_SELECT_LISTENER",
   "initProperties": {
     "listener": {
       "metadata": {
-        "label": "Configure Google Chat Listener",
-        "description": "Select an existing Google Chat listener or create a new one"
+        "label": "Listener",
+        "description": "Attach the service to a new or existing Google Chat listener."
       },
       "types": [
         {
@@ -33,8 +34,8 @@
       "choices": [
         {
           "metadata": {
-            "label": "Create new",
-            "description": "Create a new Google Chat listener"
+            "label": "Create New Listener",
+            "description": "Define a new Google Chat listener in the project."
           },
           "types": [
             {
@@ -50,7 +51,7 @@
             "listenerConfig": {
               "metadata": {
                 "label": "Listener Configurations",
-                "description": "Configure the Google Chat webhook listener"
+                "description": "Configure the Google Chat trigger listener."
               },
               "types": [
                 {
@@ -96,9 +97,10 @@
                 "listenOn": {
                   "metadata": {
                     "label": "Port",
-                    "description": "A port number to bind a new HTTP listener to, or an existing `http:Listener` to reuse. Defaults to 8000."
+                    "description": "The port or HTTP listener to listen on. Defaults to port 8000."
                   },
                   "value": "8000",
+                  "placeholder": "8000",
                   "enabled": true,
                   "editable": true,
                   "optional": true,
@@ -119,13 +121,12 @@
                       "ballerinaType": "int|http:Listener",
                       "selected": false
                     }
-                  ],
-                  "placeholder": "8000"
+                  ]
                 },
                 "auth": {
                   "metadata": {
                     "label": "Auth Config",
-                    "description": "Authentication for the Chat API client used to respond to events: a service account (JSON key file or inline credentials), OAuth2, or a pre-obtained bearer token."
+                    "description": "Authentication for the Chat API client (service account, OAuth2, or bearer token)"
                   },
                   "value": "",
                   "enabled": true,
@@ -178,18 +179,23 @@
                       "ballerinaType": "chat:ServiceAccountAuthConfig|chat:OAuth2Config|http:BearerTokenConfig",
                       "selected": false
                     }
+                  ],
+                  "validations": [
+                    {
+                      "rule": "common.validate.required"
+                    }
                   ]
                 },
                 "httpListenerConfig": {
                   "metadata": {
                     "label": "HTTP Listener Config",
-                    "description": "Optional inbound HTTP listener settings (SSL/TLS, timeouts, request limits, ...)"
+                    "description": "Optional inbound HTTP listener settings"
                   },
                   "value": "",
                   "enabled": true,
                   "editable": true,
                   "optional": true,
-                  "advanced": true,
+                  "advanced": false,
                   "codedata": {
                     "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
                     "originalName": "httpListenerConfig",
@@ -223,8 +229,8 @@
         },
         {
           "metadata": {
-            "label": "Use existing",
-            "description": "Select an existing Google Chat listener"
+            "label": "Use Existing Listener",
+            "description": "Attach to one or more Google Chat listeners already declared in the project."
           },
           "types": [
             {
@@ -233,18 +239,18 @@
             }
           ],
           "enabled": false,
-          "editable": false,
+          "editable": true,
           "optional": false,
           "advanced": false,
           "properties": {
             "existingListener": {
               "metadata": {
                 "label": "Listener(s)",
-                "description": "Select one or more existing Google Chat listeners to attach to"
+                "description": "Select one or more existing Google Chat listeners to attach to."
               },
               "types": [
                 {
-                  "fieldType": "MULTI_SELECT_LISTENER",
+                  "fieldType": "MULTIPLE_SELECT_LISTENER",
                   "selected": true,
                   "ballerinaType": "googleapis.chat:Listener"
                 }
@@ -268,10 +274,10 @@
     {
       "metadata": {
         "label": "Chat Service",
-        "description": "Handles Google Chat app interaction events. Handler methods are recognised by convention, not declared on the type; declare only the ones you need."
+        "description": "Triggers when a Google Chat interaction event is received."
       },
       "name": "ChatService",
-      "description": "Triggers when a Google Chat interaction event is received.\n\nImplement this service object to handle Chat app events. Each remote function\ncorresponds to a specific event type. You only need to implement the handlers\nrelevant to your Chat app.\n\nEach handler receives the event and an event-specific Caller for responding.\nThe Caller's respond() method sends a synchronous HTTP response back to\nGoogle Chat. Additional async Chat API operations (sendMessage, updateMessage,\netc.) are available on callers that support them.\n\n```ballerina\nremote function onMessage(chat:MessageEvent event, chat:MessageCaller caller) returns error? {\n    check caller->respond({ text: \"Got your message!\" });\n}\nremote function onAppHome(chat:ChatEvent event, chat:AppHomeCaller caller) returns error? {\n    check caller->respond({ sections: [{ widgets: [{ textParagraph: { text: \"Welcome!\" } }] }] });\n}\n```\n\n**Available event handlers:**\n- `onMessage(MessageEvent|ChatEvent, MessageCaller)` - A user sends a message\n- `onAddedToSpace(ChatEvent, MessageCaller)` - The app is added to a space\n- `onRemovedFromSpace(ChatEvent)` - The app is removed from a space (no caller)\n- `onCardClicked(ChatEvent, CardClickedCaller)` - A user clicks a button/card element\n- `onWidgetUpdated(ChatEvent, WidgetUpdatedCaller)` - A user updates a widget\n- `onAppCommand(ChatEvent, MessageCaller)` - A user invokes a command\n- `onAppHome(ChatEvent, AppHomeCaller)` - A user navigates to the app home\n- `onSubmitForm(ChatEvent, SubmitFormCaller)` - A user submits a form from app home",
+      "description": "Triggers when a Google Chat interaction event is received.",
       "enabled": true,
       "editable": false,
       "codedata": {
@@ -283,7 +289,7 @@
         "serviceConfig": {
           "metadata": {
             "label": "Service Config",
-            "description": "@chat:ServiceConfig \u2014 bearer-token verification settings for this Chat app: verify by HTTP endpoint URL (recommended) or by GCP project number."
+            "description": "Service-level configuration for the Google Chat trigger."
           },
           "types": [
             {
@@ -303,11 +309,16 @@
             "moduleName": "chat",
             "path": ""
           },
+          "validations": [
+            {
+              "rule": "common.validate.required"
+            }
+          ],
           "choices": [
             {
               "metadata": {
-                "label": "HTTP Endpoint URL",
-                "description": "Verify the bearer token's audience against this listener's public HTTPS endpoint URL (recommended)."
+                "label": "HTTP Endpoint URL Config",
+                "description": "Verifies bearer tokens using the HTTP endpoint URL as the audience."
               },
               "types": [
                 {
@@ -327,7 +338,7 @@
                 "endpointUrl": {
                   "metadata": {
                     "label": "Endpoint URL",
-                    "description": "The public HTTPS URL of this listener, exactly as entered in the Chat app's HTTP endpoint URL field."
+                    "description": "The public HTTPS URL of this listener."
                   },
                   "types": [
                     {
@@ -349,16 +360,20 @@
                   "advanced": false,
                   "codedata": {
                     "type": "MAPPING_FIELD",
-                    "field": "endpointUrl",
-                    "valueKind": "STRING_LITERAL"
-                  }
+                    "field": "endpointUrl"
+                  },
+                  "validations": [
+                    {
+                      "rule": "common.validate.required"
+                    }
+                  ]
                 }
               }
             },
             {
               "metadata": {
                 "label": "Project Number",
-                "description": "Verify the bearer token's audience against this GCP project number."
+                "description": "Verifies bearer tokens using the GCP project number as the audience."
               },
               "types": [
                 {
@@ -400,9 +415,13 @@
                   "advanced": false,
                   "codedata": {
                     "type": "MAPPING_FIELD",
-                    "field": "projectNumber",
-                    "valueKind": "STRING_LITERAL"
-                  }
+                    "field": "projectNumber"
+                  },
+                  "validations": [
+                    {
+                      "rule": "common.validate.required"
+                    }
+                  ]
                 }
               }
             }
@@ -414,7 +433,7 @@
         {
           "metadata": {
             "label": "On Message",
-            "description": "Invoked when a user sends a message to the Chat app."
+            "description": "A user sends a message."
           },
           "name": "onMessage",
           "nameEditable": false,
@@ -428,6 +447,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A user sends a message.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onMessage",
@@ -437,7 +457,7 @@
             {
               "metadata": {
                 "label": "Event",
-                "description": "Invoked when a user sends a message to the Chat app."
+                "description": "A Google Chat message interaction event."
               },
               "kind": "REQUIRED",
               "type": {
@@ -451,10 +471,6 @@
                   {
                     "fieldType": "TYPE",
                     "selected": true
-                  },
-                  {
-                    "fieldType": "TYPE",
-                    "selected": false
                   }
                 ],
                 "enabled": true,
@@ -465,7 +481,7 @@
               "name": {
                 "metadata": {
                   "label": "event",
-                  "description": "Invoked when a user sends a message to the Chat app."
+                  "description": "A Google Chat message interaction event."
                 },
                 "placeholder": "event",
                 "value": "event",
@@ -492,7 +508,7 @@
             {
               "metadata": {
                 "label": "Caller",
-                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+                "description": "An event-specific Caller for responding."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -517,7 +533,7 @@
               "name": {
                 "metadata": {
                   "label": "caller",
-                  "description": "Used to respond to the event."
+                  "description": "An event-specific Caller for responding."
                 },
                 "placeholder": "caller",
                 "value": "caller",
@@ -549,11 +565,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -562,7 +578,7 @@
         {
           "metadata": {
             "label": "On Added To Space",
-            "description": "Invoked when the Chat app is added to a space."
+            "description": "The app is added to a space."
           },
           "name": "onAddedToSpace",
           "nameEditable": false,
@@ -576,6 +592,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "The app is added to a space.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onAddedToSpace",
@@ -585,7 +602,7 @@
             {
               "metadata": {
                 "label": "Event",
-                "description": "Invoked when the Chat app is added to a space."
+                "description": "A Google Chat app interaction event."
               },
               "kind": "REQUIRED",
               "type": {
@@ -609,7 +626,7 @@
               "name": {
                 "metadata": {
                   "label": "event",
-                  "description": "Invoked when the Chat app is added to a space."
+                  "description": "A Google Chat app interaction event."
                 },
                 "placeholder": "event",
                 "value": "event",
@@ -636,7 +653,7 @@
             {
               "metadata": {
                 "label": "Caller",
-                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+                "description": "An event-specific Caller for responding."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -661,7 +678,7 @@
               "name": {
                 "metadata": {
                   "label": "caller",
-                  "description": "Used to respond to the event."
+                  "description": "An event-specific Caller for responding."
                 },
                 "placeholder": "caller",
                 "value": "caller",
@@ -693,11 +710,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -706,7 +723,7 @@
         {
           "metadata": {
             "label": "On Removed From Space",
-            "description": "Invoked when the Chat app is removed from a space."
+            "description": "The app is removed from a space (no caller)."
           },
           "name": "onRemovedFromSpace",
           "nameEditable": false,
@@ -720,6 +737,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "The app is removed from a space (no caller).",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onRemovedFromSpace",
@@ -729,7 +747,7 @@
             {
               "metadata": {
                 "label": "Event",
-                "description": "Invoked when the Chat app is removed from a space."
+                "description": "A Google Chat app interaction event."
               },
               "kind": "REQUIRED",
               "type": {
@@ -753,7 +771,7 @@
               "name": {
                 "metadata": {
                   "label": "event",
-                  "description": "Invoked when the Chat app is removed from a space."
+                  "description": "A Google Chat app interaction event."
                 },
                 "placeholder": "event",
                 "value": "event",
@@ -785,11 +803,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -798,7 +816,7 @@
         {
           "metadata": {
             "label": "On Card Clicked",
-            "description": "Invoked when a user clicks a button or card element."
+            "description": "A user clicks a button/card element."
           },
           "name": "onCardClicked",
           "nameEditable": false,
@@ -812,6 +830,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A user clicks a button/card element.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onCardClicked",
@@ -821,7 +840,7 @@
             {
               "metadata": {
                 "label": "Event",
-                "description": "Invoked when a user clicks a button or card element."
+                "description": "A Google Chat app interaction event."
               },
               "kind": "REQUIRED",
               "type": {
@@ -845,7 +864,7 @@
               "name": {
                 "metadata": {
                   "label": "event",
-                  "description": "Invoked when a user clicks a button or card element."
+                  "description": "A Google Chat app interaction event."
                 },
                 "placeholder": "event",
                 "value": "event",
@@ -872,7 +891,7 @@
             {
               "metadata": {
                 "label": "Caller",
-                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+                "description": "An event-specific Caller for responding."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -897,7 +916,7 @@
               "name": {
                 "metadata": {
                   "label": "caller",
-                  "description": "Used to respond to the event."
+                  "description": "An event-specific Caller for responding."
                 },
                 "placeholder": "caller",
                 "value": "caller",
@@ -929,11 +948,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -942,7 +961,7 @@
         {
           "metadata": {
             "label": "On Widget Updated",
-            "description": "Invoked when a user updates a widget."
+            "description": "A user updates a widget."
           },
           "name": "onWidgetUpdated",
           "nameEditable": false,
@@ -956,6 +975,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A user updates a widget.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onWidgetUpdated",
@@ -965,7 +985,7 @@
             {
               "metadata": {
                 "label": "Event",
-                "description": "Invoked when a user updates a widget."
+                "description": "A Google Chat app interaction event."
               },
               "kind": "REQUIRED",
               "type": {
@@ -989,7 +1009,7 @@
               "name": {
                 "metadata": {
                   "label": "event",
-                  "description": "Invoked when a user updates a widget."
+                  "description": "A Google Chat app interaction event."
                 },
                 "placeholder": "event",
                 "value": "event",
@@ -1016,7 +1036,7 @@
             {
               "metadata": {
                 "label": "Caller",
-                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+                "description": "An event-specific Caller for responding."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1041,7 +1061,7 @@
               "name": {
                 "metadata": {
                   "label": "caller",
-                  "description": "Used to respond to the event."
+                  "description": "An event-specific Caller for responding."
                 },
                 "placeholder": "caller",
                 "value": "caller",
@@ -1073,11 +1093,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1086,7 +1106,7 @@
         {
           "metadata": {
             "label": "On App Command",
-            "description": "Invoked when a user invokes a Chat app command."
+            "description": "A user invokes a command."
           },
           "name": "onAppCommand",
           "nameEditable": false,
@@ -1100,6 +1120,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A user invokes a command.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onAppCommand",
@@ -1109,7 +1130,7 @@
             {
               "metadata": {
                 "label": "Event",
-                "description": "Invoked when a user invokes a Chat app command."
+                "description": "A Google Chat app interaction event."
               },
               "kind": "REQUIRED",
               "type": {
@@ -1133,7 +1154,7 @@
               "name": {
                 "metadata": {
                   "label": "event",
-                  "description": "Invoked when a user invokes a Chat app command."
+                  "description": "A Google Chat app interaction event."
                 },
                 "placeholder": "event",
                 "value": "event",
@@ -1160,7 +1181,7 @@
             {
               "metadata": {
                 "label": "Caller",
-                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+                "description": "An event-specific Caller for responding."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1185,7 +1206,7 @@
               "name": {
                 "metadata": {
                   "label": "caller",
-                  "description": "Used to respond to the event."
+                  "description": "An event-specific Caller for responding."
                 },
                 "placeholder": "caller",
                 "value": "caller",
@@ -1217,11 +1238,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1230,7 +1251,7 @@
         {
           "metadata": {
             "label": "On App Home",
-            "description": "Invoked when a user navigates to the Chat app's home view."
+            "description": "A user navigates to the app home."
           },
           "name": "onAppHome",
           "nameEditable": false,
@@ -1244,6 +1265,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A user navigates to the app home.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onAppHome",
@@ -1253,7 +1275,7 @@
             {
               "metadata": {
                 "label": "Event",
-                "description": "Invoked when a user navigates to the Chat app's home view."
+                "description": "A Google Chat app interaction event."
               },
               "kind": "REQUIRED",
               "type": {
@@ -1277,7 +1299,7 @@
               "name": {
                 "metadata": {
                   "label": "event",
-                  "description": "Invoked when a user navigates to the Chat app's home view."
+                  "description": "A Google Chat app interaction event."
                 },
                 "placeholder": "event",
                 "value": "event",
@@ -1304,7 +1326,7 @@
             {
               "metadata": {
                 "label": "Caller",
-                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+                "description": "An event-specific Caller for responding."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1329,7 +1351,7 @@
               "name": {
                 "metadata": {
                   "label": "caller",
-                  "description": "Used to respond to the event."
+                  "description": "An event-specific Caller for responding."
                 },
                 "placeholder": "caller",
                 "value": "caller",
@@ -1361,11 +1383,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1374,7 +1396,7 @@
         {
           "metadata": {
             "label": "On Submit Form",
-            "description": "Invoked when a user submits a form from the Chat app's home view."
+            "description": "A user submits a form from app home."
           },
           "name": "onSubmitForm",
           "nameEditable": false,
@@ -1388,6 +1410,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A user submits a form from app home.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onSubmitForm",
@@ -1397,7 +1420,7 @@
             {
               "metadata": {
                 "label": "Event",
-                "description": "Invoked when a user submits a form from the Chat app's home view."
+                "description": "A Google Chat app interaction event."
               },
               "kind": "REQUIRED",
               "type": {
@@ -1421,7 +1444,7 @@
               "name": {
                 "metadata": {
                   "label": "event",
-                  "description": "Invoked when a user submits a form from the Chat app's home view."
+                  "description": "A Google Chat app interaction event."
                 },
                 "placeholder": "event",
                 "value": "event",
@@ -1448,7 +1471,7 @@
             {
               "metadata": {
                 "label": "Caller",
-                "description": "Used to respond to the event, e.g. via `caller->respond(...)`."
+                "description": "An event-specific Caller for responding."
               },
               "kind": "OPTIONAL",
               "type": {
@@ -1473,7 +1496,7 @@
               "name": {
                 "metadata": {
                   "label": "caller",
-                  "description": "Used to respond to the event."
+                  "description": "An event-specific Caller for responding."
                 },
                 "placeholder": "caller",
                 "value": "caller",
@@ -1505,11 +1528,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1517,9 +1540,5 @@
         }
       ]
     }
-  ],
-  "importStatements": [
-    "ballerina/http"
-  ],
-  "listenerKind": "MULTIPLE_SELECT_LISTENER"
+  ]
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/telegram.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/telegram.json
@@ -2,19 +2,20 @@
   "schemaVersion": "1.0",
   "id": "telegram",
   "displayName": "Telegram",
-  "description": "Create a service to handle Telegram Bot API webhook updates (messages, callback queries, inline queries, and more)",
+  "description": "Create a service to handle Telegram Bot API webhook updates",
   "orgName": "ballerinax",
   "packageName": "telegram",
   "moduleName": "telegram",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "telegram",
-  "icon": "icon.png",
+  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_telegram_0.9.2.png",
   "kind": "event",
+  "listenerKind": "MULTIPLE_SELECT_LISTENER",
   "initProperties": {
     "listener": {
       "metadata": {
-        "label": "Configure Telegram Listener",
-        "description": "Select an existing Telegram listener or create a new one"
+        "label": "Listener",
+        "description": "Attach the service to a new or existing Telegram webhook listener."
       },
       "types": [
         {
@@ -33,8 +34,8 @@
       "choices": [
         {
           "metadata": {
-            "label": "Create new",
-            "description": "Create a new Telegram listener"
+            "label": "Create New Listener",
+            "description": "Define a new Telegram webhook listener in the project."
           },
           "types": [
             {
@@ -50,7 +51,7 @@
             "listenerConfig": {
               "metadata": {
                 "label": "Listener Configurations",
-                "description": "Configure the Telegram webhook listener"
+                "description": "Configure the Telegram webhook listener."
               },
               "types": [
                 {
@@ -96,9 +97,10 @@
                 "listenTo": {
                   "metadata": {
                     "label": "Port",
-                    "description": "A port number to bind a new HTTP listener to, or an existing `http:Listener` to reuse"
+                    "description": "A port number to bind a new `http:Listener` to, or an existing `http:Listener`"
                   },
-                  "value": "",
+                  "placeholder": "8090",
+                  "value": "8090",
                   "enabled": true,
                   "editable": true,
                   "optional": false,
@@ -111,7 +113,7 @@
                   "types": [
                     {
                       "fieldType": "NUMBER",
-                      "ballerinaType": "int|http:Listener",
+                      "ballerinaType": "int",
                       "selected": true
                     },
                     {
@@ -120,123 +122,191 @@
                       "selected": false
                     }
                   ],
-                  "placeholder": "8090"
+                  "validations": [
+                    {
+                      "rule": "common.validate.required"
+                    }
+                  ]
                 },
-                "secretToken": {
+                "authentication": {
                   "metadata": {
-                    "label": "Secret Token",
-                    "description": "Use this secret token directly. Every inbound update is authenticated by comparing it\nagainst the `X-Telegram-Bot-Api-Secret-Token` header."
+                    "label": "Authentication",
+                    "description": "Provide exactly one of `secretToken` or `token`."
                   },
+                  "types": [
+                    {
+                      "fieldType": "CHOICE",
+                      "selected": true
+                    }
+                  ],
                   "value": "",
                   "enabled": true,
                   "editable": true,
-                  "optional": true,
+                  "optional": false,
                   "advanced": false,
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
-                    "originalName": "secretToken",
-                    "path": "secretToken"
-                  },
-                  "types": [
+                  "choices": [
                     {
-                      "fieldType": "TEXT",
-                      "ballerinaType": "string",
-                      "selected": true
+                      "metadata": {
+                        "label": "Bot Token",
+                        "description": "The bot token to derive the secret token from."
+                      },
+                      "types": [
+                        {
+                          "fieldType": "FORM",
+                          "selected": true
+                        }
+                      ],
+                      "value": "true",
+                      "enabled": true,
+                      "editable": true,
+                      "optional": false,
+                      "advanced": false,
+                      "properties": {
+                        "token": {
+                          "metadata": {
+                            "label": "Bot Token",
+                            "description": "The bot token to derive the secret token from."
+                          },
+                          "value": "",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false,
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                            "originalName": "token",
+                            "path": "token"
+                          },
+                          "types": [
+                            {
+                              "fieldType": "TEXT",
+                              "ballerinaType": "string",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "string",
+                              "selected": false
+                            }
+                          ],
+                          "validations": [
+                            {
+                              "rule": "common.validate.required"
+                            }
+                          ]
+                        },
+                        "publicUrl": {
+                          "metadata": {
+                            "label": "Public URL",
+                            "description": "This listener's public HTTPS URL, used to auto-register the webhook."
+                          },
+                          "value": "",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": false,
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                            "originalName": "publicUrl",
+                            "path": "publicUrl"
+                          },
+                          "types": [
+                            {
+                              "fieldType": "TEXT",
+                              "ballerinaType": "string",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "string",
+                              "selected": false
+                            }
+                          ]
+                        },
+                        "serviceUrl": {
+                          "metadata": {
+                            "label": "Service URL",
+                            "description": "The Telegram Bot API base URL."
+                          },
+                          "value": "\"https://api.telegram.org\"",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": true,
+                          "advanced": true,
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                            "originalName": "serviceUrl",
+                            "path": "serviceUrl"
+                          },
+                          "types": [
+                            {
+                              "fieldType": "TEXT",
+                              "ballerinaType": "string",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "string",
+                              "selected": false
+                            }
+                          ],
+                          "placeholder": "https://api.telegram.org"
+                        }
+                      }
                     },
                     {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "string",
-                      "selected": false
+                      "metadata": {
+                        "label": "Secret Token",
+                        "description": "The secret token to authenticate inbound updates against."
+                      },
+                      "types": [
+                        {
+                          "fieldType": "FORM",
+                          "selected": true
+                        }
+                      ],
+                      "value": "true",
+                      "enabled": false,
+                      "editable": true,
+                      "optional": false,
+                      "advanced": false,
+                      "properties": {
+                        "secretToken": {
+                          "metadata": {
+                            "label": "Secret Token",
+                            "description": "The secret token to authenticate inbound updates against."
+                          },
+                          "value": "",
+                          "enabled": true,
+                          "editable": true,
+                          "optional": false,
+                          "advanced": false,
+                          "codedata": {
+                            "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
+                            "originalName": "secretToken",
+                            "path": "secretToken"
+                          },
+                          "types": [
+                            {
+                              "fieldType": "TEXT",
+                              "ballerinaType": "string",
+                              "selected": true
+                            },
+                            {
+                              "fieldType": "EXPRESSION",
+                              "ballerinaType": "string",
+                              "selected": false
+                            }
+                          ],
+                          "validations": [
+                            {
+                              "rule": "common.validate.required"
+                            }
+                          ]
+                        }
+                      }
                     }
-                  ],
-                  "placeholder": "<SECRET_TOKEN>"
-                },
-                "token": {
-                  "metadata": {
-                    "label": "Bot Token",
-                    "description": "Derive the secret token from this bot token via `deriveSecretToken` \u2014 the same derivation\n`Client->setWebhook` falls back to when its own `secret_token` option is omitted, so neither\nside needs a separately invented/threaded secret. Also required (alongside `publicUrl`) for\nthe listener to register its own webhook automatically when it starts."
-                  },
-                  "value": "",
-                  "enabled": true,
-                  "editable": true,
-                  "optional": true,
-                  "advanced": false,
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
-                    "originalName": "token",
-                    "path": "token"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "TEXT",
-                      "ballerinaType": "string",
-                      "selected": true
-                    },
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "string",
-                      "selected": false
-                    }
-                  ],
-                  "placeholder": "<BOT_TOKEN>"
-                },
-                "publicUrl": {
-                  "metadata": {
-                    "label": "Public URL",
-                    "description": "This listener's public HTTPS URL. When set together with `token`, starting the listener\nautomatically registers it as the webhook via `Client->setWebhook`, so no separate\n`setWebhook` call is needed."
-                  },
-                  "value": "",
-                  "enabled": true,
-                  "editable": true,
-                  "optional": true,
-                  "advanced": false,
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
-                    "originalName": "publicUrl",
-                    "path": "publicUrl"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "TEXT",
-                      "ballerinaType": "string",
-                      "selected": true
-                    },
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "string",
-                      "selected": false
-                    }
-                  ],
-                  "placeholder": "https://<PUBLIC_HOST>/"
-                },
-                "serviceUrl": {
-                  "metadata": {
-                    "label": "Service URL",
-                    "description": "The Telegram Bot API base URL used for the automatic `setWebhook` call when `publicUrl` is\nset. Only useful to override in tests or when routing through a proxy."
-                  },
-                  "value": "\"https://api.telegram.org\"",
-                  "enabled": true,
-                  "editable": true,
-                  "optional": true,
-                  "advanced": true,
-                  "codedata": {
-                    "argType": "LISTENER_PARAM_INCLUDED_DEFAULTABLE_FIELD",
-                    "originalName": "serviceUrl",
-                    "path": "serviceUrl"
-                  },
-                  "types": [
-                    {
-                      "fieldType": "TEXT",
-                      "ballerinaType": "string",
-                      "selected": true
-                    },
-                    {
-                      "fieldType": "EXPRESSION",
-                      "ballerinaType": "string",
-                      "selected": false
-                    }
-                  ],
-                  "placeholder": "https://api.telegram.org"
+                  ]
                 }
               }
             }
@@ -244,8 +314,8 @@
         },
         {
           "metadata": {
-            "label": "Use existing",
-            "description": "Select an existing Telegram listener"
+            "label": "Use Existing Listener",
+            "description": "Attach to a Telegram listener already declared in the project."
           },
           "types": [
             {
@@ -254,18 +324,18 @@
             }
           ],
           "enabled": false,
-          "editable": false,
+          "editable": true,
           "optional": false,
           "advanced": false,
           "properties": {
             "existingListener": {
               "metadata": {
                 "label": "Listener(s)",
-                "description": "Select one or more existing Telegram listeners to attach to"
+                "description": "Select one or more existing Telegram listeners to attach to."
               },
               "types": [
                 {
-                  "fieldType": "MULTI_SELECT_LISTENER",
+                  "fieldType": "MULTIPLE_SELECT_LISTENER",
                   "selected": true,
                   "ballerinaType": "telegram:Listener"
                 }
@@ -289,10 +359,10 @@
     {
       "metadata": {
         "label": "Telegram Service",
-        "description": "Handles Telegram Bot API webhook updates. Handler methods are recognised by convention, not declared on the type; declare only the ones you need."
+        "description": "The service object a consumer implements to handle Telegram webhook updates."
       },
       "name": "TelegramService",
-      "description": "The service object a consumer implements to handle Telegram webhook updates. Attach an\nimplementation to a `Listener` to receive updates.\n\n`TelegramService` declares no remote methods of its own \u2014 implement only the handlers you need;\nan unimplemented handler is simply not invoked. Declaring a remote function under any other\nname, with the wrong parameter type, or without the `remote` qualifier is a compile error (see\nthis connector's compiler plugin). There are nine supported handlers, one per supported update\ntype:\n\n- `remote function onMessage(Message message) returns error?;` \u2014 a new incoming message.\n- `remote function onEditedMessage(Message editedMessage) returns error?;` \u2014 a message the\nbot knows about was edited.\n- `remote function onChannelPost(Message channelPost) returns error?;` \u2014 a new channel post.\n- `remote function onEditedChannelPost(Message editedChannelPost) returns error?;` \u2014 a\nchannel post the bot knows about was edited.\n- `remote function onCallbackQuery(CallbackQuery callbackQuery) returns error?;` \u2014 an inline\nkeyboard button press.\n- `remote function onInlineQuery(InlineQuery inlineQuery) returns error?;` \u2014 a new inline query.\n- `remote function onPoll(Poll poll) returns error?;` \u2014 a poll's state changed.\n- `remote function onPreCheckoutQuery(PreCheckoutQuery preCheckoutQuery) returns error?;` \u2014 a new\npre-checkout query.\n- `remote function onShippingQuery(ShippingQuery shippingQuery) returns error?;` \u2014 a new shipping\nquery.\n\nAn update outside this set (e.g. `poll_answer`, `my_chat_member`, `chat_member`,\n`chat_join_request`, business-account events) is logged and dropped rather than delivered to a\nhandler.",
+      "description": "The service object a consumer implements to handle Telegram webhook updates.",
       "enabled": true,
       "editable": false,
       "codedata": {
@@ -306,7 +376,7 @@
         {
           "metadata": {
             "label": "On Message",
-            "description": "Invoked when a new incoming message is received."
+            "description": "A new incoming message."
           },
           "name": "onMessage",
           "nameEditable": false,
@@ -320,6 +390,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A new incoming message.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onMessage",
@@ -329,7 +400,7 @@
             {
               "metadata": {
                 "label": "Message",
-                "description": "Invoked when a new incoming message is received."
+                "description": "A new incoming message."
               },
               "kind": "REQUIRED",
               "type": {
@@ -353,7 +424,7 @@
               "name": {
                 "metadata": {
                   "label": "message",
-                  "description": "Invoked when a new incoming message is received."
+                  "description": "A new incoming message."
                 },
                 "placeholder": "message",
                 "value": "message",
@@ -385,11 +456,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -398,7 +469,7 @@
         {
           "metadata": {
             "label": "On Edited Message",
-            "description": "Invoked when a message the bot knows about was edited."
+            "description": "An edited message."
           },
           "name": "onEditedMessage",
           "nameEditable": false,
@@ -412,6 +483,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "An edited message.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onEditedMessage",
@@ -421,7 +493,7 @@
             {
               "metadata": {
                 "label": "Edited Message",
-                "description": "Invoked when a message the bot knows about was edited."
+                "description": "An edited message."
               },
               "kind": "REQUIRED",
               "type": {
@@ -445,7 +517,7 @@
               "name": {
                 "metadata": {
                   "label": "editedMessage",
-                  "description": "Invoked when a message the bot knows about was edited."
+                  "description": "An edited message."
                 },
                 "placeholder": "editedMessage",
                 "value": "editedMessage",
@@ -477,11 +549,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -490,7 +562,7 @@
         {
           "metadata": {
             "label": "On Channel Post",
-            "description": "Invoked when a new channel post is received."
+            "description": "A new channel post."
           },
           "name": "onChannelPost",
           "nameEditable": false,
@@ -504,6 +576,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A new channel post.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onChannelPost",
@@ -513,7 +586,7 @@
             {
               "metadata": {
                 "label": "Channel Post",
-                "description": "Invoked when a new channel post is received."
+                "description": "A new channel post."
               },
               "kind": "REQUIRED",
               "type": {
@@ -537,7 +610,7 @@
               "name": {
                 "metadata": {
                   "label": "channelPost",
-                  "description": "Invoked when a new channel post is received."
+                  "description": "A new channel post."
                 },
                 "placeholder": "channelPost",
                 "value": "channelPost",
@@ -569,11 +642,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -582,7 +655,7 @@
         {
           "metadata": {
             "label": "On Edited Channel Post",
-            "description": "Invoked when a channel post the bot knows about was edited."
+            "description": "An edited channel post."
           },
           "name": "onEditedChannelPost",
           "nameEditable": false,
@@ -596,6 +669,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "An edited channel post.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onEditedChannelPost",
@@ -605,7 +679,7 @@
             {
               "metadata": {
                 "label": "Edited Channel Post",
-                "description": "Invoked when a channel post the bot knows about was edited."
+                "description": "An edited channel post."
               },
               "kind": "REQUIRED",
               "type": {
@@ -629,7 +703,7 @@
               "name": {
                 "metadata": {
                   "label": "editedChannelPost",
-                  "description": "Invoked when a channel post the bot knows about was edited."
+                  "description": "An edited channel post."
                 },
                 "placeholder": "editedChannelPost",
                 "value": "editedChannelPost",
@@ -661,11 +735,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -674,7 +748,7 @@
         {
           "metadata": {
             "label": "On Callback Query",
-            "description": "Invoked when an inline keyboard button is pressed."
+            "description": "An inline keyboard button press."
           },
           "name": "onCallbackQuery",
           "nameEditable": false,
@@ -688,6 +762,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "An inline keyboard button press.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onCallbackQuery",
@@ -697,7 +772,7 @@
             {
               "metadata": {
                 "label": "Callback Query",
-                "description": "Invoked when an inline keyboard button is pressed."
+                "description": "An incoming callback query from an inline keyboard button press."
               },
               "kind": "REQUIRED",
               "type": {
@@ -721,7 +796,7 @@
               "name": {
                 "metadata": {
                   "label": "callbackQuery",
-                  "description": "Invoked when an inline keyboard button is pressed."
+                  "description": "An incoming callback query from an inline keyboard button press."
                 },
                 "placeholder": "callbackQuery",
                 "value": "callbackQuery",
@@ -753,11 +828,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -766,7 +841,7 @@
         {
           "metadata": {
             "label": "On Inline Query",
-            "description": "Invoked when a new inline query is received."
+            "description": "A new inline query."
           },
           "name": "onInlineQuery",
           "nameEditable": false,
@@ -780,6 +855,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A new inline query.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onInlineQuery",
@@ -789,7 +865,7 @@
             {
               "metadata": {
                 "label": "Inline Query",
-                "description": "Invoked when a new inline query is received."
+                "description": "An incoming inline query."
               },
               "kind": "REQUIRED",
               "type": {
@@ -813,7 +889,7 @@
               "name": {
                 "metadata": {
                   "label": "inlineQuery",
-                  "description": "Invoked when a new inline query is received."
+                  "description": "An incoming inline query."
                 },
                 "placeholder": "inlineQuery",
                 "value": "inlineQuery",
@@ -845,11 +921,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -858,7 +934,7 @@
         {
           "metadata": {
             "label": "On Poll",
-            "description": "Invoked when a poll's state changes."
+            "description": "A poll's state changed."
           },
           "name": "onPoll",
           "nameEditable": false,
@@ -872,6 +948,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A poll's state changed.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onPoll",
@@ -881,7 +958,7 @@
             {
               "metadata": {
                 "label": "Poll",
-                "description": "Invoked when a poll's state changes."
+                "description": "A native poll."
               },
               "kind": "REQUIRED",
               "type": {
@@ -905,7 +982,7 @@
               "name": {
                 "metadata": {
                   "label": "poll",
-                  "description": "Invoked when a poll's state changes."
+                  "description": "A native poll."
                 },
                 "placeholder": "poll",
                 "value": "poll",
@@ -937,11 +1014,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -949,8 +1026,8 @@
         },
         {
           "metadata": {
-            "label": "On Pre Checkout Query",
-            "description": "Invoked when a new pre-checkout query is received."
+            "label": "On Pre-Checkout Query",
+            "description": "A pre-checkout query."
           },
           "name": "onPreCheckoutQuery",
           "nameEditable": false,
@@ -964,6 +1041,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A pre-checkout query.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onPreCheckoutQuery",
@@ -973,7 +1051,7 @@
             {
               "metadata": {
                 "label": "Pre-Checkout Query",
-                "description": "Invoked when a new pre-checkout query is received."
+                "description": "An incoming pre-checkout query."
               },
               "kind": "REQUIRED",
               "type": {
@@ -997,7 +1075,7 @@
               "name": {
                 "metadata": {
                   "label": "preCheckoutQuery",
-                  "description": "Invoked when a new pre-checkout query is received."
+                  "description": "An incoming pre-checkout query."
                 },
                 "placeholder": "preCheckoutQuery",
                 "value": "preCheckoutQuery",
@@ -1029,11 +1107,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1042,7 +1120,7 @@
         {
           "metadata": {
             "label": "On Shipping Query",
-            "description": "Invoked when a new shipping query is received."
+            "description": "A shipping query."
           },
           "name": "onShippingQuery",
           "nameEditable": false,
@@ -1056,6 +1134,7 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A shipping query.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onShippingQuery",
@@ -1065,7 +1144,7 @@
             {
               "metadata": {
                 "label": "Shipping Query",
-                "description": "Invoked when a new shipping query is received."
+                "description": "An incoming shipping query."
               },
               "kind": "REQUIRED",
               "type": {
@@ -1089,7 +1168,7 @@
               "name": {
                 "metadata": {
                   "label": "shippingQuery",
-                  "description": "Invoked when a new shipping query is received."
+                  "description": "An incoming shipping query."
                 },
                 "placeholder": "shippingQuery",
                 "value": "shippingQuery",
@@ -1121,11 +1200,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1133,9 +1212,5 @@
         }
       ]
     }
-  ],
-  "importStatements": [
-    "ballerina/http"
-  ],
-  "listenerKind": "MULTIPLE_SELECT_LISTENER"
+  ]
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/whatsapp.business.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger-models/whatsapp.business.json
@@ -2,19 +2,21 @@
   "schemaVersion": "1.0",
   "id": "whatsapp.business",
   "displayName": "WhatsApp Business",
-  "description": "Create a service to handle WhatsApp Business Cloud webhook events (messages, template and account updates, and more)",
+  "description": "Create a service to handle WhatsApp Business Cloud webhook events",
   "orgName": "ballerinax",
   "packageName": "whatsapp.business",
   "moduleName": "whatsapp.business",
-  "version": "2.0.1",
-  "type": "business",
-  "icon": "icon.png",
+  "version": "2.0.2",
+  "type": "whatsapp",
+  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_whatsapp.business_2.0.2.png",
   "kind": "event",
+  "listenerKind": "MULTIPLE_SELECT_LISTENER",
+  "importPrefix": "whatsapp",
   "initProperties": {
     "listener": {
       "metadata": {
-        "label": "Configure WhatsApp Business Listener",
-        "description": "Select an existing WhatsApp Business listener or create a new one"
+        "label": "Listener",
+        "description": "Attach the service to a new or existing WhatsApp webhook listener."
       },
       "types": [
         {
@@ -33,8 +35,8 @@
       "choices": [
         {
           "metadata": {
-            "label": "Create new",
-            "description": "Create a new WhatsApp Business listener"
+            "label": "Create New Listener",
+            "description": "Define a new WhatsApp webhook listener in the project."
           },
           "types": [
             {
@@ -50,7 +52,7 @@
             "listenerConfig": {
               "metadata": {
                 "label": "Listener Configurations",
-                "description": "Configure the WhatsApp Business webhook listener"
+                "description": "Configure the WhatsApp webhook listener."
               },
               "types": [
                 {
@@ -72,10 +74,10 @@
                     {
                       "fieldType": "IDENTIFIER",
                       "selected": true,
-                      "ballerinaType": "business:Listener"
+                      "ballerinaType": "whatsapp.business:Listener"
                     }
                   ],
-                  "value": "businessListener",
+                  "value": "whatsappListener",
                   "enabled": true,
                   "editable": true,
                   "optional": false,
@@ -96,9 +98,10 @@
                 "listenTo": {
                   "metadata": {
                     "label": "Port",
-                    "description": "A port number to bind a new HTTP listener to, or an existing `http:Listener` to reuse"
+                    "description": "A port number to bind a new `http:Listener` to, or an existing `http:Listener`"
                   },
-                  "value": "",
+                  "placeholder": "8090",
+                  "value": "8090",
                   "enabled": true,
                   "editable": true,
                   "optional": false,
@@ -111,7 +114,7 @@
                   "types": [
                     {
                       "fieldType": "NUMBER",
-                      "ballerinaType": "int|http:Listener",
+                      "ballerinaType": "int",
                       "selected": true
                     },
                     {
@@ -120,12 +123,16 @@
                       "selected": false
                     }
                   ],
-                  "placeholder": "8090"
+                  "validations": [
+                    {
+                      "rule": "common.validate.required"
+                    }
+                  ]
                 },
                 "verifyToken": {
                   "metadata": {
                     "label": "Verify Token",
-                    "description": "The verification token configured in the Meta App dashboard. Matched against\n`hub.verify_token` during the webhook subscription handshake before the `hub.challenge` is\nechoed back."
+                    "description": "The verification token configured in the Meta App dashboard."
                   },
                   "value": "",
                   "enabled": true,
@@ -148,12 +155,17 @@
                       "ballerinaType": "string",
                       "selected": false
                     }
+                  ],
+                  "validations": [
+                    {
+                      "rule": "common.validate.required"
+                    }
                   ]
                 },
                 "appSecret": {
                   "metadata": {
                     "label": "App Secret",
-                    "description": "The Meta app secret. Every inbound notification is authenticated by validating the\n`X-Hub-Signature-256` header against the raw request body (HMAC-SHA256)."
+                    "description": "The Meta app secret, used to verify inbound webhook notifications."
                   },
                   "value": "",
                   "enabled": true,
@@ -176,6 +188,11 @@
                       "ballerinaType": "string",
                       "selected": false
                     }
+                  ],
+                  "validations": [
+                    {
+                      "rule": "common.validate.required"
+                    }
                   ]
                 }
               }
@@ -184,8 +201,8 @@
         },
         {
           "metadata": {
-            "label": "Use existing",
-            "description": "Select an existing WhatsApp Business listener"
+            "label": "Use Existing Listener",
+            "description": "Attach to one or more WhatsApp listeners already declared in the project."
           },
           "types": [
             {
@@ -194,20 +211,20 @@
             }
           ],
           "enabled": false,
-          "editable": false,
+          "editable": true,
           "optional": false,
           "advanced": false,
           "properties": {
             "existingListener": {
               "metadata": {
                 "label": "Listener(s)",
-                "description": "Select one or more existing WhatsApp Business listeners to attach to"
+                "description": "Select one or more existing WhatsApp listeners to attach to."
               },
               "types": [
                 {
-                  "fieldType": "MULTI_SELECT_LISTENER",
+                  "fieldType": "MULTIPLE_SELECT_LISTENER",
                   "selected": true,
-                  "ballerinaType": "business:Listener"
+                  "ballerinaType": "whatsapp.business:Listener"
                 }
               ],
               "items": [],
@@ -229,15 +246,15 @@
     {
       "metadata": {
         "label": "WhatsApp Service",
-        "description": "Handles WhatsApp Business Cloud webhook events. Handler methods are recognised by convention, not declared on the type; declare only the ones you need."
+        "description": "The service type a consumer implements to handle WhatsApp Business Cloud webhook events."
       },
       "name": "WhatsAppService",
-      "description": "The service type a consumer implements to handle WhatsApp Business Cloud webhook events. Attach\nan implementation to a `Listener` to receive notifications.\n\nThere are ten possible handlers, one per webhook field the WhatsApp Business Cloud webhook\nsubscription can select. Unlike most Ballerina service types, none of them are required \u2014\ndeclare only the ones you care about; a field whose handler you did not declare (or a field\noutside this closed set, e.g. `account_alerts`, `group_lifecycle_update`) is logged and dropped\nrather than delivered anywhere.\n\nAn eleventh, optional handler, `onError`, does not correspond to a webhook field. It is invoked\nwhenever one of the ten handlers above returns an `error` while being dispatched \u2014 the\nnotification has already been acknowledged to Meta by that point, so this is the only way to\nreact to a handler failure other than logging (which always happens regardless of whether\n`onError` is declared).\n\nA compiler plugin validates every remote function you do declare on a `WhatsAppService`: its\nname must be one of the eleven below, its parameter must match the documented event type, and it\nmust return `error?`. Anything else is a compile-time error.\n\n- `remote function onMessages(MessagesNotification notification) returns error?` \u2014 Invoked once\nper `messages` webhook notification: either a batch of inbound messages or a batch of status\nupdates. Meta always sends these as two mutually exclusive shapes under this one field, never\nboth together; narrow with `notification is Messages` / `notification is MessageStatuses`.\n- `remote function onAccountReviewUpdate(AccountReviewUpdate update) returns error?` \u2014\nInvoked when a WhatsApp Business Account's review decision changes.\n- `remote function onAccountUpdate(AccountUpdate update) returns error?` \u2014 Invoked on\naccount-lifecycle and compliance changes (verification, violations, partner changes,\npricing-tier updates, restrictions, disconnection).\n- `remote function onBusinessCapabilityUpdate(BusinessCapabilityUpdate update) returns error?`\n\u2014 Invoked when a WABA's messaging or phone-number capability limits change.\n- `remote function onMessageTemplateQualityUpdate(MessageTemplateQualityUpdate update) returns error?`\n\u2014 Invoked when a message template's quality score changes.\n- `remote function onMessageTemplateStatusUpdate(MessageTemplateStatusUpdate update) returns error?`\n\u2014 Invoked when a message template's status changes (approved, rejected, disabled, ...).\n- `remote function onPhoneNumberNameUpdate(PhoneNumberNameUpdate update) returns error?` \u2014\nInvoked when a business phone number's display-name review outcome is available.\n- `remote function onPhoneNumberQualityUpdate(PhoneNumberQualityUpdate update) returns error?`\n\u2014 Invoked when a business phone number's messaging throughput/quality tier changes.\n- `remote function onSecurity(Security security) returns error?` \u2014 Invoked on\ntwo-step-verification PIN changes and reset requests for a business phone number.\n- `remote function onTemplateCategoryUpdate(TemplateCategoryUpdate update) returns error?` \u2014\nInvoked when a message template's category changes, or is about to change.\n- `remote function onError(HandlerError handlerError) returns error?` \u2014 Invoked when any of the\nhandlers above returns an error while being dispatched for an incoming notification.",
+      "description": "The service type a consumer implements to handle WhatsApp Business Cloud webhook events.",
       "enabled": true,
       "editable": false,
       "codedata": {
         "type": "SERVICE_TYPE_DESCRIPTOR",
-        "moduleName": "business",
+        "moduleName": "whatsapp",
         "originalName": "WhatsAppService"
       },
       "properties": {},
@@ -246,7 +263,7 @@
         {
           "metadata": {
             "label": "On Messages",
-            "description": "Invoked once per `messages` webhook notification carrying either a batch of inbound messages or a batch of delivery/read status updates. Narrow with `notification is business:Messages` / `notification is business:MessageStatuses`."
+            "description": "Inbound messages or status updates; see MessagesNotification for narrowing."
           },
           "name": "onMessages",
           "nameEditable": false,
@@ -260,16 +277,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "Inbound messages or status updates; see MessagesNotification for narrowing.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onMessages",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
                 "label": "Notification",
-                "description": "Invoked once per `messages` webhook notification carrying either a batch of inbound messages or a batch of delivery/read status updates. Narrow with `notification is business:Messages` / `notification is business:MessageStatuses`."
+                "description": "A `messages` webhook notification: inbound messages or status updates."
               },
               "kind": "REQUIRED",
               "type": {
@@ -277,8 +295,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:MessagesNotification",
-                "value": "business:MessagesNotification",
+                "placeholder": "whatsapp:MessagesNotification",
+                "value": "whatsapp:MessagesNotification",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -293,7 +311,7 @@
               "name": {
                 "metadata": {
                   "label": "notification",
-                  "description": "Invoked once per `messages` webhook notification carrying either a batch of inbound messages or a batch of delivery/read status updates. Narrow with `notification is business:Messages` / `notification is business:MessageStatuses`."
+                  "description": "A `messages` webhook notification: inbound messages or status updates."
                 },
                 "placeholder": "notification",
                 "value": "notification",
@@ -325,11 +343,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -338,7 +356,7 @@
         {
           "metadata": {
             "label": "On Account Review Update",
-            "description": "Invoked when a WhatsApp Business Account's review decision changes."
+            "description": "A WABA review decision changes."
           },
           "name": "onAccountReviewUpdate",
           "nameEditable": false,
@@ -352,16 +370,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A WABA review decision changes.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onAccountReviewUpdate",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Review Update",
-                "description": "Invoked when a WhatsApp Business Account's review decision changes."
+                "label": "Update",
+                "description": "A WhatsApp Business Account (WABA) review decision."
               },
               "kind": "REQUIRED",
               "type": {
@@ -369,8 +388,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:AccountReviewUpdate",
-                "value": "business:AccountReviewUpdate",
+                "placeholder": "whatsapp:AccountReviewUpdate",
+                "value": "whatsapp:AccountReviewUpdate",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -385,7 +404,7 @@
               "name": {
                 "metadata": {
                   "label": "update",
-                  "description": "Invoked when a WhatsApp Business Account's review decision changes."
+                  "description": "A WhatsApp Business Account (WABA) review decision."
                 },
                 "placeholder": "update",
                 "value": "update",
@@ -417,11 +436,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -430,7 +449,7 @@
         {
           "metadata": {
             "label": "On Account Update",
-            "description": "Invoked on account-lifecycle and compliance changes: verification, violations, partner changes, pricing-tier updates, restrictions, or disconnection."
+            "description": "Account-lifecycle or compliance changes."
           },
           "name": "onAccountUpdate",
           "nameEditable": false,
@@ -444,16 +463,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "Account-lifecycle or compliance changes.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onAccountUpdate",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Account Update",
-                "description": "Invoked on account-lifecycle and compliance changes: verification, violations, partner changes, pricing-tier updates, restrictions, or disconnection."
+                "label": "Update",
+                "description": "A WABA account-lifecycle or compliance change."
               },
               "kind": "REQUIRED",
               "type": {
@@ -461,8 +481,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:AccountUpdate",
-                "value": "business:AccountUpdate",
+                "placeholder": "whatsapp:AccountUpdate",
+                "value": "whatsapp:AccountUpdate",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -477,7 +497,7 @@
               "name": {
                 "metadata": {
                   "label": "update",
-                  "description": "Invoked on account-lifecycle and compliance changes: verification, violations, partner changes, pricing-tier updates, restrictions, or disconnection."
+                  "description": "A WABA account-lifecycle or compliance change."
                 },
                 "placeholder": "update",
                 "value": "update",
@@ -509,11 +529,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -522,7 +542,7 @@
         {
           "metadata": {
             "label": "On Business Capability Update",
-            "description": "Invoked when a WhatsApp Business Account's messaging or phone-number capability limits change."
+            "description": "A WABA's messaging or phone-number capability limits change."
           },
           "name": "onBusinessCapabilityUpdate",
           "nameEditable": false,
@@ -536,16 +556,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A WABA's messaging or phone-number capability limits change.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onBusinessCapabilityUpdate",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Capability Update",
-                "description": "Invoked when a WhatsApp Business Account's messaging or phone-number capability limits change."
+                "label": "Update",
+                "description": "A WABA business-capability change."
               },
               "kind": "REQUIRED",
               "type": {
@@ -553,8 +574,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:BusinessCapabilityUpdate",
-                "value": "business:BusinessCapabilityUpdate",
+                "placeholder": "whatsapp:BusinessCapabilityUpdate",
+                "value": "whatsapp:BusinessCapabilityUpdate",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -569,7 +590,7 @@
               "name": {
                 "metadata": {
                   "label": "update",
-                  "description": "Invoked when a WhatsApp Business Account's messaging or phone-number capability limits change."
+                  "description": "A WABA business-capability change."
                 },
                 "placeholder": "update",
                 "value": "update",
@@ -601,11 +622,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -614,7 +635,7 @@
         {
           "metadata": {
             "label": "On Message Template Quality Update",
-            "description": "Invoked when a message template's quality score changes."
+            "description": "A message template's quality score changes."
           },
           "name": "onMessageTemplateQualityUpdate",
           "nameEditable": false,
@@ -628,16 +649,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A message template's quality score changes.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onMessageTemplateQualityUpdate",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Quality Update",
-                "description": "Invoked when a message template's quality score changes."
+                "label": "Update",
+                "description": "A message template quality-score change."
               },
               "kind": "REQUIRED",
               "type": {
@@ -645,8 +667,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:MessageTemplateQualityUpdate",
-                "value": "business:MessageTemplateQualityUpdate",
+                "placeholder": "whatsapp:MessageTemplateQualityUpdate",
+                "value": "whatsapp:MessageTemplateQualityUpdate",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -661,7 +683,7 @@
               "name": {
                 "metadata": {
                   "label": "update",
-                  "description": "Invoked when a message template's quality score changes."
+                  "description": "A message template quality-score change."
                 },
                 "placeholder": "update",
                 "value": "update",
@@ -693,11 +715,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -706,7 +728,7 @@
         {
           "metadata": {
             "label": "On Message Template Status Update",
-            "description": "Invoked when a message template's status changes (approved, rejected, disabled, archived, unarchived, ...)."
+            "description": "A message template's status changes."
           },
           "name": "onMessageTemplateStatusUpdate",
           "nameEditable": false,
@@ -720,16 +742,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A message template's status changes.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onMessageTemplateStatusUpdate",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Status Update",
-                "description": "Invoked when a message template's status changes (approved, rejected, disabled, archived, unarchived, ...)."
+                "label": "Update",
+                "description": "A message template status change."
               },
               "kind": "REQUIRED",
               "type": {
@@ -737,8 +760,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:MessageTemplateStatusUpdate",
-                "value": "business:MessageTemplateStatusUpdate",
+                "placeholder": "whatsapp:MessageTemplateStatusUpdate",
+                "value": "whatsapp:MessageTemplateStatusUpdate",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -753,7 +776,7 @@
               "name": {
                 "metadata": {
                   "label": "update",
-                  "description": "Invoked when a message template's status changes (approved, rejected, disabled, archived, unarchived, ...)."
+                  "description": "A message template status change."
                 },
                 "placeholder": "update",
                 "value": "update",
@@ -785,11 +808,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -798,7 +821,7 @@
         {
           "metadata": {
             "label": "On Phone Number Name Update",
-            "description": "Invoked when a business phone number's display-name review outcome is available."
+            "description": "A phone number's display-name review outcome is available."
           },
           "name": "onPhoneNumberNameUpdate",
           "nameEditable": false,
@@ -812,16 +835,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A phone number's display-name review outcome is available.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onPhoneNumberNameUpdate",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Name Update",
-                "description": "Invoked when a business phone number's display-name review outcome is available."
+                "label": "Update",
+                "description": "A business phone number display-name review outcome."
               },
               "kind": "REQUIRED",
               "type": {
@@ -829,8 +853,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:PhoneNumberNameUpdate",
-                "value": "business:PhoneNumberNameUpdate",
+                "placeholder": "whatsapp:PhoneNumberNameUpdate",
+                "value": "whatsapp:PhoneNumberNameUpdate",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -845,7 +869,7 @@
               "name": {
                 "metadata": {
                   "label": "update",
-                  "description": "Invoked when a business phone number's display-name review outcome is available."
+                  "description": "A business phone number display-name review outcome."
                 },
                 "placeholder": "update",
                 "value": "update",
@@ -877,11 +901,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -890,7 +914,7 @@
         {
           "metadata": {
             "label": "On Phone Number Quality Update",
-            "description": "Invoked when a business phone number's messaging throughput/quality tier changes."
+            "description": "A phone number's messaging throughput/quality tier changes."
           },
           "name": "onPhoneNumberQualityUpdate",
           "nameEditable": false,
@@ -904,16 +928,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A phone number's messaging throughput/quality tier changes.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onPhoneNumberQualityUpdate",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Quality Update",
-                "description": "Invoked when a business phone number's messaging throughput/quality tier changes."
+                "label": "Update",
+                "description": "A business phone number messaging throughput/quality-tier change."
               },
               "kind": "REQUIRED",
               "type": {
@@ -921,8 +946,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:PhoneNumberQualityUpdate",
-                "value": "business:PhoneNumberQualityUpdate",
+                "placeholder": "whatsapp:PhoneNumberQualityUpdate",
+                "value": "whatsapp:PhoneNumberQualityUpdate",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -937,7 +962,7 @@
               "name": {
                 "metadata": {
                   "label": "update",
-                  "description": "Invoked when a business phone number's messaging throughput/quality tier changes."
+                  "description": "A business phone number messaging throughput/quality-tier change."
                 },
                 "placeholder": "update",
                 "value": "update",
@@ -969,11 +994,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -982,7 +1007,7 @@
         {
           "metadata": {
             "label": "On Security",
-            "description": "Invoked on two-step-verification PIN changes and reset requests for a business phone number."
+            "description": "A two-step-verification PIN change or reset request for a phone number."
           },
           "name": "onSecurity",
           "nameEditable": false,
@@ -996,16 +1021,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A two-step-verification PIN change or reset request for a phone number.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onSecurity",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Security Event",
-                "description": "Invoked on two-step-verification PIN changes and reset requests for a business phone number."
+                "label": "Security",
+                "description": "A two-step-verification PIN change, reset request, or reset success."
               },
               "kind": "REQUIRED",
               "type": {
@@ -1013,8 +1039,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:Security",
-                "value": "business:Security",
+                "placeholder": "whatsapp:Security",
+                "value": "whatsapp:Security",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -1029,7 +1055,7 @@
               "name": {
                 "metadata": {
                   "label": "security",
-                  "description": "Invoked on two-step-verification PIN changes and reset requests for a business phone number."
+                  "description": "A two-step-verification PIN change, reset request, or reset success."
                 },
                 "placeholder": "security",
                 "value": "security",
@@ -1061,11 +1087,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1074,7 +1100,7 @@
         {
           "metadata": {
             "label": "On Template Category Update",
-            "description": "Invoked when a message template's category changes, or is about to change (24-hour advance notice)."
+            "description": "A message template's category changes, or is about to change."
           },
           "name": "onTemplateCategoryUpdate",
           "nameEditable": false,
@@ -1088,16 +1114,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "A message template's category changes, or is about to change.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onTemplateCategoryUpdate",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
-                "label": "Category Update",
-                "description": "Invoked when a message template's category changes, or is about to change (24-hour advance notice)."
+                "label": "Update",
+                "description": "A message template category change."
               },
               "kind": "REQUIRED",
               "type": {
@@ -1105,8 +1132,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:TemplateCategoryUpdate",
-                "value": "business:TemplateCategoryUpdate",
+                "placeholder": "whatsapp:TemplateCategoryUpdate",
+                "value": "whatsapp:TemplateCategoryUpdate",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -1121,7 +1148,7 @@
               "name": {
                 "metadata": {
                   "label": "update",
-                  "description": "Invoked when a message template's category changes, or is about to change (24-hour advance notice)."
+                  "description": "A message template category change."
                 },
                 "placeholder": "update",
                 "value": "update",
@@ -1153,11 +1180,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1166,7 +1193,7 @@
         {
           "metadata": {
             "label": "On Error",
-            "description": "Invoked when any of the other handlers returns an error while being dispatched for an incoming notification."
+            "description": "Any handler above returned an error while being dispatched."
           },
           "name": "onError",
           "nameEditable": false,
@@ -1180,16 +1207,17 @@
           "optional": true,
           "canAddParameters": false,
           "repeatable": "FALSE",
+          "documentation": "Any handler above returned an error while being dispatched.",
           "codedata": {
             "type": "FUNCTION",
             "originalName": "onError",
-            "moduleName": "business"
+            "moduleName": "whatsapp"
           },
           "parameters": [
             {
               "metadata": {
                 "label": "Handler Error",
-                "description": "Invoked when any of the other handlers returns an error while being dispatched for an incoming notification."
+                "description": "Reports an error returned by another `WhatsAppService` handler while it was being invoked."
               },
               "kind": "REQUIRED",
               "type": {
@@ -1197,8 +1225,8 @@
                   "label": "Parameter Type",
                   "description": "The type of the parameter"
                 },
-                "placeholder": "business:HandlerError",
-                "value": "business:HandlerError",
+                "placeholder": "whatsapp:HandlerError",
+                "value": "whatsapp:HandlerError",
                 "types": [
                   {
                     "fieldType": "TYPE",
@@ -1213,7 +1241,7 @@
               "name": {
                 "metadata": {
                   "label": "handlerError",
-                  "description": "Invoked when any of the other handlers returns an error while being dispatched for an incoming notification."
+                  "description": "Reports an error returned by another `WhatsAppService` handler while it was being invoked."
                 },
                 "placeholder": "handlerError",
                 "value": "handlerError",
@@ -1245,11 +1273,11 @@
             },
             "type": "error?",
             "typeEditable": false,
+            "typeConstraint": "error?",
             "enabled": true,
             "editable": false,
             "optional": true,
             "hasError": true,
-            "importStatements": "",
             "codedata": {
               "type": "FUNCTION_RETURN"
             }
@@ -1257,9 +1285,5 @@
         }
       ]
     }
-  ],
-  "importStatements": [
-    "ballerina/http"
-  ],
-  "listenerKind": "MULTIPLE_SELECT_LISTENER"
+  ]
 }

--- a/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
+++ b/packages/ballerina-language-server/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/trigger_properties.json
@@ -250,8 +250,8 @@
       "event"
     ],
     "triggerName": "WhatsApp Business",
-    "version": "2.0.1",
-    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_whatsapp.business_2.0.1.png",
+    "version": "2.0.2",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_whatsapp.business_2.0.2.png",
     "kind": "event"
   },
   "20": {
@@ -265,8 +265,8 @@
       "event"
     ],
     "triggerName": "Telegram",
-    "version": "0.9.1",
-    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_telegram_0.9.1.png",
+    "version": "0.9.2",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_telegram_0.9.2.png",
     "kind": "event"
   },
   "21": {


### PR DESCRIPTION
## Description
- Use Ballerina Central icon URLs instead of the local `icon.png` reference.
- Declare `listenerKind: MULTIPLE_SELECT_LISTENER` and rename the `MULTI_SELECT_LISTENER` field type to `MULTIPLE_SELECT_LISTENER`.
- Add `common.validate.required` validations to mandatory properties (auth, service config choices, endpoint URL, project number, etc.).
- Clean up labels/descriptions: short, consistent listener and handler wording; move the long handler reference out of the service description into per-function `documentation`.
- Fix `packageName` values (`chat` → `googleapis.chat`) and drop redundant duplicate type entries on handler parameters.
- Set `typeConstraint: "error?"` on handler returns and drop the empty `importStatements` and redundant `valueKind` entries.
- Bump `trigger_properties.json` to WhatsApp Business `2.0.2` and Telegram `0.9.2` with matching icon URLs.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.