### PR TITLE
Create the integration from the project chooser, skipping the wizard steps

### DIFF
--- a/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/CreateProjectChooser.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/CreateProjectChooser.tsx
@@ -499,22 +499,27 @@ export function CreateProjectChooser({
             // clicked — and the extension scaffolds over whatever sits at the resolved path
             // (`createBIProjectPure` writes Ballerina.toml/main.bal/... unconditionally), so
             // a stale pass here would blank an existing package's sources.
-            let taken: TakenNames | null = null;
+            let taken: TakenNames;
             try {
                 taken = toTakenNames(await wsClient.getProjectComponentNames({ projectPath: resolvedPath }));
             } catch (error) {
-                // Unlistable target — in practice a project that does not exist yet, so
-                // there is nothing to collide with. Fail open, as the live check does.
+                // Deliberately NOT failing open. A missing or unreadable target is already
+                // reported as an EMPTY listing rather than a rejection — the extension
+                // swallows the readdir failure and `readBallerinaProject` is existsSync-
+                // guarded — so a rejection here is a genuine failure (transport, or an
+                // unexpected throw), never "this project does not exist yet". Continuing
+                // would scaffold over whatever is at the path without having verified it,
+                // which is the exact outcome this whole block exists to prevent.
                 console.error("Failed to re-check existing component names:", error);
+                setCreateError("Could not verify the contents of the target project. Please try again.");
+                return;
             }
-            if (taken) {
-                takenNamesPathRef.current = resolvedPath;
-                setTakenNames(taken);
-                const collision = resolveNameCollisionMessage(effectiveIntegrationName, taken, sanitizePackageName);
-                if (collision) {
-                    setIntegrationNameError(collision);
-                    return;
-                }
+            takenNamesPathRef.current = resolvedPath;
+            setTakenNames(taken);
+            const collision = resolveNameCollisionMessage(effectiveIntegrationName, taken, sanitizePackageName);
+            if (collision) {
+                setIntegrationNameError(collision);
+                return;
             }
 
             setIsCreating(true);
@@ -531,7 +536,11 @@ export function CreateProjectChooser({
         } catch (error) {
             console.error("Failed to create the integration:", error);
             setIsCreating(false);
-            setCreateError(error instanceof Error ? error.message : "Failed to create the integration");
+            // Lead with the operation, append the reason only when there is one — a bare
+            // transport/filesystem message leaves the user to infer what failed. The raw
+            // error is on the console above, which is where the detail is useful.
+            const reason = error instanceof Error ? error.message : "";
+            setCreateError(`Failed to create the integration.${reason ? ` ${reason}` : ""}`);
         } finally {
             setIsValidating(false);
         }

--- a/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/CreateProjectChooser.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/CreateProjectChooser.tsx
@@ -216,6 +216,8 @@ export function CreateProjectChooser({
     const [integrationNameError, setIntegrationNameError] = useState<string | null>(null);
     // Folders/titles already used in the target project, for live collision flagging.
     const [takenNames, setTakenNames] = useState<TakenNames>(emptyTakenNames());
+    // Submit-time re-check of the collision list, before anything is created.
+    const [isValidating, setIsValidating] = useState(false);
     const [isCreating, setIsCreating] = useState(false);
     const [createError, setCreateError] = useState<string | null>(null);
 
@@ -400,7 +402,7 @@ export function CreateProjectChooser({
         }
         debouncedSetIntegrationNameError(integrationNameIssue);
         return () => debouncedSetIntegrationNameError.cancel();
-    }, [integrationNameIssue]);
+    }, [debouncedSetIntegrationNameError, integrationNameIssue]);
 
     useRealtimeProjectPathValidation({
         wsClient,
@@ -487,10 +489,35 @@ export function CreateProjectChooser({
      * the creating state until it is torn down.
      */
     const handleCreateIntegration = async () => {
-        if (!canCreateIntegration || workspaceSupportPending || isCreating) return;
+        if (!canCreateIntegration || workspaceSupportPending || isValidating || isCreating) return;
         setCreateError(null);
-        setIsCreating(true);
+        setIsValidating(true);
         try {
+            // Re-check the collision against a FRESH listing rather than trusting the live
+            // one. The project name and location are edited on this same screen, so the
+            // debounced `takenNames` can still describe the previous target when Create is
+            // clicked — and the extension scaffolds over whatever sits at the resolved path
+            // (`createBIProjectPure` writes Ballerina.toml/main.bal/... unconditionally), so
+            // a stale pass here would blank an existing package's sources.
+            let taken: TakenNames | null = null;
+            try {
+                taken = toTakenNames(await wsClient.getProjectComponentNames({ projectPath: resolvedPath }));
+            } catch (error) {
+                // Unlistable target — in practice a project that does not exist yet, so
+                // there is nothing to collide with. Fail open, as the live check does.
+                console.error("Failed to re-check existing component names:", error);
+            }
+            if (taken) {
+                takenNamesPathRef.current = resolvedPath;
+                setTakenNames(taken);
+                const collision = resolveNameCollisionMessage(effectiveIntegrationName, taken, sanitizePackageName);
+                if (collision) {
+                    setIntegrationNameError(collision);
+                    return;
+                }
+            }
+
+            setIsCreating(true);
             await biWsClient.createIntegration({
                 project: {
                     integrationName: effectiveIntegrationName,
@@ -505,6 +532,8 @@ export function CreateProjectChooser({
             console.error("Failed to create the integration:", error);
             setIsCreating(false);
             setCreateError(error instanceof Error ? error.message : "Failed to create the integration");
+        } finally {
+            setIsValidating(false);
         }
     };
 
@@ -642,12 +671,13 @@ export function CreateProjectChooser({
                         disabled={
                             ballerinaUnavailable ||
                             workspaceSupportPending ||
+                            isValidating ||
                             (isLibrary ? !canProceed : !canCreateIntegration)
                         }
                         onClick={isLibrary ? handleNext : handleCreateIntegration}
                         appearance="primary"
                     >
-                        {isLibrary ? "Next" : "Create Integration"}
+                        {isLibrary ? "Next" : isValidating ? "Validating..." : "Create Integration"}
                     </Button>
                 </span>
             </FormFooter>

--- a/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/CreateProjectChooser.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/ProjectForm/embedded/integrator-form/CreateProjectChooser.tsx
@@ -25,20 +25,27 @@ import {
     joinPath,
     splitPath,
     sanitizePackageName,
+    validateComponentName,
     validateProjectName,
 } from "./utils";
 import { useRealtimeProjectPathValidation } from "./useRealtimeProjectPathValidation";
 import { FieldGroup, ProjectSectionContainer } from "./styles";
-import { DEFAULT_PROJECT_NAME } from "./types";
+import { DEFAULT_INTEGRATION_NAME, DEFAULT_PROJECT_NAME } from "./types";
 import { CreateFlowShell } from "./shared/CreateFlowShell";
 import { FormFooter } from "./shared/FormPageLayout";
 import { useDirectoryNameCoupling } from "../../hooks/useDirectoryNameCoupling";
+import {
+    checkNameCollision as resolveNameCollisionMessage,
+    resolveDefaultNameAndDirectory,
+    toTakenNames,
+    emptyTakenNames,
+    TakenNames,
+} from "../../hooks/resolveAvailableDirectoryName";
 import { LibraryCreationView } from "./LibraryCreationView";
 import { ProjectTypeSelector } from "../../components";
-import { CreateIntegrationWizard } from "../../../CreateIntegrationWizard";
+import { CreatingIntegrationView } from "../../../CreateIntegrationWizard/components/CreatingIntegrationView";
 import { ProjectContext } from "../../../CreateIntegrationWizard/types";
 import { BiWsClient } from "../../../wsManager/WsClient";
-import { BiWsClientProvider } from "../../../wsManager/WsClientContext";
 
 /** A group of related fields, separated by generous whitespace rather than a
  *  hard divider so the form reads as a couple of calm sections. */
@@ -73,9 +80,11 @@ const ProjectGroupFields = styled.div`
  *  Location resolve to a brand-new project, or to one that already exists?
  *
  *  Styled as a tinted strip sealed to the container rather than as a `Note` callout,
- *  which the starting-point section below already uses. The duplicate `background` is
+ *  which the starting-point section below already uses. Hitting an existing project is
+ *  not an error — it is a legal target — but it silently changes what Create does, so
+ *  it is toned as a warning rather than as neutral info. The duplicate `background` is
  *  a fallback for runtimes without `color-mix()` (Chromium < 111). */
-const ProjectStatusStrip = styled.div`
+const ProjectStatusStrip = styled.div<{ isWarning?: boolean }>`
     display: flex;
     align-items: flex-start;
     gap: 6px;
@@ -83,16 +92,24 @@ const ProjectStatusStrip = styled.div`
     font-size: 12px;
     line-height: 1.4;
     color: var(--vscode-descriptionForeground);
-    background: var(--vscode-inputValidation-infoBackground, var(--vscode-sideBar-background));
-    background: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, var(--vscode-editor-background));
+    background: ${(props: { isWarning?: boolean }) =>
+        props.isWarning
+            ? "var(--vscode-inputValidation-warningBackground, var(--vscode-sideBar-background))"
+            : "var(--vscode-inputValidation-infoBackground, var(--vscode-sideBar-background))"};
+    background: ${(props: { isWarning?: boolean }) =>
+        props.isWarning
+            ? "color-mix(in srgb, var(--vscode-editorWarning-foreground) 14%, var(--vscode-editor-background))"
+            : "color-mix(in srgb, var(--vscode-textLink-foreground) 12%, var(--vscode-editor-background))"};
     border-top: 1px solid var(--vscode-panel-border);
 `;
 
 /** The scannable half of the status ("New project" / "Existing project"),
  *  lifted above the trailing detail clause so the key distinction registers at
- *  a glance without resorting to a louder color. */
-const ProjectStatusLead = styled.span`
-    color: var(--vscode-foreground);
+ *  a glance. The new-project case stays on the plain foreground — it needs no
+ *  louder color; the existing-project case carries the warning tone. */
+const ProjectStatusLead = styled.span<{ isWarning?: boolean }>`
+    color: ${(props: { isWarning?: boolean }) =>
+        props.isWarning ? "var(--vscode-editorWarning-foreground)" : "var(--vscode-foreground)"};
     font-weight: 500;
 `;
 
@@ -112,14 +129,45 @@ const STATUS_ICON_SX = {
 /** Nudged down from the codicon default of 16px to sit comfortably beside 12px text. */
 const STATUS_ICON_GLYPH_SX = { fontSize: "14px" } as const;
 
+/** Same sizing, warning-toned — the glyph would otherwise inherit the strip's
+ *  muted description color and read as neutral info. */
+const STATUS_ICON_WARNING_GLYPH_SX = {
+    ...STATUS_ICON_GLYPH_SX,
+    color: "var(--vscode-editorWarning-foreground)",
+} as const;
+
 /** Frame budget for the Project name preselect retry (~0.5s at 60fps). Only a
  *  backstop: the field is normally ready within a frame or two, and this just
  *  guarantees a mount that never satisfies the readiness check still ends up
  *  focused instead of retrying forever. */
 const PRESELECT_MAX_FRAMES = 30;
 
-/** Which screen of the Create flow is showing. */
-type Screen = "chooser" | "integration" | "library";
+/** Form-level failure from the create call itself — the fields are all valid at
+ *  that point, so there is no single input to hang the message off. */
+const FormError = styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin-top: 12px;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--vscode-errorForeground);
+`;
+
+/** Gives the create-in-progress screen room to centre itself inside the scrolling form body. */
+const CreatingSlot = styled.div`
+    display: flex;
+    min-height: 320px;
+`;
+
+/**
+ * Which screen of the Create flow is showing. The integration route no longer has
+ * a screen of its own: the 3-step integration wizard (Name → Type → Configure) is
+ * bypassed for now, and the chooser collects the integration name inline and
+ * creates an empty integration directly. Restore the `"integration"` screen (and
+ * the `CreateIntegrationWizard` render behind it) to bring the wizard back.
+ */
+type Screen = "chooser" | "library";
 
 interface CreateProjectChooserProps {
     /** The wizard client (native BI WS) used by the integration route. */
@@ -137,9 +185,12 @@ interface CreateProjectChooserProps {
 
 /**
  * Screen 1 of the Create flow: pick the project and the starting point (integration or
- * library), then route to the integration wizard or the library form in the same shell.
- * The Default project is pre-selected; existing vs new is detected live and shown under
- * the location field.
+ * library). The Default project is pre-selected; existing vs new is detected live and
+ * shown under the location field.
+ *
+ * The integration route finishes here — the name the wizard's first step used to collect
+ * is asked for inline, and Create submits an empty integration. The library route still
+ * hands off to the library form in the same shell.
  */
 export function CreateProjectChooser({
     biWsClient,
@@ -151,9 +202,22 @@ export function CreateProjectChooser({
     const firstFieldRef = useRef<HTMLInputElement>(null);
     const defaultPathInitialized = useRef(false);
     const projectNameTouchedRef = useRef(false);
+    // Set the moment the user edits the integration name, so the async default-name
+    // indexing below never clobbers what they typed.
+    const integrationNameTouchedRef = useRef(false);
+    // The location `takenNames` currently describes, so the refresh effect below can
+    // skip a path it has already listed (and re-list whenever the project retargets).
+    const takenNamesPathRef = useRef<string | null>(null);
 
     const [screen, setScreen] = useState<Screen>("chooser");
     const [isLibrary, setIsLibrary] = useState(false);
+
+    const [integrationName, setIntegrationName] = useState(DEFAULT_INTEGRATION_NAME);
+    const [integrationNameError, setIntegrationNameError] = useState<string | null>(null);
+    // Folders/titles already used in the target project, for live collision flagging.
+    const [takenNames, setTakenNames] = useState<TakenNames>(emptyTakenNames());
+    const [isCreating, setIsCreating] = useState(false);
+    const [createError, setCreateError] = useState<string | null>(null);
 
     const [projectName, setProjectName] = useState(DEFAULT_PROJECT_NAME);
     const dirCoupling = useDirectoryNameCoupling(() => sanitizePackageName(DEFAULT_PROJECT_NAME), sanitizePackageName);
@@ -173,9 +237,25 @@ export function CreateProjectChooser({
         []
     );
 
+    const debouncedSetIntegrationNameError = useMemo(
+        () => debounce((error: string) => setIntegrationNameError(error), 300),
+        []
+    );
+
     const autoDirectoryName = projectName.trim() ? sanitizePackageName(projectName) : "";
     const effectiveDirectoryName = dirTouched ? directoryName.trim() : (directoryName.trim() || autoDirectoryName);
     const resolvedPath = editablePath ? joinPath(editablePath, effectiveDirectoryName) : "";
+
+    // The integration package created inside the project. Its folder and its Ballerina
+    // package name are both derived from the name — unlike the wizard there is no
+    // editable path field here, since the location is already resolved above.
+    const effectiveIntegrationName = integrationName.trim() || DEFAULT_INTEGRATION_NAME;
+    const integrationPackageName = sanitizePackageName(effectiveIntegrationName) || "untitled";
+    // Resolved synchronously — the displayed diagnostic is debounced, so gating Create on
+    // the error state alone would leave it clickable for a beat after a bad edit.
+    const integrationNameIssue =
+        validateComponentName(integrationName) ||
+        resolveNameCollisionMessage(integrationName, takenNames, sanitizePackageName);
 
     // Seed the Default project location once (`<defaultLocation>/default`). The
     // realtime validation then reports whether it already exists (add into it) or
@@ -270,6 +350,58 @@ export function CreateProjectChooser({
         return () => debouncedSetProjectNameError.cancel();
     }, [projectName]);
 
+    // List what the target project already contains, so the integration name below can
+    // be flagged live when it collides. The project name/location are editable on this
+    // same screen, so the target moves — re-list whenever it does (debounced to match
+    // the path validation hook, which watches the same value). An existing project that
+    // already holds an "Untitled" also shifts the default name to "Untitled_2".
+    useEffect(() => {
+        const targetPath = resolvedPath.trim();
+        if (!targetPath || targetPath === takenNamesPathRef.current) {
+            return;
+        }
+        let cancelled = false;
+        const timer = setTimeout(async () => {
+            let taken = emptyTakenNames();
+            try {
+                // A brand-new project has nothing to list; failing open just defers
+                // collision reporting to the extension's own submit-time validation,
+                // whereas keeping the previous project's list would reject names that
+                // are actually free here.
+                taken = toTakenNames(await wsClient.getProjectComponentNames({ projectPath: targetPath }));
+            } catch (error) {
+                console.error("Failed to list existing component names:", error);
+            }
+            if (cancelled) {
+                return;
+            }
+            takenNamesPathRef.current = targetPath;
+            setTakenNames(taken);
+            if (!integrationNameTouchedRef.current) {
+                setIntegrationName(
+                    resolveDefaultNameAndDirectory(DEFAULT_INTEGRATION_NAME, taken, sanitizePackageName).name
+                );
+            }
+        }, 300);
+        return () => {
+            cancelled = true;
+            clearTimeout(timer);
+        };
+    }, [wsClient, resolvedPath]);
+
+    // Mirrors the project-name check above: clear a resolved error immediately, debounce
+    // a new one so "required" doesn't flash on every keystroke. Keyed on the issue itself,
+    // so a stale diagnostic also clears once the target project is re-listed.
+    useEffect(() => {
+        if (!integrationNameIssue) {
+            debouncedSetIntegrationNameError.cancel();
+            setIntegrationNameError(null);
+            return;
+        }
+        debouncedSetIntegrationNameError(integrationNameIssue);
+        return () => debouncedSetIntegrationNameError.cancel();
+    }, [integrationNameIssue]);
+
     useRealtimeProjectPathValidation({
         wsClient,
         projectPath: editablePath,
@@ -303,21 +435,20 @@ export function CreateProjectChooser({
     };
 
     /**
-     * Browse: the picked folder IS the project location. An existing project is used as-is
-     * (with its real name); otherwise it becomes a new project there.
+     * Browse: the picked folder is the parent LOCATION, not the project folder. The
+     * project keeps the name the user gave it and is targeted at `<picked>/<name>` —
+     * whether something already lives there is reported live by the path validation
+     * above, so nothing here needs to inspect the folder.
      */
     const handlePathSelection = async () => {
         try {
-            const result = await wsClient.selectFileOrDirPath({ startPath: resolvedPath || editablePath || defaultPath });
+            const result = await wsClient.selectFileOrDirPath({ startPath: editablePath || defaultPath });
             if (!result.path) return;
-            const { base, name: folderName } = splitPath(result.path);
-            const info = await wsClient.getExistingProjectInfo({ projectPath: result.path });
-            projectNameTouchedRef.current = true;
-            setEditablePath(base);
-            dirCoupling.setDirectoryName(folderName);
-            setProjectName(info?.isProject ? (info.name || folderName) : folderName);
-            dirCoupling.setDirTouched(true);
+            setEditablePath(result.path);
             setPathTouched(true);
+            // Pin the name: the one-shot default-project lookup can still be in flight,
+            // and its result no longer describes the location just picked.
+            projectNameTouchedRef.current = true;
         } catch (error) {
             console.error("Failed to select path:", error);
             setPathError("Failed to select the project folder. Please try again.");
@@ -326,7 +457,7 @@ export function CreateProjectChooser({
 
     const startingPointNoun = isLibrary ? "library" : "integration";
 
-    /** The resolved project the wizard / library form creates the artifact into. */
+    /** The resolved project the integration / library is created into. */
     const projectContext: ProjectContext = {
         isNewProject: !existingWorkspace,
         workspacePath: resolvedPath,
@@ -335,23 +466,59 @@ export function CreateProjectChooser({
 
     const canProceed =
         !projectNameError && !pathError && !!projectName.trim() && !!editablePath && !!effectiveDirectoryName;
+    /** The integration route submits from this screen, so its name must be valid too. */
+    const canCreateIntegration = canProceed && !integrationNameIssue;
+
+    const handleIntegrationNameChange = (value: string) => {
+        integrationNameTouchedRef.current = true;
+        setIntegrationName(value);
+    };
 
     const handleNext = () => {
         if (!canProceed || workspaceSupportPending) return;
-        setScreen(isLibrary ? "library" : "integration");
+        setScreen("library");
     };
 
-    if (screen === "integration") {
+    /**
+     * Integration route: create the project and an EMPTY integration package inside it,
+     * straight from this screen. The artifact-type/configure steps are skipped for now,
+     * so no artifact is sent — the same payload the wizard's "Create Empty Integration"
+     * used to submit. The extension reloads the window from here, so the form stays in
+     * the creating state until it is torn down.
+     */
+    const handleCreateIntegration = async () => {
+        if (!canCreateIntegration || workspaceSupportPending || isCreating) return;
+        setCreateError(null);
+        setIsCreating(true);
+        try {
+            await biWsClient.createIntegration({
+                project: {
+                    integrationName: effectiveIntegrationName,
+                    packageName: integrationPackageName,
+                    projectPath: resolvedPath,
+                    directoryName: integrationPackageName,
+                    newProject: projectContext.isNewProject,
+                    workspaceName: projectContext.workspaceName,
+                },
+            });
+        } catch (error) {
+            console.error("Failed to create the integration:", error);
+            setIsCreating(false);
+            setCreateError(error instanceof Error ? error.message : "Failed to create the integration");
+        }
+    };
+
+    if (isCreating) {
         return (
-            <CreateFlowShell
-                title="New Integration"
-                subtitle={`In project ${projectName.trim() || DEFAULT_PROJECT_NAME}`}
-                onBack={() => setScreen("chooser")}
-                bodyFill
-            >
-                <BiWsClientProvider wsClient={biWsClient} onBack={onBack}>
-                    <CreateIntegrationWizard embedded showHeader={false} projectContext={projectContext} />
-                </BiWsClientProvider>
+            <CreateFlowShell title="Create">
+                <CreatingSlot>
+                    <CreatingIntegrationView
+                        variant="create"
+                        integrationName={effectiveIntegrationName}
+                        projectName={projectContext.workspaceName}
+                        isNewProject={projectContext.isNewProject}
+                    />
+                </CreatingSlot>
             </CreateFlowShell>
         );
     }
@@ -407,15 +574,15 @@ export function CreateProjectChooser({
                     </ProjectGroupFields>
 
                     {!pathError && resolvedPath && (
-                        <ProjectStatusStrip>
+                        <ProjectStatusStrip isWarning={existingWorkspace}>
                             <Icon
-                                name={existingWorkspace ? "info" : "new-folder"}
+                                name={existingWorkspace ? "warning" : "new-folder"}
                                 isCodicon
                                 sx={STATUS_ICON_SX}
-                                iconSx={STATUS_ICON_GLYPH_SX}
+                                iconSx={existingWorkspace ? STATUS_ICON_WARNING_GLYPH_SX : STATUS_ICON_GLYPH_SX}
                             />
                             <span>
-                                <ProjectStatusLead>
+                                <ProjectStatusLead isWarning={existingWorkspace}>
                                     {existingWorkspace ? "Existing project" : "New project"}
                                 </ProjectStatusLead>
                                 {existingWorkspace
@@ -436,6 +603,31 @@ export function CreateProjectChooser({
                 />
             </Section>
 
+            {/* The integration is named here rather than on a step of its own — the
+                wizard is bypassed, so this screen submits. The library route keeps its
+                own form, which already collects a name alongside its package details. */}
+            {!isLibrary && (
+                <Section>
+                    <FieldGroup>
+                        <TextField
+                            onTextChange={handleIntegrationNameChange}
+                            value={integrationName}
+                            label="Integration name"
+                            placeholder="Enter an integration name"
+                            required={true}
+                            errorMsg={integrationNameError || ""}
+                        />
+                    </FieldGroup>
+                </Section>
+            )}
+
+            {createError && (
+                <FormError>
+                    <Icon name="error" isCodicon sx={{ marginTop: "1px" }} />
+                    <span>{createError}</span>
+                </FormError>
+            )}
+
             <FormFooter>
                 <span
                     title={
@@ -447,11 +639,15 @@ export function CreateProjectChooser({
                     }
                 >
                     <Button
-                        disabled={ballerinaUnavailable || workspaceSupportPending || !canProceed}
-                        onClick={handleNext}
+                        disabled={
+                            ballerinaUnavailable ||
+                            workspaceSupportPending ||
+                            (isLibrary ? !canProceed : !canCreateIntegration)
+                        }
+                        onClick={isLibrary ? handleNext : handleCreateIntegration}
                         appearance="primary"
                     >
-                        Next
+                        {isLibrary ? "Next" : "Create Integration"}
                     </Button>
                 </span>
             </FormFooter>


### PR DESCRIPTION
## Purpose

The unified Create flow asked for a project, then handed off to the three-step integration wizard (Name → Type → Configure). That is three screens to get to an empty integration, and the wizard's first step asks for a name the user has already been thinking about on the previous screen.

No linked issue.

## Goals

Collapse creating an integration into a single screen: the project chooser collects the integration name inline and creates the empty integration itself. The type/configure steps are skipped **for now** — the wizard component is untouched and the `Screen` type carries a comment describing exactly what to restore to bring it back.

Two related fixes to the same screen came out of testing it:
- Browse was overwriting the project name with the picked folder's name.
- Landing on an existing project was styled as neutral info, though it silently changes what Create does.

## Approach

All changes are in `CreateProjectChooser.tsx`.

**Single-screen create**
- Dropped the `"integration"` screen that mounted `CreateIntegrationWizard`. The wizard itself is unchanged and still reachable from `MACHINE_VIEW.BIProjectForm`, `AddProjectForm` and `AddIntegrationPanel`.
- The wizard's Name-step field now sits at the bottom of the chooser, rendered only when the starting point is "integration". **Create Integration** submits `createIntegration` with no artifact — the same payload the wizard's "Create Empty Integration" skip sent. While it is in flight the screen swaps to the same `CreatingIntegrationView`, so the hand-off across the window reload still reads as one continuous screen.
- The library route is unchanged: picking "library" hides the field and the button reverts to **Next** → the existing library form.
- Carried over the wizard's name handling so the inline field is not a downgrade — live validation, collision checks against the target project (re-listed when the project name or location retargets), and default-name indexing (`Untitled` → `Untitled_2` when taken). Create is gated on a synchronously computed validity check rather than the debounced diagnostic, so it never stays clickable for a beat after a bad edit.
- The collision is **re-checked at submit time** against a fresh listing. Because the project name and location are edited on the same screen as Create, `resolvedPath` moves while the user types and the debounced list can still describe the previous target. That window is not cosmetic: `createBIProjectPure` writes `Ballerina.toml`, `main.bal`, `connections.bal` and the rest unconditionally into the resolved path with no guard for a package already being there, so a colliding name that slips through would blank an existing integration's sources. Fails open when the path cannot be listed (a project that does not exist yet). Follows the library form's `isValidating` pattern.

**Browse no longer overwrites the project name**

The picked folder is now the parent *location*, not the project folder, so the name is appended as `<picked>/<name>` instead of replacing what the user typed. Dropped the `getExistingProjectInfo` lookup that was overwriting the name with the picked folder's `Ballerina.toml` title, and the `setDirTouched(true)` that decoupled the folder from the name afterwards — renaming after a browse now retargets correctly. Typing directly in the field is unchanged; its last segment is still the editable folder name. Existing-project detection is unaffected: it comes from `useRealtimeProjectPathValidation` watching the resolved target.

**Existing-project status reads as a warning**

Hitting an existing project is a legal target, but it silently changes what Create does, so the status strip is toned as a warning instead of neutral info — warning-tinted background, warning-colored lead, and the codicon switched `info` → `warning` with an explicit color (it would otherwise inherit the strip's muted description foreground). The "New project" state is untouched.

## UI Component Development

- [ ] Added reusable UI components to the ui-toolkit — **N/A**. No new reusable component; this rearranges an existing screen.
- [x] Use ui-toolkit components wherever possible — `TextField`, `DirectorySelector`, `Button` and `Icon` all come from `@wso2/ui-toolkit`. The two styled elements added (the form-error row and the progress slot) mirror the ones already in `LibraryCreationView`.
- [x] Matches with the native VSCode look and feel — all colors are VS Code theme variables (`--vscode-editorWarning-foreground`, `--vscode-inputValidation-warningBackground`, `--vscode-errorForeground`), with a non-`color-mix()` fallback for Chromium < 111.

## User stories

As a developer creating an integration, I give the project a name and location, pick "integration", name it, and press Create — without stepping through a wizard to reach an empty integration.

## Release note

Creating an integration from the Create flow is now a single screen: the integration is named alongside the project and created directly, instead of stepping through the Name/Type/Configure wizard. Browsing for a location no longer overwrites the project name, and targeting an existing project is now flagged as a warning.

## Documentation

N/A — no documented behavior changes. This rearranges fields within an existing screen and does not add or remove a user-facing capability; the create/library flows and their outcomes are unchanged.

## Training

N/A

## Certification

N/A — no impact on certification exams. The change is a form layout and validation change with no new concepts or APIs.

## Marketing

N/A

## Automation tests

- Unit tests
  > None added. The chooser's direct-create path (payload shape for new vs existing projects, and the rejection path restoring the form with an error) is not covered, and both reviewers asked for it.
  >
  > An earlier revision of this description claimed the package had no way to test this. That was wrong: it was written against a base that predated #790, which added `src/test/rpcHarness.tsx` and `views/TypeDiagram/index.test.tsx` — component tests rendering via `react-dom/client` + `act`, explicitly with no extra test-only dependency. This branch is now rebased onto current `main`, so that pattern is available and the test is writable as-is.
  >
  > Leaving it as a follow-up to keep this PR to the behaviour change; happy to add it here instead if reviewers would rather it not merge without one.
- Integration tests
  > None added, and none affected. Every create-flow locator in `e2e-test` ("Integration Name", "Select Path", "Next", "Create Empty Integration") targets the standalone `CreateIntegrationWizard`, which this PR does not modify. No spec references "Project name" or "Choose your starting point". All four e2e groups passed on the previous push.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — FindSecurityBugs is a Java/SpotBugs plugin; this is a TypeScript/React webview change with no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples

N/A

## Related PRs

None.

## Migrations (if applicable)

N/A

## Test environment

macOS 15 (Darwin 25.5.0), Node 16.15.1 for the isolated typecheck. Not exercised end to end in a running VS Code — see the note below on reachability. Rebased onto current `main` (was ~176 commits behind); nothing upstream touches this file and the rebase was content-identical.

## Learning

Worth flagging for reviewers: `CreateProjectChooser` has no mount point in this repo. Its only call site is `EmbeddedBIProjectForm.tsx` under `mode="create"`, and that component is exposed solely as the `ballerinaBiForm` Module Federation remote — built and shipped here, consumed by the WSO2 Integrator extension. So this change is only visible through that host; the in-repo entry points (BI Welcome card, `ballerina.open.bi.new`, `BI.project-explorer.add`) all still route to the wizard or `AddProjectForm`.

Unrelated, but it bites anyone testing this: `EmbeddedBIProjectForm`'s doc comment calls `create` "the primary mode going forward," while the prop defaults to `mode = "integration"`. A host that mounts the remote without explicitly passing `mode="create"` silently gets the old wizard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Simplifies integration creation by collecting the name and creating an empty integration on the project chooser screen.
- Preserves the existing wizard through its current entry points.
- Keeps library creation unchanged.
- Adds name validation, default-name indexing, debounced feedback, and collision checks.
- Rechecks collisions during submission before creation.
- Allows listing failures for nonexistent target projects.
- Updates folder browsing to select the parent location without replacing the project name.
- Uses warning styling for existing-project targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->