### PR TITLE
[Workflow] Fix pre-release testing bugs: duplicate connection options, stale activity list, broken Create New Type form

### DIFF
--- a/packages/ballerina-extension/src/utils/project-artifacts.ts
+++ b/packages/ballerina-extension/src/utils/project-artifacts.ts
@@ -572,8 +572,16 @@ function processDeletion(artifact: BaseArtifact, artifactCategoryKey: string, pr
         try {
             const projectPath = activeProjectPath;
             const project = projectStructure.projects.find(project => isSamePath(project.projectPath, projectPath));
-            project.directoryMap[mapping.mapKey] =
-                project.directoryMap[mapping.mapKey]?.filter(value => value.id !== artifact.id) ?? [];
+            // Deletion notifications carry only the artifact id (no type), so a category that fans out
+            // into multiple directory map keys cannot be disambiguated here. Sweep every key the
+            // category can produce; ids are unique within a category, so this is safe.
+            const mapKeys = artifactCategoryKey === ARTIFACT_TYPE.Workflows
+                ? [DIRECTORY_MAP.WORKFLOW, DIRECTORY_MAP.ACTIVITY]
+                : [mapping.mapKey];
+            for (const mapKey of mapKeys) {
+                project.directoryMap[mapKey] =
+                    project.directoryMap[mapKey]?.filter(value => value.id !== artifact.id) ?? [];
+            }
         } catch (error) {
             //TODO: Hack: Properly fix for the workspace scenario
             console.error(`Error processing deletion for artifact ${artifact.id} in category ${artifactCategoryKey}:`, error);

--- a/packages/ballerina-side-panel/src/components/editors/ConnectionEditor/ConnectionEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/ConnectionEditor/ConnectionEditor.tsx
@@ -16,11 +16,9 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import styled from "@emotion/styled";
-import { Codicon, LinkButton, ProgressRing } from "@wso2/ui-toolkit";
-import { AllowedConnector, AvailableNode, Category, CodeData, Item } from "@wso2/ballerina-core";
-import { useRpcContext } from "@wso2/ballerina-rpc-client";
+import { AllowedConnector } from "@wso2/ballerina-core";
 
 import { FormField } from "../../Form/types";
 import { useFormContext } from "../../../context";
@@ -53,35 +51,9 @@ const Description = styled.div`
     color: var(--vscode-descriptionForeground);
 `;
 
-const AddButtons = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    margin-top: 6px;
-`;
-
-// Recursively flatten search categories (which may nest Categories within their
-// items) down to AvailableNodes.
-const flattenAvailableNodes = (items: Item[] | undefined): AvailableNode[] => {
-    const out: AvailableNode[] = [];
-    for (const item of items ?? []) {
-        if ((item as Category).items) {
-            out.push(...flattenAvailableNodes((item as Category).items));
-        } else if ((item as AvailableNode).codedata) {
-            out.push(item as AvailableNode);
-        }
-    }
-    return out;
-};
-
 export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({ field }) => {
-    const { form, fileName, targetLineRange, onRequestCreateConnection } = useFormContext();
-    const { rpcClient } = useRpcContext();
+    const { form } = useFormContext();
     const { register, setValue, watch } = form;
-    const [loadingKey, setLoadingKey] = useState<string | null>(null);
-
-    const connectorKey = (c: AllowedConnector, i: number) =>
-        `${c.codedata?.module}-${c.codedata?.object}-${i}`;
 
     useEffect(() => {
         register(field.key, {
@@ -101,50 +73,6 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({ field }) => 
         field.onValueChange?.(val);
     };
 
-    const handleSaved = (variableName: string) => {
-        setValue(field.key, variableName, { shouldDirty: true, shouldValidate: true });
-        field.onValueChange?.(variableName);
-    };
-
-    const resolveAvailableNode = async (codedata: CodeData, label: string): Promise<AvailableNode> => {
-        const fallback: AvailableNode = {
-            codedata,
-            metadata: { label },
-            enabled: true,
-        } as AvailableNode;
-        try {
-            const response = await rpcClient.getBIDiagramRpcClient().search({
-                position: targetLineRange
-                    ? { startLine: targetLineRange.startLine, endLine: targetLineRange.endLine }
-                    : undefined,
-                filePath: fileName,
-                queryMap: { q: codedata.module ?? "", limit: 60 },
-                searchKind: "CONNECTOR",
-            });
-            const all = flattenAvailableNodes(response.categories as Item[]);
-            const match = all.find((n) =>
-                n.codedata?.org === codedata.org &&
-                n.codedata?.module === codedata.module &&
-                n.codedata?.object === codedata.object
-            );
-            return match ?? fallback;
-        } catch (err) {
-            console.error(">>> Connector lookup failed for inline create", err);
-            return fallback;
-        }
-    };
-
-    const handleAddNewClick = async (c: AllowedConnector, key: string) => {
-        if (!onRequestCreateConnection || !c.codedata) return;
-        setLoadingKey(key);
-        try {
-            const selectedConnector = await resolveAvailableNode(c.codedata as CodeData, c.addNewConnectionLabel);
-            onRequestCreateConnection({ selectedConnector, onSaved: handleSaved });
-        } finally {
-            setLoadingKey(null);
-        }
-    };
-
     return (
         <Container>
             <Label htmlFor={field.key}>
@@ -158,24 +86,6 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({ field }) => 
                 onChange={(val) => handleChange(val)}
                 nodeReferenceFilters={nodeReferenceFilters}
             />
-            {connectors.length > 0 && (
-                <AddButtons>
-                    {connectors.map((c, i) => {
-                        const key = connectorKey(c, i);
-                        const isLoading = loadingKey === key;
-                        return (
-                            <LinkButton
-                                key={key}
-                                onClick={() => !isLoading && handleAddNewClick(c, key)}
-                                sx={{ padding: "4px 6px", margin: 0, fontSize: "13px", opacity: isLoading ? 0.7 : 1 }}
-                            >
-                                {isLoading ? <ProgressRing sx={{ width: 12, height: 12 }} /> : <Codicon name="add" />}
-                                {c.addNewConnectionLabel}
-                            </LinkButton>
-                        );
-                    })}
-                </AddButtons>
-            )}
         </Container>
     );
 };

--- a/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NodeReferenceSelectEditor/NodeReferenceSelectEditor.tsx
+++ b/packages/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NodeReferenceSelectEditor/NodeReferenceSelectEditor.tsx
@@ -17,9 +17,18 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
-import { CodeData, SearchNodesQuery, SearchNodesTypeConstraint } from "@wso2/ballerina-core";
-import { Codicon, LinkButton } from "@wso2/ui-toolkit";
+import {
+    AllowedConnector,
+    AvailableNode,
+    Category,
+    CodeData,
+    Item,
+    SearchNodesQuery,
+    SearchNodesTypeConstraint,
+} from "@wso2/ballerina-core";
+import { Codicon, LinkButton, ProgressRing } from "@wso2/ui-toolkit";
 import { FormField } from "../../../Form/types";
 import { NodeReferenceSelect, NodeReferenceSelectItem } from "../../NodeReferenceSelect";
 import { useFormContext } from "../../../../context";
@@ -39,6 +48,27 @@ interface NodeReferenceSelectEditorProps {
     onChange: (value: string, cursorPosition: number) => void;
     nodeReferenceFilters?: NodeReferenceFilter[];
 }
+
+const AddButtons = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 6px;
+`;
+
+// Recursively flatten search categories (which may nest Categories within their
+// items) down to AvailableNodes.
+const flattenAvailableNodes = (items: Item[] | undefined): AvailableNode[] => {
+    const out: AvailableNode[] = [];
+    for (const item of items ?? []) {
+        if ((item as Category).items) {
+            out.push(...flattenAvailableNodes((item as Category).items));
+        } else if ((item as AvailableNode).codedata) {
+            out.push(item as AvailableNode);
+        }
+    }
+    return out;
+};
 
 function ensureValueInItems(
     items: NodeReferenceSelectItem[],
@@ -63,7 +93,8 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
     value, field, onChange, nodeReferenceFilters,
 }) => {
     const { rpcClient } = useRpcContext();
-    const { targetLineRange, fileName, onCreateNode } = useFormContext();
+    const { targetLineRange, fileName, onCreateNode, onRequestCreateConnection } = useFormContext();
+    const [loadingConnectorKey, setLoadingConnectorKey] = useState<string | null>(null);
 
     const searchNodesKind = field.codedata?.searchNodesKind;
     const targetType = field.codedata?.targetType as SearchNodesTypeConstraint | undefined;
@@ -145,7 +176,58 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
         fetchItems();
     }, [value]);
 
