### PR TITLE
Rework the Copilot entry point on the overview page

### DIFF
--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
@@ -136,9 +136,24 @@ async function addReturnNodeFromDiagram(locatorOwner: ReturnType<typeof switchTo
     await expect(locatorOwner.getByText('payload', { exact: true })).toBeVisible({ timeout: 30000 });
     await locatorOwner.getByText('payload', { exact: true }).click({ force: true });
     await expect.poll(async () => locatorOwner.locator('[data-testid="ex-editor-expression"] .cm-content').evaluate((element) => element.textContent)).toBe('payload');
-    await locatorOwner.locator('[data-testid="ex-editor-expression"] .cm-content').click({ force: true });
-    await page.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
-    await page.page.keyboard.type('{key: string `uploads/${name}`, size: payload.content.length()}');
+    // Dispatch directly into CM6 — typing this key-by-key risks bracket auto-close mangling it.
+    const expressionText = '{key: string `uploads/${name}`, size: payload.content.length()}';
+    const exEditorContainer = locatorOwner.locator('[data-testid="ex-editor-expression"]');
+    const dispatched = await exEditorContainer.evaluate((container, text) => {
+        const cmContent = container.querySelector('.cm-content');
+        const view = (cmContent as any)?.cmView?.view;
+        if (!view) {
+            return false;
+        }
+        view.focus();
+        view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+        return true;
+    }, expressionText);
+    if (!dispatched) {
+        const editorInput = exEditorContainer.locator('div[contenteditable="true"]');
+        await editorInput.click({ clickCount: 3 });
+        await editorInput.fill(expressionText);
+    }
     await locatorOwner.getByRole('button', { name: 'Close Helper Panel' }).click({ force: true }).catch(() => {});
     await locatorOwner.getByText('Return value.', { exact: true }).click({ force: true }).catch(() => {});
     await locatorOwner.getByRole('button', { name: 'Save' }).click({ force: true });

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/connections/connections.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/connections/connections.spec.ts
@@ -17,7 +17,7 @@
  */
 import { Frame, Locator, test } from '@playwright/test';
 import * as path from 'path';
-import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page, logStep, newProjectPath } from '../utils/helpers';
+import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page, logStep, newProjectPath, domClick } from '../utils/helpers';
 import { switchToIFrame, Form } from '@wso2/playwright-vscode-tester';
 import { ProjectExplorer, Diagram, SidePanel } from '../utils/pages';
 import { DEFAULT_PROJECT_NAME } from '../utils/helpers/constants';
@@ -326,10 +326,17 @@ export default function createTests() {
             artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page, 30000);
 
             await artifactWebView.getByRole('button', { name: /Add Artifact/i }).click({ force: true });
-            await artifactWebView.locator('[data-testid="function-card-Connection"], #connection').first().click({ force: true });
+            // The floating Copilot orb can dock exactly over this card/link, so a
+            // coordinate click (even with `force`) can silently land on the orb
+            // instead — same failure class `domClick` exists to avoid (see its doc).
+            const connectionCard = artifactWebView.locator('[data-testid="function-card-Connection"], #connection').first();
+            await connectionCard.waitFor({ state: 'visible', timeout: 30000 });
+            await domClick(connectionCard);
             await page.page.waitForTimeout(1500);
 
-            await artifactWebView.getByText('Connect via API Specification', { exact: false }).first().click({ force: true });
+            const apiSpecOption = artifactWebView.getByText('Connect via API Specification', { exact: false }).first();
+            await apiSpecOption.waitFor({ state: 'visible', timeout: 30000 });
+            await domClick(apiSpecOption);
             await page.page.waitForTimeout(1000);
 
             const connectorNameInput = artifactWebView.locator('#connector-name');

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/connections/connections.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/connections/connections.spec.ts
@@ -325,12 +325,12 @@ export default function createTests() {
             // diagram — no explicit "Open View" navigation is needed.
             artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page, 30000);
 
-            await artifactWebView.getByRole('button', { name: /Add Artifact/i }).click({ force: true });
-            // The floating Copilot orb can dock exactly over this card/link, so a
-            // coordinate click (even with `force`) can silently land on the orb
-            // instead — same failure class `domClick` exists to avoid (see its doc).
+            // The diagram can still be settling right after the previous test's save
+            // (same drag-tolerance trap as elsewhere in this file) — retry the click
+            // rather than assume it registered.
             const connectionCard = artifactWebView.locator('[data-testid="function-card-Connection"], #connection').first();
