### PR TITLE
Revert "Enable e2e test and address review suggestions of #748"

### DIFF
--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
@@ -112,7 +112,7 @@ export default function createTests() {
                 }
             });
             await artifactWebView.getByRole('button', { name: 'Save' }).click();
-            await page.page.waitForTimeout(3000);
+            await page.page.waitForTimeout(1000);
 
             // 17. Add if condition to check if variables are equal
             await diagram.clickHoverAddButtonByIndex(2);

--- a/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
+++ b/packages/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
@@ -203,7 +203,7 @@ test.describe('Ballerina E2E Group 4', { tag: '@group4' }, async () => {
     test.describe.skip(inlineDataMapper); // Failing due to a issue
 
     // <----Diagram Test---->
-    test.describe(diagram);
+//     test.describe(diagram);
 
     // <----Test Explorer Test---->
     test.describe(testExplorer);

--- a/packages/ballerina-extension/src/core/extended-language-client.ts
+++ b/packages/ballerina-extension/src/core/extended-language-client.ts
@@ -317,6 +317,7 @@ import { debug, handlePullModuleProgress } from "../utils";
 import { CMP_LS_CLIENT_COMPLETIONS, CMP_LS_CLIENT_DIAGNOSTICS, getMessageObject, sendTelemetryEvent, TM_EVENT_LANG_CLIENT } from "../features/telemetry";
 import { DefinitionParams, InitializeParams, InitializeResult, Location, LocationLink, TextDocumentPositionParams } from 'vscode-languageserver-protocol';
 import { updateProjectArtifacts } from "../utils/project-artifacts";
+import { whenSourceUpdatesSettle } from "../utils/source-update-barrier";
 import { RPCLayer } from "../../src/RPCLayer";
 import { VisualizerWebview } from "../../src/views/visualizer/webview";
 
@@ -1191,6 +1192,13 @@ export class ExtendedLangClient extends LanguageClient implements ExtendedLangCl
     // <------------ BI APIS START --------------->
 
     async getFlowModel(params: BIFlowModelRequest): Promise<BIFlowModelResponse> {
+        // Callers turn this model's line ranges into positions they replay to the LS later — the
+        // diagram's "+" insertion targets above all — so the model must not be built from a file
+        // caught mid-write. `updateSourceCode` applies the LS text edits unformatted first and
+        // formats in a second document version; a read landing in between yields positions that
+        // no longer point where they did once the file is formatted. Gated here rather than per
+        // caller so every path (BI diagram, data mapper, anything added later) is covered.
+        await whenSourceUpdatesSettle();
         return this.sendRequest<BIFlowModelResponse>(EXTENDED_APIS.BI_FLOW_MODEL, params);
     }
 

--- a/packages/ballerina-extension/src/test-support/sourceUpdateBarrier.test.ts
+++ b/packages/ballerina-extension/src/test-support/sourceUpdateBarrier.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// L1: the barrier that keeps flow-model reads off the unformatted document `updateSourceCode`
+// leaves behind between its raw text edit and the follow-up format.
+
+import {
+    beginSourceUpdate,
+    isSourceUpdateInFlight,
+    SourceUpdateHandle,
+    whenSourceUpdatesSettle,
+} from "../utils/source-update-barrier";
+
+/** Resolves after the pending microtasks and one macrotask, so a settled await can land. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("source update barrier", () => {
+    let open: SourceUpdateHandle[] = [];
+
+    /** Starts an update and remembers it, so afterEach can drain a case that failed midway. */
+    const start = (): SourceUpdateHandle => {
+        const handle = beginSourceUpdate();
+        open.push(handle);
+        return handle;
+    };
+
+    afterEach(() => {
+        open.forEach((handle) => handle.done());
+        open = [];
+        expect(isSourceUpdateInFlight()).toBe(false);
+    });
+
+    it("resolves immediately when nothing is in flight", async () => {
+        let settled = false;
+        void whenSourceUpdatesSettle().then(() => { settled = true; });
+        await flush();
+        expect(settled).toBe(true);
+    });
+
+    it("holds a waiter for the whole update and releases it at the end", async () => {
+        const update = start();
+
+        let settled = false;
+        void whenSourceUpdatesSettle().then(() => { settled = true; });
+        await flush();
+        expect(settled).toBe(false);
+
+        update.done();
+        await flush();
+        expect(settled).toBe(true);
+    });
+
+    it("waits for the last of several overlapping updates", async () => {
+        const first = start();
+        const second = start();
+
+        let settled = false;
+        void whenSourceUpdatesSettle().then(() => { settled = true; });
+
+        first.done();
+        await flush();
+        expect(settled).toBe(false);
+
+        second.done();
+        await flush();
+        expect(settled).toBe(true);
+    });
+
+    it("does not release a waiter into a mid-write state when updates are back to back", async () => {
+        const first = start();
+
+        let settled = false;
+        void whenSourceUpdatesSettle().then(() => { settled = true; });
+
+        // The next save starts in the same tick the previous one ends — the sequence a diagram
+        // refresh lands in when a form is submitted right after the last one finished.
+        first.done();
+        const second = start();
+        await flush();
+        expect(settled).toBe(false);
+
+        second.done();
+        await flush();
+        expect(settled).toBe(true);
+    });
+
+    it("treats a repeated done() as a no-op, so an early release plus a finally net is safe", async () => {
+        const update = start();
+        const concurrent = start();
+
+        update.done();
+        update.done(); // the `finally` net after the write already released itself
+        expect(isSourceUpdateInFlight()).toBe(true); // `concurrent` must still hold it
+
+        let settled = false;
+        void whenSourceUpdatesSettle().then(() => { settled = true; });
+        await flush();
+        expect(settled).toBe(false);
+
+        concurrent.done();
+        await flush();
+        expect(settled).toBe(true);
+    });
+
+    it("gives up after the timeout so a stuck write delays a read instead of withholding it", async () => {
+        start(); // never released within the test's window
+
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => { });
+        try {
+            let settled = false;
+            void whenSourceUpdatesSettle(20).then(() => { settled = true; });
+
+            await flush();
+            expect(settled).toBe(false);
+
+            await new Promise((resolve) => setTimeout(resolve, 40));
+            expect(settled).toBe(true);
+            expect(warn).toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it("bounds the whole wait, not each update, when writes run back to back", async () => {
+        let current = start();
+        // Hand off to a new update every 10ms: each one alone is short, but the chain outlives
+        // the 30ms budget, which a per-update timeout would never notice.
+        const chain = setInterval(() => {
+            const next = start();
+            current.done();
+            current = next;
+        }, 10);
+
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => { });
+        try {
+            let settled = false;
+            void whenSourceUpdatesSettle(30).then(() => { settled = true; });
+
+            await new Promise((resolve) => setTimeout(resolve, 60));
+            expect(settled).toBe(true);
+            expect(warn).toHaveBeenCalled();
+        } finally {
+            clearInterval(chain);
+            warn.mockRestore();
+        }
+    });
+});

--- a/packages/ballerina-extension/src/utils/source-update-barrier.ts
+++ b/packages/ballerina-extension/src/utils/source-update-barrier.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// A source update is not one atomic write: `updateSourceCode` applies the LS text edits
+// verbatim first — they are unindented, the LS relies on the follow-up format — and formats
+// the document in a second version. In between, the file holds text whose positions do not
+// match the final source.
+//
+// Readers that turn document positions into durable UI state must not sample that state. The
+// flow diagram is the sharp case: it builds its "+" insertion targets from the model's line
+// ranges and replays them to the LS later, so a model read mid-write hands back a position that
+// points somewhere else once the file is formatted.
+//
+// Scope: this is a barrier on *when* a read runs, not on which file it reads. It is deliberately
+// coarse — matching a reader's path against the write's would silently stop gating on any path
+// shape the comparison did not anticipate, which is the failure mode being fixed. Writes are
+// short and the wait is capped, so the coarseness costs little.
+
+/** Ceiling on how long a reader waits before giving up and reading anyway. */
+export const MAX_SOURCE_UPDATE_WAIT_MS = 5000;
+
+let inFlight = 0;
+let settled: Promise<void> = Promise.resolve();
+let release: () => void = () => { };
+
+/** A single in-progress update. {@link SourceUpdateHandle.done} is idempotent. */
+export interface SourceUpdateHandle {
+    /**
+     * Declares this update finished. Safe to call more than once — a caller can release early,
+     * as soon as the file reaches its final shape, and still keep a `finally` net for the
+     * paths that return or throw before that point.
+     */
+    done(): void;
+}
+
+/**
+ * Marks the start of a source update. Returns the handle that ends it; because only the handle
+ * can end it, an update cannot be released by anyone else or released twice.
+ */
+export function beginSourceUpdate(): SourceUpdateHandle {
+    if (inFlight++ === 0) {
+        settled = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+    }
+    let finished = false;
+    return {
+        done(): void {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            if (--inFlight === 0) {
+                release();
+            }
+        },
+    };
+}
+
+/**
+ * Resolves once no source update is mid-write, so a caller reads a file only in a state that
+ * matches what the LS reports from there on.
+ *
+ * Bounded by `timeoutMs` over the whole wait, not per update: individual updates are bounded
+ * (each resolves, rejects, or times out), but they can run back to back, and a read is worth
+ * delaying — not withholding. On expiry the read proceeds against whatever is on disk, which
+ * is the pre-barrier behaviour.
+ */
+export async function whenSourceUpdatesSettle(timeoutMs: number = MAX_SOURCE_UPDATE_WAIT_MS): Promise<void> {
+    if (inFlight === 0) {
+        // Overwhelmingly the common case — take it without allocating a timer.
+        return;
+    }
+
+    let timer: NodeJS.Timeout | undefined;
+    const expired = new Promise<"expired">((resolve) => {
+        timer = setTimeout(() => resolve("expired"), timeoutMs);
+    });
+    try {
+        // Loop rather than await once: a waiter released by one update can be resumed after the
+        // next one has already started writing, which is the same mid-write state to avoid.
+        while (inFlight > 0) {
+            const outcome = await Promise.race([settled.then(() => "settled" as const), expired]);
+            if (outcome === "expired") {
+                console.warn(
+                    `>>> source update did not settle within ${timeoutMs}ms; reading anyway ` +
+                    `(positions may be mid-write)`
+                );
+                return;
+            }
+        }
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/** True while at least one source update is applying. Exposed for tests and diagnostics. */
+export function isSourceUpdateInFlight(): boolean {
+    return inFlight > 0;
+}

--- a/packages/ballerina-extension/src/utils/source-utils.ts
+++ b/packages/ballerina-extension/src/utils/source-utils.ts
@@ -23,6 +23,7 @@ import { Uri } from 'vscode';
 import { ArtifactData, EVENT_TYPE, MACHINE_VIEW, ProjectStructureArtifactResponse, STModification, TextEdit } from '@wso2/ballerina-core';
 import { openView, StateMachine, undoRedoManager } from '../stateMachine';
 import { ArtifactsUpdated, ArtifactNotificationHandler } from './project-artifacts-handler';
+import { beginSourceUpdate, SourceUpdateHandle } from './source-update-barrier';
 import { existsSync, writeFileSync, mkdirSync } from 'fs';
 import * as path from 'path';
 import { notifyCurrentWebview } from '../RPCLayer';
@@ -49,6 +50,23 @@ export interface UpdateSourceCodeRequest {
 }
 
 export async function updateSourceCode(updateSourceCodeRequest: UpdateSourceCodeRequest, isChangeFromHelperPane?: boolean): Promise<ProjectStructureArtifactResponse[]> {
+    // Held across the raw edit, the format, and the wait in between, so readers that gate on
+    // `whenSourceUpdatesSettle` never see the unformatted intermediate document. The write
+    // releases it as soon as the file is formatted; this is the net for the paths that return
+    // or throw before reaching that point.
+    const update = beginSourceUpdate();
+    try {
+        return await applySourceCodeUpdate(updateSourceCodeRequest, update, isChangeFromHelperPane);
+    } finally {
+        update.done();
+    }
+}
+
+async function applySourceCodeUpdate(
+    updateSourceCodeRequest: UpdateSourceCodeRequest,
+    update: SourceUpdateHandle,
+    isChangeFromHelperPane?: boolean
+): Promise<ProjectStructureArtifactResponse[]> {
     const skipUndoRedoStack = updateSourceCodeRequest.artifactData?.artifactType === "CONFIGURABLE";
     // Capture the current undo/redo manager instance for the whole operation. The
     // module-level `undoRedoManager` is reassigned to a fresh instance when the
@@ -222,6 +240,15 @@ export async function updateSourceCode(updateSourceCodeRequest: UpdateSourceCode
             }
 
             await workspace.applyEdit(formattedWorkspaceEdit);
+
+            // The document has reached its final shape, so readers gated on the barrier can go.
+            // Everything below is bookkeeping — dependency resolution, then waiting out the
+            // recompile for the artifact notification — and holding them through a compile they
+            // no longer need would delay a diagram refresh for seconds. Safe to release before
+            // the LS has caught up: the client sends `didChange` from the change event that
+            // `applyEdit` awaits, so it is on the wire ahead of any request a released reader
+            // sends (no `didChange` middleware or sync delay is configured, see core/extension).
+            update.done();
 
             // Handle missing dependencies after all changes are applied
             if (updateSourceCodeRequest.resolveMissingDependencies) {

--- a/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
+++ b/packages/ballerina-language-server/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
@@ -18,8 +18,6 @@
 
 package io.ballerina.flowmodelgenerator.core;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -110,18 +108,6 @@ public class AvailableNodesGenerator {
     private static final String BALLERINAX = "ballerinax";
     private static final String TEST_MODULE_PREFIX = "test";
     private static final String TEST_CONFIG_ANNOTATION = "Config";
-
-    /**
-     * Which workflow artifacts each package declares, keyed by the package instance.
-     *
-     * <p>Weak keys make Caffeine compare by identity, which is what gives this its invalidation:
-     * every edit rebuilds the package ({@code Package.Modifier} hands the project a new instance),
-     * so a changed source is always a new key and the scan reruns. A superseded package is only
-     * held here weakly, so it is collected with the entry rather than kept alive by it. The size
-     * bound is a backstop for the handful of packages a session has open at once.
-     */
-    private static final Cache<Package, WorkflowArtifacts> WORKFLOW_ARTIFACTS_CACHE =
-            Caffeine.newBuilder().weakKeys().maximumSize(16).build();
 
     public AvailableNodesGenerator(SemanticModel semanticModel, Document document, Package pkg, Path filePath) {
         this.rootBuilder = new Category.Builder(null).name(Category.Name.ROOT);
@@ -463,45 +449,28 @@ public class AvailableNodesGenerator {
      * Whether the package declares workflow functions and durable agents, scanned across every
      * module rather than the default one alone — a multi-module package whose workflows live
      * outside the default module would otherwise lose the whole Workflow category. Both answers
-     * come from one pass, memoized on this generator and, behind it, on the package itself.
-     *
-     * <p>The scan walks every module symbol, so its cost grows with the package. That is fine
-     * once per package version and wasteful once per palette open, which is what a
-     * generator-lifetime memo alone would give — a generator is built fresh for every request.
-     * {@link #WORKFLOW_ARTIFACTS_CACHE} carries the answer across opens instead, for as long as
-     * the package it was computed from is the current one.
+     * come from one pass, memoized for the lifetime of this generator (one palette open).
      *
      * @return the artifacts the package declares
      */
     private WorkflowArtifacts workflowArtifacts() {
-        if (this.workflowArtifacts == null) {
-            this.workflowArtifacts =
-                    WORKFLOW_ARTIFACTS_CACHE.get(this.pkg, AvailableNodesGenerator::scanWorkflowArtifacts);
+        if (this.workflowArtifacts != null) {
+            return this.workflowArtifacts;
         }
-        return this.workflowArtifacts;
-    }
-
-    /**
-     * Scans every module of the package for a {@code @workflow:Workflow} function and a
-     * module-level {@code workflow:DurableAgent}, resolving both against the semantic model so an
-     * aliased import prefix cannot change the answer.
-     *
-     * @param pkg the package to scan
-     * @return the artifacts the package declares
-     */
-    private static WorkflowArtifacts scanWorkflowArtifacts(Package pkg) {
         boolean hasWorkflows = false;
         boolean hasDurableAgents = false;
-        for (Module module : pkg.modules()) {
+        for (Module module : this.pkg.modules()) {
             for (Symbol symbol : module.getCompilation().getSemanticModel().moduleSymbols()) {
                 hasWorkflows = hasWorkflows || WorkflowUtil.isWorkflowFunction(symbol);
                 hasDurableAgents = hasDurableAgents || WorkflowUtil.isDurableAgentVariable(symbol);
                 if (hasWorkflows && hasDurableAgents) {
-                    return new WorkflowArtifacts(true, true);
+                    this.workflowArtifacts = new WorkflowArtifacts(true, true);
+                    return this.workflowArtifacts;
                 }
             }
         }
-        return new WorkflowArtifacts(hasWorkflows, hasDurableAgents);
+        this.workflowArtifacts = new WorkflowArtifacts(hasWorkflows, hasDurableAgents);
+        return this.workflowArtifacts;
     }
 
     private List<Item> getAiNodes(boolean disableBallerinaAiNodes) {


### PR DESCRIPTION
Reverts ballerina-platform/ballerina-vscode#812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Reverts the workflow and end-to-end test changes from pull request `#812`.
- Restores the diagram end-to-end test configuration.
- Removes the source-update barrier and related synchronization tests.
- Restores package-level workflow artifact caching in `AvailableNodesGenerator`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->