-    const showCreateNew = !!onCreateNode && !!searchNodesKind && field.editable && !field.actionCallback;
+    // A field carries at most one way to create the referenced node: explicit connector
+    // actions from the LS (`metadata.connectors`, e.g. "Add new HTTP connection") win over
+    // the generic "Create New <kind>" link derived from `searchNodesKind`.
+    const connectors: AllowedConnector[] = field.metadata?.connectors ?? [];
+    const showConnectorActions = connectors.length > 0;
+    const showCreateNew = !showConnectorActions && !!onCreateNode && !!searchNodesKind && field.editable && !field.actionCallback;
+
+    const connectorKey = (c: AllowedConnector, i: number) =>
+        `${c.codedata?.module}-${c.codedata?.object}-${i}`;
+
+    const resolveAvailableNode = async (codedata: CodeData, label: string): Promise<AvailableNode> => {
+        const fallback: AvailableNode = {
+            codedata,
+            metadata: { label },
+            enabled: true,
+        } as AvailableNode;
+        try {
+            const response = await rpcClient.getBIDiagramRpcClient().search({
+                position: targetLineRange
+                    ? { startLine: targetLineRange.startLine, endLine: targetLineRange.endLine }
+                    : undefined,
+                filePath: fileName,
+                queryMap: { q: codedata.module ?? "", limit: 60 },
+                searchKind: "CONNECTOR",
+            });
+            const all = flattenAvailableNodes(response.categories as Item[]);
+            const match = all.find((n) =>
+                n.codedata?.org === codedata.org &&
+                n.codedata?.module === codedata.module &&
+                n.codedata?.object === codedata.object
+            );
+            return match ?? fallback;
+        } catch (err) {
+            console.error(">>> Connector lookup failed for inline create", err);
+            return fallback;
+        }
+    };
+
+    const handleAddNewConnectorClick = async (c: AllowedConnector, key: string) => {
+        if (!onRequestCreateConnection || !c.codedata) return;
+        setLoadingConnectorKey(key);
+        try {
+            const selectedConnector = await resolveAvailableNode(c.codedata as CodeData, c.addNewConnectionLabel);
+            onRequestCreateConnection({
+                selectedConnector,
+                onSaved: (variableName: string) => onChange(variableName, variableName?.length),
+            });
+        } finally {
+            setLoadingConnectorKey(null);
+        }
+    };
+
     const agentCodeData = field.codedata?.data?.agent as CodeData | undefined;
     const creationCodeData = agentCodeData ?? (field.codedata?.data?.connection as CodeData | undefined);
     const createNewLabel = !showCreateNew