-            await connectionCard.waitFor({ state: 'visible', timeout: 30000 });
+            await clickUntil(artifactWebView.getByRole('button', { name: /Add Artifact/i }), connectionCard, 'Add Artifact button');
+            // domClick avoids the floating Copilot orb intercepting a coordinate click.
             await domClick(connectionCard);
             await page.page.waitForTimeout(1500);
 

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/expression-editor/expression-editor-advanced.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/expression-editor/expression-editor-advanced.spec.ts
@@ -659,18 +659,18 @@ export default function createTests() {
             const panel = frame.getByTestId('side-panel');
 
             await openNodePalette(frame);
-            await panel.getByText('AI', { exact: true }).first().click({ force: true });
+            await domClick(panel.getByText('AI', { exact: true }).first());
             await page.page.waitForTimeout(2000);
-            await panel.getByText('Agent', { exact: true }).last().click({ force: true });
+            await domClick(panel.getByText('Agent', { exact: true }).last());
             await page.page.waitForTimeout(2500);
-            await panel.getByText('Add Agent', { exact: false }).last().click({ force: true });
+            await domClick(panel.getByText('Add Agent', { exact: false }).last());
             await panel.getByText('AI Agent', { exact: true }).first().waitFor({ timeout: 30000 });
             logStep('AI Agent form open');
 
             // Expand Instructions (second Expand Editor) → markdown toolbar
             const expandBtns = panel.locator('[title="Expand Editor"]');
             await expandBtns.nth(1).waitFor({ state: 'visible', timeout: 15000 });
-            await expandBtns.nth(1).click({ force: true });
+            await domClick(expandBtns.nth(1));
             await page.page.waitForTimeout(2500);
             for (const tool of ['Bold', 'Italic', 'Bulleted List', 'Numbered List', 'Blockquote']) {
                 expect(await frame.locator(`[title="${tool}"]`).count(), `markdown toolbar missing ${tool}`).toBeGreaterThan(0);
@@ -681,14 +681,14 @@ export default function createTests() {
             await ed.click({ force: true });
             await page.page.keyboard.type('You are a helpful assistant', { delay: 20 });
             await page.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
-            await frame.locator('[title="Bold"]').last().click({ force: true });
+            await domClick(frame.locator('[title="Bold"]').last());
             await page.page.waitForTimeout(800);
             // Explicitly collapse the (still-active) "select all" selection before
             // splitting a new line — see collapseToEnd's comment for why a plain
             // 'End' keypress is not reliable here.
             await collapseToEnd(ed);
             await page.page.keyboard.press('Enter');
-            await frame.locator('[title="Bulleted List"]').last().click({ force: true });
+            await domClick(frame.locator('[title="Bulleted List"]').last());
             await page.page.waitForTimeout(500);
             await page.page.keyboard.type('Answer briefly', { delay: 20 });
             await page.page.waitForTimeout(800);
@@ -697,7 +697,7 @@ export default function createTests() {
             expect(html).toContain('<li>');
             logStep('Bold + bulleted list applied in the rich prompt editor');
 
-            await frame.locator('[title="Minimize Editor"], [title="Minimize"]').last().click({ force: true });
+            await domClick(frame.locator('[title="Minimize Editor"], [title="Minimize"]').last());
             await page.page.waitForTimeout(1500);
 
             // Fill required Query: insert the "greeting" (int) variable via
@@ -709,10 +709,10 @@ export default function createTests() {
             await queryEd.click({ force: true });
             await page.page.waitForTimeout(1000);
             await frame.getByText('Variables', { exact: true }).last().waitFor({ timeout: 10000 });
-            await frame.getByText('Variables', { exact: true }).last().click({ force: true });
+            await domClick(frame.getByText('Variables', { exact: true }).last());
             const greetingOption = frame.getByText(greetingName, { exact: true }).last();
             await greetingOption.waitFor({ state: 'visible', timeout: 15000 });
-            await greetingOption.click({ force: true });
+            await domClick(greetingOption);
             await page.page.waitForTimeout(1500);
 
             const varChip = queryEd.locator('span[contenteditable="false"]', { hasText: greetingName }).first();
@@ -723,7 +723,7 @@ export default function createTests() {
 
             const save = panel.getByRole('button', { name: 'Save' }).last();
             await expect(save).toBeEnabled({ timeout: 15000 });
-            await save.click({ force: true });
+            await domClick(save);
             logStep('Agent node saved');
 
             const agents = await pollGenerated('agents.bal', '**You are a helpful assistant**');

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/tryit/http-try-it-existing.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/tryit/http-try-it-existing.spec.ts
@@ -19,7 +19,7 @@ import { expect, test } from '@playwright/test';
 import * as path from 'path';
 import * as os from 'os';
 import fs from 'fs';
-import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, logStep, newProjectPath, page, toggleNotifications } from '../utils/helpers';
+import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, domClick, initTest, logStep, newProjectPath, page, toggleNotifications } from '../utils/helpers';
 import { switchToIFrame } from '@wso2/playwright-vscode-tester';
 
 type WebView = NonNullable<Awaited<ReturnType<typeof switchToIFrame>>>;
@@ -275,11 +275,13 @@ export default function createTests() {
             const webview = await getWebView();
 
             logStep('Navigate to the secure resource\'s flow diagram');
-            await webview.getByText('HTTP Service - /', { exact: false }).first().click({ force: true });
+            const serviceNodeLink = webview.getByText('HTTP Service - /', { exact: false }).first();
+            await serviceNodeLink.waitFor({ state: 'visible', timeout: 30000 });
+            await domClick(serviceNodeLink);
             await page.page.waitForTimeout(1000);
             const secureRow = webview.getByText('secure', { exact: false }).first();
             await secureRow.waitFor({ timeout: 15000 });
-            await secureRow.click({ force: true });
+            await domClick(secureRow);
             await page.page.waitForTimeout(1500);
 
             const hurlPath = path.join(newProjectPath, 'target', 'TryIt.hurl');
@@ -288,7 +290,7 @@ export default function createTests() {
             logStep('Click the resource\'s own Try It button');
             const tryResourceBtn = webview.locator('vscode-button[title="Try Resource"]').first();
             await tryResourceBtn.waitFor({ timeout: 15000 });
-            await tryResourceBtn.click({ force: true });
+            await domClick(tryResourceBtn);
             await page.page.waitForTimeout(1500);
 
             const hurlOption = page.page.getByRole('option', { name: /Try It.*Hurl Client/ }).first();

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
@@ -17,6 +17,7 @@
  */
 
 import { Frame, Locator, Page } from "@playwright/test";
+import { domClick } from "../helpers";
 
 export class SidePanel {
     private sidePanel!: Locator;
@@ -49,9 +50,9 @@ export class SidePanel {
             }
         }
         await nodeContainer.waitFor({ state: 'visible', timeout: 30000 });
-        // `force` — the floating Copilot orb/invite box has been observed to
+        // domClick — the floating Copilot orb/invite box has been observed to
         // overlap and intercept pointer events on nodes in this panel.
-        await nodeContainer.click({ force: true });
+        await domClick(nodeContainer);
     }
 
     /**
@@ -63,9 +64,9 @@ export class SidePanel {
         try {
             await sectionContainer.click({ timeout: 5000 });
         } catch {
-            // Fall back to force click if a VS Code overlay (e.g. notification popup)
-            // is blocking the element — this can occur on macOS but not on Linux CI.
-            await sectionContainer.click({ force: true });
+            // Fall back to domClick if a VS Code overlay (e.g. notification popup,
+            // the Copilot orb) is blocking the element.
+            await domClick(sectionContainer);
         }
     }
 }

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.test.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from "react";
+import { act } from "react-dom/test-utils";
+import { createRoot, Root } from "react-dom/client";
+import type { AgentRunStatus } from "@wso2/ballerina-core";
+
+// @wso2/ballerina-core's barrel export (lib/index.js) re-exports WSConnection,
+// which requires vscode-ws-jsonrpc — an ESM-only package jest cannot load
+// without extra transform config. shared.ts only needs MACHINE_VIEW's keys to
+// exist (as property-access targets), not any real value.
+jest.mock("@wso2/ballerina-core", () => ({ MACHINE_VIEW: {} }));
+
+import { useAgentRunState, __resetAgentRunStatusStoreForTests } from "./shared";
+
+// react-dom/test-utils' act() requires this flag; @testing-library/react sets
+// it automatically, but nothing does here since this package doesn't depend on it.
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let mockRpcClient: any;
+
+jest.mock("@wso2/ballerina-rpc-client", () => ({
+    useRpcContext: () => ({ rpcClient: mockRpcClient }),
+}));
+
+function makeStatus(overrides: Partial<AgentRunStatus> = {}): AgentRunStatus {
+    return { state: "running", aiPanelOpen: false, timestamp: 0, ...overrides };
+}
+
+/** A mock rpcClient plus a `notify` helper standing in for the extension host pushing a live update. */
+function makeRpcClient() {
+    let pushed: ((status: AgentRunStatus) => void) | undefined;
+    const client = {
+        getCommonRpcClient: () => ({
+            getAgentRunStatus: jest.fn().mockResolvedValue(undefined),
+        }),
+        onAgentRunStatusChanged: jest.fn((cb: (status: AgentRunStatus) => void) => {
+            pushed = cb;
+        }),
+    };
+    return {
+        client,
+        notify: (status: AgentRunStatus) => {
+            if (!pushed) {
+                throw new Error("onAgentRunStatusChanged callback was never registered");
+            }
+            act(() => pushed!(status));
+        },
+    };
+}
+
+describe("useAgentRunState", () => {
+    const containers: HTMLDivElement[] = [];
+    const roots: Root[] = [];
+
+    function mount(onRender: (state: string | undefined) => void): void {
+        function Harness(): null {
+            onRender(useAgentRunState());
+            return null;
+        }
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        containers.push(container);
+        roots.push(root);
+        act(() => root.render(React.createElement(Harness)));
+    }
+
+    beforeEach(() => {
+        __resetAgentRunStatusStoreForTests();
+        mockRpcClient = undefined;
+    });
+
+    afterEach(() => {
+        roots.forEach((root) => act(() => root.unmount()));
+        containers.forEach((container) => container.remove());
+        roots.length = 0;
+        containers.length = 0;
+    });
+
+    it("returns undefined and never subscribes when rpcClient is absent", () => {
+        mockRpcClient = null;
+        const onRender = jest.fn();
+
+        mount(onRender);
+
+        expect(onRender).toHaveBeenCalledWith(undefined);
+    });
+
+    it("updates when a live AgentRunStatus is pushed through onAgentRunStatusChanged", () => {
+        const { client, notify } = makeRpcClient();
+        mockRpcClient = client;
+        const onRender = jest.fn();
+        mount(onRender);
+
+        notify(makeStatus({ state: "awaiting-input" }));
+
+        expect(onRender).toHaveBeenLastCalledWith("awaiting-input");
+    });
+
+    it("initializes a subscriber mounted after the cache is warm from the cached status", () => {
+        const { client, notify } = makeRpcClient();
+        mockRpcClient = client;
+        mount(jest.fn());
+        notify(makeStatus({ state: "running" }));
+
+        const onRenderSecond = jest.fn();
+        mount(onRenderSecond);
+
+        // The very first render (before this subscriber's own effect fires)
+        // must already reflect the cache — proving the lazy useState
+        // initializer, not just the live subscription, picks it up.
+        expect(onRenderSecond.mock.calls[0][0]).toBe("running");
+    });
+
+    it("stops receiving updates once unmounted", () => {
+        const { client, notify } = makeRpcClient();
+        mockRpcClient = client;
+        const onRender = jest.fn();
+        mount(onRender);
+        notify(makeStatus({ state: "running" }));
+
+        const callsBeforeUnmount = onRender.mock.calls.length;
+        act(() => roots[0].unmount());
+        notify(makeStatus({ state: "error" }));
+
+        expect(onRender.mock.calls.length).toBe(callsBeforeUnmount);
+    });
+});

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -303,6 +303,27 @@ export function useAiPanelOpen(): boolean {
     return open;
 }
 
+/**
+ * True while a Copilot turn is in flight — it says nothing about what the turn
+ * will produce, since the prompt may not be asking for artifacts at all.
+ * `awaiting-input` counts: the turn has not settled yet.
+ */
+export function useAgentWorking(): boolean {
+    const { rpcClient } = useRpcContext();
+    const isWorking = (status: AgentRunStatus | null) =>
+        status?.state === "running" || status?.state === "awaiting-input";
+    const [working, setWorking] = useState(() => isWorking(currentStatus));
+
+    useEffect(() => {
+        if (!rpcClient) {
+            return;
+        }
+        return subscribeAgentRunStatus(rpcClient, (status) => setWorking(isWorking(status)));
+    }, [rpcClient]);
+
+    return working;
+}
+
 // ---------------------------------------------------------------------------
 // Contextual mini-chat launch requests.
 //

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -45,9 +45,10 @@ export function loadAnchor(): Anchor {
     } catch {
         stored = null;
     }
-    // Default to bottom-center so the copilot invitation is front and center
-    // when BI opens; users can drag the orb to any of the six anchors.
-    return stored && (ANCHORS as readonly string[]).includes(stored) ? (stored as Anchor) : "bottom-center";
+    // bottom-center sits on top of whatever the active view docks at its own
+    // bottom-center (form submit buttons, artifact-picker cards, …), so default
+    // to bottom-right instead; users can still drag the orb to any anchor.
+    return stored && (ANCHORS as readonly string[]).includes(stored) ? (stored as Anchor) : "bottom-right";
 }
 
 export const ORB_COLORS: Record<AgentRunState, [string, string, string]> = {

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -286,6 +286,14 @@ export function subscribeAgentRunStatus(
     };
 }
 
+/** Test-only: clears the module-level status cache and listeners between test cases. */
+export function __resetAgentRunStatusStoreForTests(): void {
+    currentStatus = null;
+    statusWired = false;
+    receivedStatusNotification = false;
+    statusListeners.clear();
+}
+
 /**
  * True while the Copilot panel is open — inline copilot surfaces stand down so
  * the panel is the only chat entry point. Seeded from the cached status so a

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -303,21 +303,19 @@ export function useAiPanelOpen(): boolean {
     return open;
 }
 
-/** True while a turn is in flight — says nothing about what it will produce. */
-export function useAgentWorking(): boolean {
+/** The live run status, for views that need the state and its label, not just a flag. */
+export function useAgentRunStatus(): AgentRunStatus | null {
     const { rpcClient } = useRpcContext();
-    const isWorking = (status: AgentRunStatus | null) =>
-        status?.state === "running" || status?.state === "awaiting-input";
-    const [working, setWorking] = useState(() => isWorking(currentStatus));
+    const [status, setStatus] = useState(() => currentStatus);
 
     useEffect(() => {
         if (!rpcClient) {
             return;
         }
-        return subscribeAgentRunStatus(rpcClient, (status) => setWorking(isWorking(status)));
+        return subscribeAgentRunStatus(rpcClient, setStatus);
     }, [rpcClient]);
 
-    return working;
+    return status;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -132,6 +132,8 @@ export const AmbientFrame = styled.div<AmbientFrameProps>`
 `;
 
 /** User-facing label for a non-idle run state, shared by the orb and the hero box. */
+export const AWAITING_INPUT_LABEL = "Copilot needs your input";
+
 export function activeStateLabel(status: AgentRunStatus): string {
     switch (status.state) {
         case "completed":
@@ -139,7 +141,7 @@ export function activeStateLabel(status: AgentRunStatus): string {
         case "running":
             return status.label ?? "Working on it…";
         case "awaiting-input":
-            return status.label ?? "Copilot needs your input";
+            return status.label ?? AWAITING_INPUT_LABEL;
         case "error":
             return status.label ?? "Copilot hit an error";
         default:

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -303,19 +303,19 @@ export function useAiPanelOpen(): boolean {
     return open;
 }
 
-/** The live run status, for views that need the state and its label, not just a flag. */
-export function useAgentRunStatus(): AgentRunStatus | null {
+/** The live run state — says nothing about what the turn will produce. */
+export function useAgentRunState(): AgentRunState | undefined {
     const { rpcClient } = useRpcContext();
-    const [status, setStatus] = useState(() => currentStatus);
+    const [state, setState] = useState(() => currentStatus?.state);
 
     useEffect(() => {
         if (!rpcClient) {
             return;
         }
-        return subscribeAgentRunStatus(rpcClient, setStatus);
+        return subscribeAgentRunStatus(rpcClient, (status) => setState(status?.state));
     }, [rpcClient]);
 
-    return status;
+    return state;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
+++ b/packages/ballerina-visualizer/src/components/AgentStatusOrb/shared.ts
@@ -303,11 +303,7 @@ export function useAiPanelOpen(): boolean {
     return open;
 }
 
-/**
- * True while a Copilot turn is in flight — it says nothing about what the turn
- * will produce, since the prompt may not be asking for artifacts at all.
- * `awaiting-input` counts: the turn has not settled yet.
- */
+/** True while a turn is in flight — says nothing about what it will produce. */
 export function useAgentWorking(): boolean {
     const { rpcClient } = useRpcContext();
     const isWorking = (status: AgentRunStatus | null) =>

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -82,7 +82,7 @@ const ButtonContainer = styled.div`
     gap: 8px;
 `;
 
-const WorkingRow = styled.div`
+const StatusRow = styled.div`
     display: flex;
     align-items: center;
     gap: 8px;
@@ -1221,48 +1221,47 @@ export function PackageOverview(props: PackageOverviewProps) {
                                             <Typography variant="h3" sx={{ marginBottom: "16px" }}>
                                                 Your integration is empty
                                             </Typography>
-                                            {/* Only when the hero is absent — its active form already
-                                                carries the same status. */}
-                                            {agentWorking && !showHero && (
-                                                <WorkingRow>
-                                                    {awaitingInput ? (
-                                                        <Codicon name="comment-discussion" />
-                                                    ) : (
-                                                        <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
-                                                    )}
-                                                    <Typography
-                                                        variant="body1"
-                                                        sx={{ color: "var(--vscode-descriptionForeground)" }}
-                                                    >
-                                                        {awaitingInput ? "Copilot needs your input" : "Copilot is working…"}
-                                                    </Typography>
-                                                </WorkingRow>
-                                            )}
+                                            {/* One line in every state, so starting a turn does not
+                                                reflow the block. The icon is dropped when the hero is
+                                                present, since its active form already animates. */}
+                                            <StatusRow>
+                                                {agentWorking && !showHero && (
+                                                    awaitingInput
+                                                        ? <Codicon name="comment-discussion" />
+                                                        : <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
+                                                )}
+                                                <Typography
+                                                    variant="body1"
+                                                    sx={{ color: "var(--vscode-descriptionForeground)" }}
+                                                >
+                                                    {agentWorking
+                                                        ? (awaitingInput ? "Copilot needs your input" : "Copilot is working…")
+                                                        : showHero
+                                                            ? "Describe what you want to build, or add an artifact to get started"
+                                                            : "Add an artifact to get started"}
+                                                </Typography>
+                                            </StatusRow>
                                             {showHero && (
                                                 <HeroRow>
                                                     <CopilotHeroBox placeholder="What would you like to build?" />
                                                 </HeroRow>
                                             )}
-                                            {!agentWorking && (
-                                                <>
-                                                    <Typography
-                                                        variant="body1"
-                                                        sx={{ marginBottom: "24px", color: "var(--vscode-descriptionForeground)" }}
-                                                    >
-                                                        {showHero
-                                                            ? "Describe what you want to build, or add an artifact to get started"
-                                                            : "Add an artifact to get started"}
-                                                    </Typography>
-                                                    <ButtonContainer>
-                                                        {/* An empty integration means the creation wizard was
-                                                            skipped — offer it again here rather than the raw
-                                                            artifact list, so the guided flow can be resumed. */}
-                                                        <Button appearance="primary" onClick={() => setShowAddIntegration(true)}>
-                                                            <Codicon name="add" sx={{ marginRight: 8 }} /> Add Integration
-                                                        </Button>
-                                                    </ButtonContainer>
-                                                </>
-                                            )}
+                                            <ButtonContainer>
+                                                {/* An empty integration means the creation wizard was
+                                                    skipped — offer it again here rather than the raw
+                                                    artifact list, so the guided flow can be resumed. */}
+                                                {/* Disabled rather than hidden mid-turn: reverting the
+                                                    generation restores a pre-turn checkpoint and drops
+                                                    whatever is not in it, including an artifact added now. */}
+                                                <Button
+                                                    appearance="primary"
+                                                    onClick={() => setShowAddIntegration(true)}
+                                                    disabled={agentWorking}
+                                                    tooltip={agentWorking ? "Available once Copilot finishes" : undefined}
+                                                >
+                                                    <Codicon name="add" sx={{ marginRight: 8 }} /> Add Integration
+                                                </Button>
+                                            </ButtonContainer>
                                         </EmptyStateContainer>
                                     ) : (
                                         <React.Suspense

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -44,7 +44,7 @@ import { TitleBar } from "../../../components/TitleBar";
 import { PublishToCentralButton } from "./PublishToCentralButton";
 import { LibraryOverview } from "./LibraryOverview";
 import { CopilotHeroBox } from "../../../components/AgentStatusOrb/CopilotHeroBox";
-import { useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
+import { useAgentWorking, useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
 
 /** Only reachable from an empty integration, and it pulls in the whole wizard +
  *  artifact form tree — so keep it out of the overview's own chunk. */
@@ -80,6 +80,13 @@ const ButtonContainer = styled.div`
     display: flex;
     align-items: flex-end;
     gap: 8px;
+`;
+
+const WorkingRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 24px;
 `;
 
 const EmptyStateContainer = styled.div`
@@ -841,6 +848,7 @@ export function PackageOverview(props: PackageOverviewProps) {
     const [isLibrary, setIsLibrary] = useState<boolean>(false);
     const [isNPSupported, setIsNPSupported] = useState<boolean>(false);
     const aiPanelOpen = useAiPanelOpen();
+    const agentWorking = useAgentWorking();
     const showHero = !isLibrary && !aiPanelOpen;
     // Shows the Create Integration wizard in place of the overview, for an empty
     // integration whose owner skipped it at creation time.
@@ -1210,27 +1218,44 @@ export function PackageOverview(props: PackageOverviewProps) {
                                             <Typography variant="h3" sx={{ marginBottom: "16px" }}>
                                                 Your integration is empty
                                             </Typography>
-                                            <Typography
-                                                variant="body1"
-                                                sx={{ marginBottom: "24px", color: "var(--vscode-descriptionForeground)" }}
-                                            >
-                                                {showHero
-                                                    ? "Describe what you want to build, or add an artifact to get started"
-                                                    : "Add an artifact to get started"}
-                                            </Typography>
+                                            {agentWorking ? (
+                                                <WorkingRow>
+                                                    <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
+                                                    <Typography
+                                                        variant="body1"
+                                                        sx={{ color: "var(--vscode-descriptionForeground)" }}
+                                                    >
+                                                        Copilot is working…
+                                                    </Typography>
+                                                </WorkingRow>
+                                            ) : (
+                                                <Typography
+                                                    variant="body1"
+                                                    sx={{ marginBottom: "24px", color: "var(--vscode-descriptionForeground)" }}
+                                                >
+                                                    {showHero
+                                                        ? "Describe what you want to build, or add an artifact to get started"
+                                                        : "Add an artifact to get started"}
+                                                </Typography>
+                                            )}
                                             {showHero && (
                                                 <HeroRow>
                                                     <CopilotHeroBox placeholder="What would you like to build?" />
                                                 </HeroRow>
                                             )}
-                                            <ButtonContainer>
-                                                {/* An empty integration means the creation wizard was
-                                                    skipped — offer it again here rather than the raw
-                                                    artifact list, so the guided flow can be resumed. */}
-                                                <Button appearance="primary" onClick={() => setShowAddIntegration(true)}>
-                                                    <Codicon name="add" sx={{ marginRight: 8 }} /> Add Integration
-                                                </Button>
-                                            </ButtonContainer>
+                                            {/* Hidden while Copilot is working: it may or may not be
+                                                creating artifacts, so inviting a competing add is wrong
+                                                either way until the turn settles. */}
+                                            {!agentWorking && (
+                                                <ButtonContainer>
+                                                    {/* An empty integration means the creation wizard was
+                                                        skipped — offer it again here rather than the raw
+                                                        artifact list, so the guided flow can be resumed. */}
+                                                    <Button appearance="primary" onClick={() => setShowAddIntegration(true)}>
+                                                        <Codicon name="add" sx={{ marginRight: 8 }} /> Add Integration
+                                                    </Button>
+                                                </ButtonContainer>
+                                            )}
                                         </EmptyStateContainer>
                                     ) : (
                                         <React.Suspense

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -126,14 +126,12 @@ const MainContent = styled.div<{ fullWidth?: boolean }>`
     max-height: calc(100vh - 90px);
 `;
 
-// Pinned to the foot of the design panel (which carries no padding of its own),
-// so it stays reachable once the artifact list is long enough to scroll.
+// Centred in the empty state, above the Add Integration button. Bounded so the
+// prompt box does not stretch the full panel width on a wide editor.
 const HeroRow = styled.div`
-    flex: none;
-    position: sticky;
-    bottom: 0;
-    padding: 16px;
-    background: var(--vscode-editor-background);
+    width: 100%;
+    max-width: 560px;
+    margin-bottom: 24px;
 `;
 
 const DiagramPanel = styled.div<{ noPadding?: boolean, noBorder?: boolean }>`
@@ -1216,9 +1214,15 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                 variant="body1"
                                                 sx={{ marginBottom: "24px", color: "var(--vscode-descriptionForeground)" }}
                                             >
-                                                Add an artifact to get started, or describe what you want to build in
-                                                the Copilot box below
+                                                {showHero
+                                                    ? "Describe what you want to build, or add an artifact to get started"
+                                                    : "Add an artifact to get started"}
                                             </Typography>
+                                            {showHero && (
+                                                <HeroRow>
+                                                    <CopilotHeroBox placeholder="What would you like to build?" />
+                                                </HeroRow>
+                                            )}
                                             <ButtonContainer>
                                                 {/* An empty integration means the creation wizard was
                                                     skipped — offer it again here rather than the raw
@@ -1240,13 +1244,6 @@ export function PackageOverview(props: PackageOverviewProps) {
                                         </React.Suspense>
                                     )}
                                 </DiagramContent>
-                            )}
-                            {showHero && (
-                                <HeroRow>
-                                    <CopilotHeroBox
-                                        placeholder={isEmptyIntegration() ? "What would you like to build?" : "What would you like to change?"}
-                                    />
-                                </HeroRow>
                             )}
                         </DiagramPanel>
                         {!isLibrary && (

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -1221,26 +1221,27 @@ export function PackageOverview(props: PackageOverviewProps) {
                                             <Typography variant="h3" sx={{ marginBottom: "16px" }}>
                                                 Your integration is empty
                                             </Typography>
-                                            {/* One line in every state, so starting a turn does not
-                                                reflow the block. The icon is dropped when the hero is
-                                                present, since its active form already animates. */}
-                                            <StatusRow>
-                                                {agentWorking && !showHero && (
-                                                    awaitingInput
-                                                        ? <Codicon name="comment-discussion" />
-                                                        : <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
-                                                )}
-                                                <Typography
-                                                    variant="body1"
-                                                    sx={{ color: "var(--vscode-descriptionForeground)" }}
-                                                >
-                                                    {agentWorking
-                                                        ? (awaitingInput ? "Copilot needs your input" : "Copilot is working…")
-                                                        : showHero
-                                                            ? "Describe what you want to build, or add an artifact to get started"
-                                                            : "Add an artifact to get started"}
-                                                </Typography>
-                                            </StatusRow>
+                                            {/* Skipped only while the hero carries the status itself, so
+                                                the two never state it at once. */}
+                                            {!(agentWorking && showHero) && (
+                                                <StatusRow>
+                                                    {agentWorking && (
+                                                        awaitingInput
+                                                            ? <Codicon name="comment-discussion" />
+                                                            : <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
+                                                    )}
+                                                    <Typography
+                                                        variant="body1"
+                                                        sx={{ color: "var(--vscode-descriptionForeground)" }}
+                                                    >
+                                                        {agentWorking
+                                                            ? (awaitingInput ? "Copilot needs your input" : "Copilot is working…")
+                                                            : showHero
+                                                                ? "Describe what you want to build, or add an artifact to get started"
+                                                                : "Add an artifact to get started"}
+                                                    </Typography>
+                                                </StatusRow>
+                                            )}
                                             {showHero && (
                                                 <HeroRow>
                                                     <CopilotHeroBox placeholder="What would you like to build?" />

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -1221,6 +1221,11 @@ export function PackageOverview(props: PackageOverviewProps) {
                                             <Typography variant="h3" sx={{ marginBottom: "16px" }}>
                                                 Your integration is empty
                                             </Typography>
+                                            {showHero && (
+                                                <HeroRow>
+                                                    <CopilotHeroBox placeholder="What would you like to build?" />
+                                                </HeroRow>
+                                            )}
                                             {/* Skipped only while the hero carries the status itself, so
                                                 the two never state it at once. */}
                                             {!(agentWorking && showHero) && (
@@ -1241,11 +1246,6 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                                 : "Add an artifact to get started"}
                                                     </Typography>
                                                 </StatusRow>
-                                            )}
-                                            {showHero && (
-                                                <HeroRow>
-                                                    <CopilotHeroBox placeholder="What would you like to build?" />
-                                                </HeroRow>
                                             )}
                                             <ButtonContainer>
                                                 {/* An empty integration means the creation wizard was

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -1219,7 +1219,7 @@ export function PackageOverview(props: PackageOverviewProps) {
                                             <Typography variant="h3" sx={{ marginBottom: "16px" }}>
                                                 Your integration is empty
                                             </Typography>
-                                            {agentWorking ? (
+                                            {agentWorking && (
                                                 <WorkingRow>
                                                     <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
                                                     <Typography
@@ -1229,15 +1229,6 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                         Copilot is working…
                                                     </Typography>
                                                 </WorkingRow>
-                                            ) : (
-                                                <Typography
-                                                    variant="body1"
-                                                    sx={{ marginBottom: "24px", color: "var(--vscode-descriptionForeground)" }}
-                                                >
-                                                    {showHero
-                                                        ? "Describe what you want to build, or add an artifact to get started"
-                                                        : "Add an artifact to get started"}
-                                                </Typography>
                                             )}
                                             {showHero && (
                                                 <HeroRow>
@@ -1245,14 +1236,24 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                 </HeroRow>
                                             )}
                                             {!agentWorking && (
-                                                <ButtonContainer>
-                                                    {/* An empty integration means the creation wizard was
-                                                        skipped — offer it again here rather than the raw
-                                                        artifact list, so the guided flow can be resumed. */}
-                                                    <Button appearance="primary" onClick={() => setShowAddIntegration(true)}>
-                                                        <Codicon name="add" sx={{ marginRight: 8 }} /> Add Integration
-                                                    </Button>
-                                                </ButtonContainer>
+                                                <>
+                                                    <Typography
+                                                        variant="body1"
+                                                        sx={{ marginBottom: "24px", color: "var(--vscode-descriptionForeground)" }}
+                                                    >
+                                                        {showHero
+                                                            ? "Describe what you want to build, or add an artifact to get started"
+                                                            : "Add an artifact to get started"}
+                                                    </Typography>
+                                                    <ButtonContainer>
+                                                        {/* An empty integration means the creation wizard was
+                                                            skipped — offer it again here rather than the raw
+                                                            artifact list, so the guided flow can be resumed. */}
+                                                        <Button appearance="primary" onClick={() => setShowAddIntegration(true)}>
+                                                            <Codicon name="add" sx={{ marginRight: 8 }} /> Add Integration
+                                                        </Button>
+                                                    </ButtonContainer>
+                                                </>
                                             )}
                                         </EmptyStateContainer>
                                     ) : (

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -44,7 +44,7 @@ import { TitleBar } from "../../../components/TitleBar";
 import { PublishToCentralButton } from "./PublishToCentralButton";
 import { LibraryOverview } from "./LibraryOverview";
 import { CopilotHeroBox } from "../../../components/AgentStatusOrb/CopilotHeroBox";
-import { useAgentRunState, useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
+import { AWAITING_INPUT_LABEL, useAgentRunState, useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
 
 /** Only reachable from an empty integration, and it pulls in the whole wizard +
  *  artifact form tree — so keep it out of the overview's own chunk. */
@@ -1240,7 +1240,7 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                         sx={{ color: "var(--vscode-descriptionForeground)" }}
                                                     >
                                                         {agentWorking
-                                                            ? (awaitingInput ? "Copilot needs your input" : "Copilot is working…")
+                                                            ? (awaitingInput ? AWAITING_INPUT_LABEL : "Copilot is working…")
                                                             : showHero
                                                                 ? "Describe what you want to build, or add an artifact to get started"
                                                                 : "Add an artifact to get started"}

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -44,7 +44,7 @@ import { TitleBar } from "../../../components/TitleBar";
 import { PublishToCentralButton } from "./PublishToCentralButton";
 import { LibraryOverview } from "./LibraryOverview";
 import { CopilotHeroBox } from "../../../components/AgentStatusOrb/CopilotHeroBox";
-import { activeStateLabel, useAgentRunStatus, useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
+import { useAgentRunState, useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
 
 /** Only reachable from an empty integration, and it pulls in the whole wizard +
  *  artifact form tree — so keep it out of the overview's own chunk. */
@@ -849,8 +849,9 @@ export function PackageOverview(props: PackageOverviewProps) {
     const [isLibrary, setIsLibrary] = useState<boolean>(false);
     const [isNPSupported, setIsNPSupported] = useState<boolean>(false);
     const aiPanelOpen = useAiPanelOpen();
-    const agentStatus = useAgentRunStatus();
-    const turnInFlight = agentStatus?.state === "running" || agentStatus?.state === "awaiting-input";
+    const agentState = useAgentRunState();
+    const awaitingInput = agentState === "awaiting-input";
+    const agentWorking = agentState === "running" || awaitingInput;
     const showHero = !isLibrary && !aiPanelOpen;
     // Shows the Create Integration wizard in place of the overview, for an empty
     // integration whose owner skipped it at creation time.
@@ -1220,18 +1221,20 @@ export function PackageOverview(props: PackageOverviewProps) {
                                             <Typography variant="h3" sx={{ marginBottom: "16px" }}>
                                                 Your integration is empty
                                             </Typography>
-                                            {/* Only when the hero is absent: its active form is the same
-                                                status, with the run's own label and a way back to the panel. */}
-                                            {turnInFlight && !showHero && agentStatus && (
+                                            {/* Only when the hero is absent — its active form already
+                                                carries the same status. */}
+                                            {agentWorking && !showHero && (
                                                 <WorkingRow>
-                                                    {agentStatus.state === "running" && (
+                                                    {awaitingInput ? (
+                                                        <Codicon name="comment-discussion" />
+                                                    ) : (
                                                         <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
                                                     )}
                                                     <Typography
                                                         variant="body1"
                                                         sx={{ color: "var(--vscode-descriptionForeground)" }}
                                                     >
-                                                        {activeStateLabel(agentStatus)}
+                                                        {awaitingInput ? "Copilot needs your input" : "Copilot is working…"}
                                                     </Typography>
                                                 </WorkingRow>
                                             )}
@@ -1240,7 +1243,7 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                     <CopilotHeroBox placeholder="What would you like to build?" />
                                                 </HeroRow>
                                             )}
-                                            {!turnInFlight && (
+                                            {!agentWorking && (
                                                 <>
                                                     <Typography
                                                         variant="body1"

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -44,7 +44,7 @@ import { TitleBar } from "../../../components/TitleBar";
 import { PublishToCentralButton } from "./PublishToCentralButton";
 import { LibraryOverview } from "./LibraryOverview";
 import { CopilotHeroBox } from "../../../components/AgentStatusOrb/CopilotHeroBox";
-import { useAgentWorking, useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
+import { activeStateLabel, useAgentRunStatus, useAiPanelOpen } from "../../../components/AgentStatusOrb/shared";
 
 /** Only reachable from an empty integration, and it pulls in the whole wizard +
  *  artifact form tree — so keep it out of the overview's own chunk. */
@@ -849,7 +849,8 @@ export function PackageOverview(props: PackageOverviewProps) {
     const [isLibrary, setIsLibrary] = useState<boolean>(false);
     const [isNPSupported, setIsNPSupported] = useState<boolean>(false);
     const aiPanelOpen = useAiPanelOpen();
-    const agentWorking = useAgentWorking();
+    const agentStatus = useAgentRunStatus();
+    const turnInFlight = agentStatus?.state === "running" || agentStatus?.state === "awaiting-input";
     const showHero = !isLibrary && !aiPanelOpen;
     // Shows the Create Integration wizard in place of the overview, for an empty
     // integration whose owner skipped it at creation time.
@@ -1219,14 +1220,18 @@ export function PackageOverview(props: PackageOverviewProps) {
                                             <Typography variant="h3" sx={{ marginBottom: "16px" }}>
                                                 Your integration is empty
                                             </Typography>
-                                            {agentWorking && (
+                                            {/* Only when the hero is absent: its active form is the same
+                                                status, with the run's own label and a way back to the panel. */}
+                                            {turnInFlight && !showHero && agentStatus && (
                                                 <WorkingRow>
-                                                    <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
+                                                    {agentStatus.state === "running" && (
+                                                        <ProgressRing color={ThemeColors.PRIMARY} sx={{ width: 16, height: 16 }} />
+                                                    )}
                                                     <Typography
                                                         variant="body1"
                                                         sx={{ color: "var(--vscode-descriptionForeground)" }}
                                                     >
-                                                        Copilot is working…
+                                                        {activeStateLabel(agentStatus)}
                                                     </Typography>
                                                 </WorkingRow>
                                             )}
@@ -1235,7 +1240,7 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                     <CopilotHeroBox placeholder="What would you like to build?" />
                                                 </HeroRow>
                                             )}
-                                            {!agentWorking && (
+                                            {!turnInFlight && (
                                                 <>
                                                     <Typography
                                                         variant="body1"

--- a/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -89,7 +89,7 @@ const WorkingRow = styled.div`
     margin-bottom: 24px;
 `;
 
-const EmptyStateContainer = styled.div`
+const EmptyStateContainer = styled.div<{ withHero?: boolean }>`
     position: absolute;
     top: 0;
     left: 0;
@@ -99,6 +99,8 @@ const EmptyStateContainer = styled.div`
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    // Offsets the prompt bar's height so the block keeps its former position.
+    padding-bottom: ${(props: { withHero?: boolean }) => (props.withHero ? "96px" : "0")};
 `;
 
 const PageLayout = styled.div`
@@ -133,8 +135,7 @@ const MainContent = styled.div<{ fullWidth?: boolean }>`
     max-height: calc(100vh - 90px);
 `;
 
-// Centred in the empty state, above the Add Integration button. Bounded so the
-// prompt box does not stretch the full panel width on a wide editor.
+// Bounded so the prompt box does not stretch the full panel width.
 const HeroRow = styled.div`
     width: 100%;
     max-width: 560px;
@@ -1214,7 +1215,7 @@ export function PackageOverview(props: PackageOverviewProps) {
                             {!isLibrary && (
                                 <DiagramContent>
                                     {isEmptyIntegration() ? (
-                                        <EmptyStateContainer>
+                                        <EmptyStateContainer withHero={showHero}>
                                             <Typography variant="h3" sx={{ marginBottom: "16px" }}>
                                                 Your integration is empty
                                             </Typography>
@@ -1243,9 +1244,6 @@ export function PackageOverview(props: PackageOverviewProps) {
                                                     <CopilotHeroBox placeholder="What would you like to build?" />
                                                 </HeroRow>
                                             )}
-                                            {/* Hidden while Copilot is working: it may or may not be
-                                                creating artifacts, so inviting a competing add is wrong
-                                                either way until the turn settles. */}
                                             {!agentWorking && (
                                                 <ButtonContainer>
                                                     {/* An empty integration means the creation wizard was

--- a/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -1091,8 +1091,7 @@ export function WorkspaceOverview({ isInDevant, isICPSupported }: WorkspaceOverv
                                         variant="body1"
                                         sx={{ marginBottom: "24px", color: "var(--vscode-descriptionForeground)" }}
                                     >
-                                        Add an integration or library to get started, or describe what you want to
-                                        build in the Copilot box above
+                                        Start by adding integrations and libraries to your project
                                     </Typography>
                                     <ButtonContainer>
                                         <Button appearance="primary" onClick={handleAddResource}>


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/1998

Follow-up to #785 on where the Copilot prompt bar lives in the integration (package) overview.

- Move the prompt bar into the empty-integration state — centred, above the Add Integration button — instead of pinned to the foot of the design panel
- Show the bar only while the integration is empty; once artifacts exist the floating orb takes over, so there is one ambient Copilot surface rather than two competing ones
- Make the empty-state copy follow the bar, so it stops inviting the user to describe what they want to build when the bar is hidden
- While a Copilot turn is in flight, show a loader with "Copilot is working…" and hide the Add Integration button — the turn may not be creating artifacts at all, so neither an add invitation nor a generation claim is right until it settles
- Restore the project overview's empty-state copy, which still pointed at a Copilot box that #785 removed from that page

https://github.com/user-attachments/assets/6bb8b1b3-1cc4-4c22-8ece-4c52da65a634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Reworked the Copilot entry point on the integration overview page.

Moved the Copilot prompt bar into the centered empty-integration state above the Add Integration button. Show the prompt bar only when the integration has no artifacts. Use the floating orb after artifacts exist.

Added shared Copilot run-status tracking. Show the “Copilot is working…” state during active turns and hide the Add Integration button.

Updated the package overview and restored the project overview empty-state messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->