### PR TITLE
Open a single-integration workspace on startup

### DIFF
--- a/packages/ballerina-extension/src/rpc-managers/visualizer/rpc-manager.ts
+++ b/packages/ballerina-extension/src/rpc-managers/visualizer/rpc-manager.ts
@@ -100,7 +100,11 @@ export class VisualizerRpcManager implements VisualizerAPI {
                         ? MACHINE_VIEW.WorkspaceOverview
                         : MACHINE_VIEW.PackageOverview
                 },
-                true
+                true,
+                // Home is the way back up to the workspace, so it keeps the workspace overview
+                // even when a single integration would otherwise collapse onto itself — the
+                // landing view is already that integration, so redirecting here does nothing.
+                { exactView: true }
             );
         });
     }

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -35,7 +35,8 @@ import {
     getNodeByIndex,
     getNodeByName,
     getNodeByUid,
-    getView
+    getView,
+    resolveSingleIntegrationOverride
 } from './utils/state-machine-utils';
 import * as path from 'path';
 import { extension } from './BalExtensionContext';
@@ -1003,13 +1004,35 @@ export const StateMachine = {
     },
 };
 
-export function openView(type: EVENT_TYPE, viewLocation: VisualizerLocation, resetHistory = false) {
+export interface OpenViewOptions {
+    /**
+     * Take `viewLocation.view` literally, skipping the single-integration redirect in
+     * {@link openView}. For callers whose whole purpose is to reach the workspace overview —
+     * Home being the one — since redirecting them to the integration overview would land on
+     * the page the user is already looking at and make the control appear dead.
+     */
+    exactView?: boolean;
+}
+
+export function openView(
+    type: EVENT_TYPE,
+    viewLocation: VisualizerLocation,
+    resetHistory = false,
+    options?: OpenViewOptions
+) {
     if (resetHistory) {
         StateMachine.setReadyMode();
         history?.clear();
     }
     extension.hasPullModuleResolved = false;
     extension.hasPullModuleNotification = false;
+    // A workspace holding a single integration opens on that integration rather than a one-item
+    // workspace overview. Applied to every navigation, not just the first: the project explorer
+    // re-navigates once its tree finishes loading, seconds after startup, and a first-navigation
+    // gate would let that second one land back on the workspace overview.
+    if (!options?.exactView) {
+        Object.assign(viewLocation, resolveSingleIntegrationOverride(viewLocation, StateMachine.context()));
+    }
     const projectPath = viewLocation.projectPath || StateMachine.context().projectPath;
     const { orgName, packageName } = getOrgAndPackageName(StateMachine.context().projectInfo, projectPath);
     viewLocation.org = orgName;

--- a/packages/ballerina-extension/src/stateMachine.ts
+++ b/packages/ballerina-extension/src/stateMachine.ts
@@ -1030,14 +1030,20 @@ export function openView(
     // workspace overview. Applied to every navigation, not just the first: the project explorer
     // re-navigates once its tree finishes loading, seconds after startup, and a first-navigation
     // gate would let that second one land back on the workspace overview.
-    if (!options?.exactView) {
-        Object.assign(viewLocation, resolveSingleIntegrationOverride(viewLocation, StateMachine.context()));
-    }
-    const projectPath = viewLocation.projectPath || StateMachine.context().projectPath;
+    //
+    // The override REPLACES the location rather than merging into it. The fields a redirected
+    // navigation carried describe a target that no longer applies, and `identifier` with
+    // `artifactType` would survive onto the overview's history entry and send `updateView`
+    // hunting for an artifact that this view does not have.
+    const singleIntegrationOverride = options?.exactView
+        ? undefined
+        : resolveSingleIntegrationOverride(viewLocation, StateMachine.context());
+    const location = singleIntegrationOverride ?? viewLocation;
+    const projectPath = location.projectPath || StateMachine.context().projectPath;
     const { orgName, packageName } = getOrgAndPackageName(StateMachine.context().projectInfo, projectPath);
-    viewLocation.org = orgName;
-    viewLocation.package = packageName;
-    stateService.send({ type: type, viewLocation: viewLocation });
+    location.org = orgName;
+    location.package = packageName;
+    stateService.send({ type: type, viewLocation: location });
 }
 
 export function updateView(refreshTreeView?: boolean, updatedIdentifier?: string) {

--- a/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
+++ b/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
@@ -75,6 +75,13 @@ describe("getSoleIntegration", () => {
         expect(getSoleIntegration(workspaceOf(pkg("utils", true)))).toBeUndefined();
         expect(getSoleIntegration(undefined)).toBeUndefined();
     });
+
+    // `projectPath` is optional on ProjectStructure. The package overview resolves its contents
+    // by path, so redirecting to a pathless package would hang on a spinner forever — worse than
+    // the one-item list it replaced.
+    it("returns nothing for a sole integration with no project path", () => {
+        expect(getSoleIntegration(workspaceOf({ ...pkg("orders"), projectPath: undefined }))).toBeUndefined();
+    });
 });
 
 describe("resolveSingleIntegrationOverride", () => {

--- a/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
+++ b/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
@@ -17,11 +17,13 @@
  */
 
 import type {
+    DIRECTORY_MAP as DirectoryMap,
     MACHINE_VIEW as MachineView,
     ProjectStructure,
     ProjectStructureResponse,
     VisualizerLocation,
 } from "@wso2/ballerina-core";
+import type { NodePosition } from "@wso2/syntax-tree";
 
 // The real barrel pulls in a WebSocket LS client that jest cannot load, so stub it. The view
 // names must match the real enum values — the assertions below compare against them.
@@ -30,9 +32,10 @@ const MACHINE_VIEW = {
     WorkspaceOverview: "Workspace Overview",
     ServiceDesigner: "Service Designer",
 } as unknown as typeof MachineView;
+const DIRECTORY_MAP = { FUNCTION: "FUNCTION" } as unknown as typeof DirectoryMap;
 jest.mock("@wso2/ballerina-core", () => ({
     MACHINE_VIEW,
-    DIRECTORY_MAP: {},
+    DIRECTORY_MAP,
     EVENT_TYPE: {},
     FOCUS_FLOW_DIAGRAM_VIEW: {},
     isSamePath: (a: string, b: string) => a === b,
@@ -91,11 +94,22 @@ describe("resolveSingleIntegrationOverride", () => {
     // Both shapes a navigation can take, since the caller cannot tell them apart: the project
     // explorer names the workspace overview outright, other entry points send a bare location
     // and let `findView` resolve it.
+    //
+    // `toEqual(expected)` is also asserting what the redirect DROPS, and that is load-bearing:
+    // `openView` replaces the caller's location with this one, so a field missing here is a
+    // field that does not reach the state machine. The `groupId` position mirrors the clause in
+    // `findView` (stateMachine.ts) that sends such a navigation to the workspace overview —
+    // `groupId` is not on `NodePosition`, so nothing but this test pins the two together.
     it.each<[string, VisualizerLocation]>([
         ["an explicit workspace overview", { view: MACHINE_VIEW.WorkspaceOverview }],
         ["a bare navigation with no view", {}],
         ["a bare navigation carrying only a document", { documentUri: "/workspace/orders/main.bal" }],
-    ])("redirects %s to the sole integration", (_label, viewLocation) => {
+        ["a bare navigation carrying a groupId position", { position: { groupId: "g1" } as unknown as NodePosition }],
+        [
+            "a bare navigation carrying artifact fields",
+            { documentUri: "/workspace/orders/main.bal", identifier: "greet", artifactType: DIRECTORY_MAP.FUNCTION },
+        ],
+    ])("redirects %s to the sole integration, dropping the rest", (_label, viewLocation) => {
         expect(resolveSingleIntegrationOverride(viewLocation, soleIntegration)).toEqual(expected);
     });
 
@@ -108,7 +122,7 @@ describe("resolveSingleIntegrationOverride", () => {
     });
 
     it("names the package it redirects to — the overview renders nothing without one", () => {
-        expect(resolveSingleIntegrationOverride({}, soleIntegration).projectPath).toBeTruthy();
+        expect(resolveSingleIntegrationOverride({}, soleIntegration)?.projectPath).toBeTruthy();
     });
 
     it("leaves every navigation alone outside a single-integration workspace", () => {

--- a/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
+++ b/packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {
+    MACHINE_VIEW as MachineView,
+    ProjectStructure,
+    ProjectStructureResponse,
+    VisualizerLocation,
+} from "@wso2/ballerina-core";
+
+// The real barrel pulls in a WebSocket LS client that jest cannot load, so stub it. The view
+// names must match the real enum values — the assertions below compare against them.
+const MACHINE_VIEW = {
+    PackageOverview: "Overview",
+    WorkspaceOverview: "Workspace Overview",
+    ServiceDesigner: "Service Designer",
+} as unknown as typeof MachineView;
+jest.mock("@wso2/ballerina-core", () => ({
+    MACHINE_VIEW,
+    DIRECTORY_MAP: {},
+    EVENT_TYPE: {},
+    FOCUS_FLOW_DIAGRAM_VIEW: {},
+    isSamePath: (a: string, b: string) => a === b,
+}));
+
+jest.mock("../stateMachine", () => ({
+    StateMachine: { context: jest.fn() },
+    openView: jest.fn(),
+}));
+
+import { getSoleIntegration, resolveSingleIntegrationOverride } from "../utils/state-machine-utils";
+
+const WORKSPACE_ROOT = "/workspace";
+
+function pkg(name: string, isLibrary = false): ProjectStructure {
+    return {
+        projectName: name,
+        projectPath: `${WORKSPACE_ROOT}/${name}`,
+        isLibrary,
+        directoryMap: {} as ProjectStructure["directoryMap"],
+    };
+}
+
+function workspaceOf(...projects: ProjectStructure[]): ProjectStructureResponse {
+    return { workspaceName: "orders", workspacePath: WORKSPACE_ROOT, projects };
+}
+
+describe("getSoleIntegration", () => {
+    it("returns the only integration of a single-integration workspace", () => {
+        expect(getSoleIntegration(workspaceOf(pkg("orders")))?.projectPath).toBe(`${WORKSPACE_ROOT}/orders`);
+    });
+
+    it("returns nothing once there is more than one package to choose between", () => {
+        expect(getSoleIntegration(workspaceOf(pkg("orders"), pkg("shipping")))).toBeUndefined();
+        expect(getSoleIntegration(workspaceOf(pkg("orders"), pkg("utils", true)))).toBeUndefined();
+    });
+
+    it("returns nothing when the workspace has no integration to land on", () => {
+        expect(getSoleIntegration(workspaceOf())).toBeUndefined();
+        expect(getSoleIntegration(workspaceOf(pkg("utils", true)))).toBeUndefined();
+        expect(getSoleIntegration(undefined)).toBeUndefined();
+    });
+});
+
+describe("resolveSingleIntegrationOverride", () => {
+    const soleIntegration = { workspacePath: WORKSPACE_ROOT, projectStructure: workspaceOf(pkg("orders")) };
+    const expected = { view: MACHINE_VIEW.PackageOverview, projectPath: `${WORKSPACE_ROOT}/orders` };
+
+    // Both shapes a navigation can take, since the caller cannot tell them apart: the project
+    // explorer names the workspace overview outright, other entry points send a bare location
+    // and let `findView` resolve it.
+    it.each<[string, VisualizerLocation]>([
+        ["an explicit workspace overview", { view: MACHINE_VIEW.WorkspaceOverview }],
+        ["a bare navigation with no view", {}],
+        ["a bare navigation carrying only a document", { documentUri: "/workspace/orders/main.bal" }],
+    ])("redirects %s to the sole integration", (_label, viewLocation) => {
+        expect(resolveSingleIntegrationOverride(viewLocation, soleIntegration)).toEqual(expected);
+    });
+
+    it.each<[string, VisualizerLocation]>([
+        ["a view other than the workspace overview", { view: MACHINE_VIEW.ServiceDesigner }],
+        ["a navigation that already names a package", { projectPath: `${WORKSPACE_ROOT}/orders` }],
+        ["a navigation resolving an artifact position", { position: { startLine: 1, startColumn: 0, endLine: 2, endColumn: 0 } }],
+    ])("leaves %s alone", (_label, viewLocation) => {
+        expect(resolveSingleIntegrationOverride(viewLocation, soleIntegration)).toBeUndefined();
+    });
+
+    it("names the package it redirects to — the overview renders nothing without one", () => {
+        expect(resolveSingleIntegrationOverride({}, soleIntegration).projectPath).toBeTruthy();
+    });
+
+    it("leaves every navigation alone outside a single-integration workspace", () => {
+        const multi = { workspacePath: WORKSPACE_ROOT, projectStructure: workspaceOf(pkg("orders"), pkg("shipping")) };
+        expect(resolveSingleIntegrationOverride({ view: MACHINE_VIEW.WorkspaceOverview }, multi)).toBeUndefined();
+        expect(resolveSingleIntegrationOverride({}, multi)).toBeUndefined();
+        expect(
+            resolveSingleIntegrationOverride({}, { projectPath: "/standalone", projectStructure: workspaceOf(pkg("standalone")) })
+        ).toBeUndefined();
+    });
+});

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -31,13 +31,18 @@ import path from "path";
 /**
  * The single integration a workspace holds, or undefined when it holds anything else.
  *
- * Libraries deliberately do not qualify: a workspace whose only package is a library still
- * needs the workspace overview, which is the only surface offering to add the first
- * integration.
+ * Cardinality counts packages, not integrations: a workspace pairing one integration with a
+ * library has two things to show, and only the workspace overview shows both. A library-only
+ * workspace is excluded for the same reason — that overview is the sole surface offering to add
+ * the first integration.
+ *
+ * A package with no `projectPath` does not qualify either. The package overview resolves its
+ * contents by path, so redirecting to one without a path would replace the list with a view
+ * that can never finish loading.
  */
 export function getSoleIntegration(projectStructure?: ProjectStructureResponse): ProjectStructure | undefined {
     const projects = projectStructure?.projects ?? [];
-    if (projects.length !== 1 || projects[0].isLibrary) {
+    if (projects.length !== 1 || projects[0].isLibrary || !projects[0].projectPath) {
         return undefined;
     }
     return projects[0];

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { DIRECTORY_MAP, EVENT_TYPE, FOCUS_FLOW_DIAGRAM_VIEW, HistoryEntry, isSamePath, MACHINE_VIEW, ProjectStructureArtifactResponse, SyntaxTreeResponse, UpdatedArtifactsResponse } from "@wso2/ballerina-core";
+import { DIRECTORY_MAP, EVENT_TYPE, FOCUS_FLOW_DIAGRAM_VIEW, HistoryEntry, isSamePath, MACHINE_VIEW, ProjectStructure, ProjectStructureArtifactResponse, ProjectStructureResponse, SyntaxTreeResponse, UpdatedArtifactsResponse, VisualizerLocation } from "@wso2/ballerina-core";
 import { NodePosition, STKindChecker, STNode, traversNode } from "@wso2/syntax-tree";
 import { StateMachine, openView } from "../stateMachine";
 import { Uri } from "vscode";
@@ -27,6 +27,53 @@ import { FindConstructByIndexVisitor } from "./history/find-construct-by-index-v
 import { getConstructBodyString } from "./history/util";
 import { extension } from "../BalExtensionContext";
 import path from "path";
+
+/**
+ * The single integration a workspace holds, or undefined when it holds anything else.
+ *
+ * Libraries deliberately do not qualify: a workspace whose only package is a library still
+ * needs the workspace overview, which is the only surface offering to add the first
+ * integration.
+ */
+export function getSoleIntegration(projectStructure?: ProjectStructureResponse): ProjectStructure | undefined {
+    const projects = projectStructure?.projects ?? [];
+    if (projects.length !== 1 || projects[0].isLibrary) {
+        return undefined;
+    }
+    return projects[0];
+}
+
+/**
+ * The package overview a navigation should be redirected to, or undefined to leave it alone.
+ *
+ * A workspace overview listing one integration is a list with nothing to choose from, so every
+ * route to it opens that integration instead. Two shapes reach it and both redirect: an explicit
+ * `view: WorkspaceOverview`, and a bare navigation with no view at all (which `findView` would
+ * otherwise resolve to it). Navigations that already name a package, or that carry an artifact
+ * position to resolve, are left alone.
+ *
+ * Back is unaffected — `goBack` replays history through `updateView` and never reaches the
+ * `openView` call site that applies this.
+ */
+export function resolveSingleIntegrationOverride(
+    viewLocation: VisualizerLocation,
+    context: Pick<VisualizerLocation, "workspacePath" | "projectPath" | "projectStructure">
+): VisualizerLocation | undefined {
+    if (viewLocation.projectPath || !context.workspacePath) {
+        return undefined;
+    }
+    const isBareNavigation =
+        !viewLocation.view &&
+        !context.projectPath &&
+        (!viewLocation.position || "groupId" in viewLocation.position);
+    if (viewLocation.view !== MACHINE_VIEW.WorkspaceOverview && !isBareNavigation) {
+        return undefined;
+    }
+    const soleIntegration = getSoleIntegration(context.projectStructure);
+    return soleIntegration
+        ? { view: MACHINE_VIEW.PackageOverview, projectPath: soleIntegration.projectPath }
+        : undefined;
+}
 
 export async function getView(documentUri: string, position: NodePosition, projectPath: string): Promise<HistoryEntry> {
     const haveTreeData = !!StateMachine.context().projectStructure;

--- a/packages/ballerina-extension/src/utils/state-machine-utils.ts
+++ b/packages/ballerina-extension/src/utils/state-machine-utils.ts
@@ -57,6 +57,11 @@ export function getSoleIntegration(projectStructure?: ProjectStructureResponse):
  * otherwise resolve to it). Navigations that already name a package, or that carry an artifact
  * position to resolve, are left alone.
  *
+ * The returned location is the whole location, not a patch: `openView` replaces the caller's
+ * with it, so anything the redirected navigation carried — `documentUri`, `identifier`,
+ * `artifactType`, a `groupId` position — is deliberately dropped. All of it describes a target
+ * that no longer applies once the destination is the package overview.
+ *
  * Back is unaffected — `goBack` replays history through `updateView` and never reaches the
  * `openView` call site that applies this.
  */


### PR DESCRIPTION
## Purpose
> Opening a project that contains a single integration lands on the workspace overview — a list with one item on it. The one thing worth reaching is one click behind a screen that has nothing to choose from, on every window open.
Fixes: https://github.com/wso2/product-integrator/issues/2052

https://github.com/user-attachments/assets/e2db167c-04ab-4a77-ac1e-6d10b7c1e5b5



## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Open such a project directly on that integration's overview. Projects with more than one package are unchanged, and the workspace overview stays reachable — this removes a click on the way in, it does not remove the screen.

## Approach
> Describe how you are implementing the solutions.

The redirect lives in `openView` rather than at each call site. That is the only place that can put `projectPath` into the machine context — which is where the webview reads the package an overview is for — and it means a navigation route added later inherits the behaviour instead of quietly reintroducing the one-item list. It applies to every navigation, not only the first: the project explorer re-navigates once its tree finishes loading, seconds after startup, and a first-navigation gate let that second one land back on the workspace overview.

Two shapes reach the workspace overview and both redirect: an explicit `view: WorkspaceOverview` (the project explorer's Open Overview), and a bare navigation with no view at all, which `findView` would otherwise resolve to it. Navigations that already name a package, or that carry an artifact position to resolve, are left alone.

The rule itself is `resolveSingleIntegrationOverride`, a pure function in `state-machine-utils`. It returns the whole location and `openView` swaps it in, so anything the redirected navigation carried — `documentUri`, `identifier`, `artifactType`, a `groupId` position — is dropped. All of it describes a target that stopped applying once the destination became the package overview, and `identifier` with `artifactType` would otherwise survive onto the overview's history entry and send `updateView` hunting for an artifact this view does not have.

**What does not redirect, and why.** The workspace overview is a real workspace-level surface: the workspace README, renaming the project, Add Integration or Library, deploy-all, ICP enable-all. None of that exists anywhere else in the webview. So the one-item list is an unhelpful thing to land *on*, not an unhelpful thing to *have*, and two cases keep it deliberately:

| Workspace | Lands on |
|---|---|
| `orders` | `orders` overview |
| `orders` + `shipping` | workspace overview |
| `orders` + `utils` (library) | workspace overview |
| `utils` (library) only | workspace overview |

- **A library alongside an integration counts.** Cardinality counts packages, not integrations — two packages means two things worth showing, and only the workspace overview shows both. A library-only workspace is excluded for the same reason: that overview is the sole surface offering to add the first integration.
- **Home opts out**, via a new `exactView` flag on `openView`, and is the only caller passing it. Home is the way back up to the workspace; redirecting it would land on the page the user is already looking at, and since `MainPanel` keys its remount on view/identifier/documentUri/projectPath — all unchanged — the button rendered nothing and looked dead. Keeping the escape hatch was preferred over hiding Home, which would cost access to everything listed above in exactly the workspaces this change targets.
- **A package with no `projectPath` does not qualify.** The field is optional on `ProjectStructure` and the package overview resolves its contents by path, so redirecting to a pathless package would replace the list with a view that never finishes loading.

Back is unaffected: `goBack` replays history through `updateView` and never reaches `openView`.

## UI Component Development
- [x] Added reusable UI components to the ui-toolkit — N/A, no new UI. This changes which existing view the window opens on; no component was added or altered.
- [x] Use ui-toolkit components wherever possible — N/A, as above.
- [x] Matches with the native VSCode look and feel — unchanged; both destinations are existing views.

## User stories
> Summary of user stories addressed by this change

As a developer whose project contains one integration, I want the window to open on that integration so I can start working without clicking through a list of one.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

A project containing a single integration now opens directly on that integration's overview instead of the project overview. Projects with more than one integration are unchanged, and the project overview remains available from the Home button.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR.

N/A — no documented behaviour changes. The screens, their contents and the navigation controls are all as before; only the view the window opens on differs, for a single-integration project.

## Training
N/A

## Certification
N/A — no user-facing concept or workflow is added or removed; this changes a default landing view.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `packages/ballerina-extension/src/test-support/singleIntegrationLanding.test.ts` — 14 cases over `getSoleIntegration` and `resolveSingleIntegrationOverride`, covering the rule from both sides: every navigation shape that must redirect (explicit workspace overview, bare, bare carrying a document, bare carrying a `groupId` position, bare carrying artifact fields) and every shape that must be left alone (another view, one already naming a package, one resolving an artifact position). Also the workspace shapes that disqualify — multi-package, library alongside integration, library-only, empty, absent structure, and a sole integration with no `projectPath` — plus the invariant that a redirect always names a package, since the overview renders nothing without one. Full host suite: 112 passing.
 - Integration tests
   > None added. The behaviour is a navigation default in the extension host, exercised by the unit tests above. Labelled `Checks/Run Ballerina UI Tests` so the existing UI suite runs against it.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript only, no Java changed
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no persisted state. Adding a second integration makes the redirect stop firing on its own; nothing to clear.

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested

macOS 15 (darwin 25.5.0), VS Code, Node 20. Verified by hand in a single-integration workspace: window opens on the integration overview and stays there (an earlier revision was overridden a few seconds in by the explorer's second navigation), Home reaches the workspace overview, Back behaves as before.

## Learning
> Describe the research phase.

Three producers of the workspace overview had to be found before the change would hold: an explicit `view: WorkspaceOverview` from callers, `findView`'s fallback when no package is selected, and `showView`'s no-view fallbacks. An earlier revision missed the first — the project explorer's Open Overview names the view outright — so nothing changed at startup. A later one scoped the redirect to the first navigation and was overridden seconds later by the explorer re-navigating once its tree loaded. Handling the shared choke point in `openView` covers all of them.

Worth recording for the next person: `goBack` does not route through `openView` at all, so navigation changes made there cannot affect Back — which is what identified a stale-`projectPath` write in the `webViewLoaded` assign, since that broke Home and Back together, as the cause of a regression rather than the redirect.