@@ -167,6 +249,24 @@ export const NodeReferenceSelectEditor: React.FC<NodeReferenceSelectEditorProps>
                 loading={loading}
                 onChange={(val) => onChange(val, val?.length)}
             />
+            {showConnectorActions && (
+                <AddButtons>
+                    {connectors.map((c, i) => {
+                        const key = connectorKey(c, i);
+                        const isLoading = loadingConnectorKey === key;
+                        return (
+                            <LinkButton
+                                key={key}
+                                onClick={() => !isLoading && handleAddNewConnectorClick(c, key)}
+                                sx={{ padding: "4px 6px", margin: 0, fontSize: "13px", opacity: isLoading ? 0.7 : 1 }}
+                            >
+                                {isLoading ? <ProgressRing sx={{ width: 12, height: 12 }} /> : <Codicon name="add" />}
+                                {c.addNewConnectionLabel}
+                            </LinkButton>
+                        );
+                    })}
+                </AddButtons>
+            )}
             {showCreateNew && (
                 <LinkButton
                     onClick={() => onCreateNode(

--- a/packages/ballerina-visualizer/src/views/BI/CreateIntegrationWizard/steps/configure/FunctionConfigureForm.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/CreateIntegrationWizard/steps/configure/FunctionConfigureForm.tsx
@@ -186,6 +186,10 @@ export function FunctionConfigureForm({ wsClient, projectRoot, kind, isSubmittin
                     onSubmit={handleOnSubmit}
                     preserveFieldOrder={true}
                     submitText="Create Integration"
+                    // Pre-project: the type editor resolves its file from the visualizer state
+                    // machine (absent here), and a type created in the throwaway staging package
+                    // would never reach the generated integration — so don't offer creation.
+                    allowTypeCreation={false}
                 />
             </FormBody>
         </FormContainer>

--- a/packages/ballerina-visualizer/src/views/BI/Forms/ArtifactForm/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/Forms/ArtifactForm/index.tsx
@@ -134,6 +134,10 @@ interface ArtifactFormProps {
     recordsOnly?: boolean;
     serverValidationErrors?: ValidationResult[];
     footerActionButton?: boolean;
+    // Hides the type helper's "Create New Type" action. Used by pre-project hosts
+    // (e.g. the Add Integration wizard) where the type editor has no visualizer
+    // state machine to resolve a file path from, so created types have nowhere to go.
+    allowTypeCreation?: boolean;
 }
 
 export function ArtifactForm(props: ArtifactFormProps) {
@@ -175,7 +179,8 @@ export function ArtifactForm(props: ArtifactFormProps) {
         secondarySubmitText,
         onSecondarySubmit,
         serverValidationErrors,
-        footerActionButton
+        footerActionButton,
+        allowTypeCreation = true
     } = props;
 
     const { rpcClient } = useRpcContext();
@@ -856,7 +861,7 @@ export function ArtifactForm(props: ArtifactFormProps) {
             onChange: onChange,
             changeTypeHelperState: changeHelperPaneState,
             updateImports: handleUpdateImports,
-            onTypeCreate: handleCreateNewType,
+            onTypeCreate: allowTypeCreation ? handleCreateNewType : undefined,
             onCloseCompletions: handleCloseCompletions,
             exprRef: exprRef,
             typeHelperContext: typeHelperContext,

--- a/packages/ballerina-visualizer/src/views/BI/TypeEditor/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/TypeEditor/index.tsx
@@ -81,11 +81,16 @@ export const FormTypeEditor = (props: FormTypeEditorProps) => {
     useEffect(() => {
         if (rpcClient) {
             rpcClient.getVisualizerLocation().then((machineView) => {
-                setFilePath(machineView.metadata.recordFilePath);
+                const recordFilePath = machineView?.metadata?.recordFilePath;
+                if (!recordFilePath) {
+                    console.warn(">>> FormTypeEditor: no recordFilePath in the visualizer location; type editor cannot render");
+                    return;
+                }
+                setFilePath(recordFilePath);
                 rpcClient
                     .getBIDiagramRpcClient()
                     .getEndOfFile({
-                        filePath: machineView.metadata.recordFilePath
+                        filePath: recordFilePath
                     })
                     .then((linePosition) => {
                         setTargetLineRange({

--- a/packages/ballerina-visualizer/src/views/BI/TypeHelper/index.tsx
+++ b/packages/ballerina-visualizer/src/views/BI/TypeHelper/index.tsx
@@ -61,7 +61,7 @@ type TypeHelperProps = {
     onChange: (newType: string, newCursorPosition: number) => void;
     changeTypeHelperState: (isOpen: boolean) => void;
     updateImports: (key: string, imports: { [key: string]: string }, codedata?: CodeData) => void;
-    onTypeCreate: (typeName: string) => void;
+    onTypeCreate?: (typeName: string) => void;
     onCloseCompletions?: () => void;
     typeHelperContext?: TypeHelperContext;
     recordsOnly?: boolean;
@@ -261,7 +261,7 @@ const TypeHelperEl = (props: TypeHelperProps) => {
 
     const handleTypeCreate = (typeName?: string) => {
         changeTypeHelperState(false);
-        onTypeCreate(typeName || 'MyType');
+        onTypeCreate?.(typeName || 'MyType');
     };
 
     return (
@@ -285,7 +285,7 @@ const TypeHelperEl = (props: TypeHelperProps) => {
                 onSearchTypeBrowser={handleSearchTypeBrowser}
                 onTypeItemClick={handleTypeItemClick}
                 onClose={handleTypeHelperClose}
-                onTypeCreate={recordsOnly ? undefined : handleTypeCreate}
+                onTypeCreate={recordsOnly || !onTypeCreate ? undefined : handleTypeCreate}
                 onCloseCompletions={onCloseCompletions}
                 exprRef={exprRef}
             />


### PR DESCRIPTION
## Purpose

Fixes three workflow designer bugs found during pre-release alpha testing.

Resolves:
- https://github.com/wso2/product-integrator/issues/2064
- https://github.com/wso2/product-integrator/issues/2065
- https://github.com/wso2/product-integrator/issues/2066

## Goals

1. The **Call REST API** activity form should offer a single way to create a new HTTP connection (#2064).
2. Deleting an activity under **Workflow Activities** in the project explorer should remove it from the list immediately (#2065).
3. The **Workflow Input Data Type** field in the Add Integration wizard should not open a broken, empty "Create New Type" form (#2066).

## Approach

**#2064 — redundant connection creation options**
The Connection field rendered two create actions from two components: the generic `+ Create New Http` link from `NodeReferenceSelectEditor` (driven by `codedata.searchNodesKind`) and the LS-metadata-driven `+ Add new HTTP connection` button from `ConnectionEditor` (`metadata.connectors[].addNewConnectionLabel`). The create affordance is now owned by a single component: `NodeReferenceSelectEditor` renders either the explicit connector actions (when the field carries `metadata.connectors`) or the generic link — never both — and `ConnectionEditor` reduces to label + form registration + the reference select. Reference fields rendered through `ExpressionField`'s SELECT mode get the same single-affordance rule for free.

**#2065 — deleted Workflow Activity still listed**
The LS publishes deletions as id-only stub artifacts (`Artifact.emptyArtifact` — no `type`), but `processDeletion` resolved the directory-map key via `getDirectoryMapKeyAndIcon`, which disambiguates the shared `Workflows` category *by type*. A deleted workflow activity therefore always resolved to the `WORKFLOW` key and was never removed from `directoryMap.ACTIVITY`, which is what the project explorer's "Workflow Activities" section and the overview render. Deletions in the `Workflows` category now sweep both the `WORKFLOW` and `ACTIVITY` keys (ids are unique within a category, so this is safe).

**#2066 — empty Create New Type form in the wizard**
In the pre-project wizard, `FormTypeEditor` resolves its target file from the visualizer state machine, but the wizard's stub RPC adapter returns an empty visualizer location — `machineView.metadata.recordFilePath` threw inside the promise chain and the "Create New Type" modal opened with a blank body. Additionally, a type created at this stage would land in the throwaway staging package and never reach the generated integration. The wizard's configure form now opts out of type creation via a new `allowTypeCreation` flag on `ArtifactForm` (the type helper no longer offers "Create New Type" there), and `FormTypeEditor` guards the `metadata.recordFilePath` access so a missing location logs a warning instead of failing silently.

Supporting inline type creation inside the wizard would need the type-editor RPCs (`getEndOfFile`, `getVisibleTypes`, `updateType`, `search`, …) on the wizard's WS bridge plus carrying staged types into the generated integration — better tracked as a follow-up enhancement.

## UI Component Development

- [x] No new UI components — existing ui-toolkit components only.

## User stories

Workflow developers testing the pre-release designer can create REST API activity connections without ambiguity, see the Workflow Activities list reflect deletions immediately, and are not offered a broken type-creation form while creating a durable workflow.

## Release note

Fixes workflow designer issues: duplicate connection-creation options in the Call REST API activity form, stale Workflow Activities list after deleting an activity, and an empty "Create New Type" form in the Add Integration wizard.

## Documentation

N/A — bug fixes with no behavior documented.

## Training

N/A

## Certification

N/A — bug fixes, no certification impact.

## Marketing

N/A

## Automation tests

- Unit tests: N/A — covered by manual verification; no existing unit-test harness for these webview paths.
- Integration tests: existing e2e suites run on CI.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no (TypeScript-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

macOS (darwin 25.5), VS Code desktop, Node 18+, rush build.

## Learning

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the duplicate connection creation option from the Call REST API activity.
- Removed deleted workflow activities from all relevant project explorer directory maps.
- Disabled type creation in the Add Integration wizard.
- Added safeguards for missing visualizer metadata.
- Preserved type creation by default through the new optional `allowTypeCreation` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->