### PR TITLE
Auto-select staging/* branch for nightly build

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -7,11 +7,12 @@ on:
     inputs:
       sourceBranch:
         description: >-
-          Branch to run the nightly pipeline against. Defaults to main, which is
-          what the schedule always uses.
+          Branch to run the nightly pipeline against. Leave blank to auto-select:
+          the latest staging/* branch if one exists, otherwise main — the same
+          resolution the schedule always uses.
         required: false
         type: string
-        default: main
+        default: ''
 
 permissions:
   contents: read
@@ -27,8 +28,9 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   # builds/nightly branch — selected source plus a single version commit
   #
-  # Scheduled runs reset the branch to main; manual runs reset it to sourceBranch (main by
-  # default). It is then force-pushed, so it is never a merge target and never accumulates
+  # Scheduled runs, and manual runs with sourceBranch left blank, reset the branch to the
+  # latest staging/* branch if one exists, otherwise main; an explicit sourceBranch always
+  # wins. It is then force-pushed, so it is never a merge target and never accumulates
   # history. `git diff <selected-source> builds/nightly` is always exactly the version bump.
   # Its purpose is to give every nightly VSIX an inspectable commit that pins both the source
   # and the version it was built at.
@@ -61,11 +63,25 @@ jobs:
 
       - name: Reset builds/nightly to the source branch
         env:
-          SOURCE_BRANCH: ${{ inputs.sourceBranch || 'main' }}
+          INPUT_SOURCE_BRANCH: ${{ inputs.sourceBranch }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [ -n "${INPUT_SOURCE_BRANCH}" ]; then
+            SOURCE_BRANCH="${INPUT_SOURCE_BRANCH}"
+          else
+            # No explicit source given (scheduled run, or manual run left blank): prefer the
+            # latest staging/* branch (e.g. staging/5.14.0) if one exists, so the nightly
+            # pipeline follows the active release staging branch without a workflow edit
+            # each time one is cut. Falls back to main once no staging/* branch remains.
+            latest_staging=$(git ls-remote --heads origin \
+              | awk -F'refs/heads/' '/refs\/heads\/staging\// { print $2 }' \
+              | sort -t/ -k2 -V | tail -n 1)
+            SOURCE_BRANCH="${latest_staging:-main}"
+          fi
+
           # Checkout fetches only the triggering ref, so fetch the requested source
           # explicitly even though the initial checkout uses fetch-depth 0.
           SOURCE_BRANCH="$(git check-ref-format --branch "${SOURCE_BRANCH}")"


### PR DESCRIPTION
## Purpose
Nightly builds now prefer the latest staging/* branch (e.g. staging/5.14.0) over main when no explicit sourceBranch is given, so the pipeline follows the active release staging branch without a manual workflow edit each time one is cut.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> The ui-toolkit lives in the [wso2/vscode-extensions](https://github.com/wso2/vscode-extensions) repository, pulled in here as the `submodules/wso2-vscode-extensions` submodule. Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [instructions](../submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit/README.md) when adding the component.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from `submodules/wso2-vscode-extensions/workspaces/common-libs/ui-toolkit` to view current components.
- [ ] Matches with the native VSCode look and feel.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions and operating systems on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated nightly builds to select the latest `staging/*` branch when no `sourceBranch` is provided. The workflow falls back to `main` when no staging branch exists. Explicit branch selections remain unchanged. The sync step fetches and resets `builds/nightly` to the selected branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->